### PR TITLE
Bug fixes

### DIFF
--- a/aeon/dj_pipeline/analysis/visit_analysis.py
+++ b/aeon/dj_pipeline/analysis/visit_analysis.py
@@ -629,7 +629,9 @@ class VisitForagingBout(dj.Computed):
                     ts_array = in_patch_times[change_ind[i - 1] : change_ind[i]]
 
                 wheel_start, wheel_end = ts_array[0], ts_array[-1]
-                if wheel_start > wheel_end:  # skip if timestamps were misaligned
+                if (
+                    wheel_start >= wheel_end
+                ):  # skip if timestamps were misaligned or a single timestamp
                     continue
 
                 wheel_data = acquisition.FoodPatchWheel.get_wheel_data(

--- a/aeon/dj_pipeline/utils/plotting.py
+++ b/aeon/dj_pipeline/utils/plotting.py
@@ -762,6 +762,11 @@ def _get_filtered_subject_weight(
         .set_index("weight_subject_timestamps")
         .dropna()
     )
+
+    # Return empty dataframe if no weight data
+    if subject_weight.empty:
+        return subject_weight
+
     subject_weight = subject_weight.loc[visit_start:visit_end]
 
     # Exclude data during maintenance


### PR DESCRIPTION
- Some foraging bouts were not ingested because of search ranges containing only a single timestamp (i.e. animal was only in the patch for 20ms). 
- Earlier experiments did not have filtered subject weight, so skip the weight plot when the filtered subject weight is empty.