### PR TITLE
debug OSC.Slice reading csv file

### DIFF
--- a/aeon/schema/octagon.py
+++ b/aeon/schema/octagon.py
@@ -24,7 +24,7 @@ class OSC:
             'typetag',
             'wall_id',
             'r', 'g', 'b', 'a',
-            'delay']) }
+            'delay', 'aperture_angle']) }
 
     @staticmethod
     def gratings_slice(pattern):
@@ -36,6 +36,7 @@ class OSC:
             'spatial_frequency',
             'temporal_frequency',
             'angle',
+            'aperture_angle',
             'delay']) }
 
     @staticmethod

--- a/aeon/schema/octagon.py
+++ b/aeon/schema/octagon.py
@@ -76,7 +76,7 @@ class OSC:
     def tracking_response(pattern):
         return { "TrackingResponse": _reader.Csv(f"{pattern}_return_tracking_response_*", columns=[
             'typetag',
-            'dont-know',
+            'id',
             'response_position_x_1',
             'response_position_y_1',
             'response_theta_1',
@@ -86,7 +86,7 @@ class OSC:
     def tracking_slice_onset(pattern):
         return { "TrackingSliceOnset": _reader.Csv(f"{pattern}_return_tracking_slice_onset_*", columns=[
             'typetag',
-            'dont-know',
+            'id',
             'slice_onset_position_x_1',
             'slice_onset_position_y_1',
             'slice_onset_theta_1',

--- a/aeon/schema/octagon.py
+++ b/aeon/schema/octagon.py
@@ -71,6 +71,26 @@ class OSC:
     @staticmethod
     def start_new_session(pattern):
         return { "StartNewSession": _reader.Csv(f"{pattern}_startnewsession_*", columns=['typetag', 'path' ]) }
+    
+    @staticmethod
+    def tracking_response(pattern):
+        return { "TrackingResponse": _reader.Csv(f"{pattern}_return_tracking_response_*", columns=[
+            'typetag',
+            'dont-know',
+            'response_position_x_1',
+            'response_position_y_1',
+            'response_theta_1',
+            'response_area_1'])}
+    
+    @staticmethod
+    def tracking_slice_onset(pattern):
+        return { "TrackingSliceOnset": _reader.Csv(f"{pattern}_return_tracking_slice_onset_*", columns=[
+            'typetag',
+            'dont-know',
+            'slice_onset_position_x_1',
+            'slice_onset_position_y_1',
+            'slice_onset_theta_1',
+            'slice_onset_area_1'])}
 
 class TaskLogic:
     @staticmethod


### PR DESCRIPTION
As described in issue #181, the Octagon OSC messages have changed sometime in August and there is one extra column in the OSC_octagonslice csv file and one extra column in the OSC_octagongratingsslice csv file. The API need to be updated to correctly read in these files. This merge request fix this issue.

However, this fix does not allow backward compatibility. Files after August will be read correctly but OSC files before that will not. Please feel free to review the issue and accept/reject the change.

Thanks.