### PR TITLE
Exclude dj_pipeline from precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,8 @@
 default_language_version:
   python: python3.11
 
-files: "^(docker|aeon\/dj_pipeline)\/.*$"
+files: "^(test|aeon(?!\/dj_pipeline\/).*)$"
+exclude: ".*\/__pycache__\/.*"
 repos:
   - repo: meta
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,8 @@ exclude = '''
     | dist
     | env
     | venv
+    | dj_pipeline
+    | __pycache__
 )/
 '''
 
@@ -107,7 +109,7 @@ ignore = [
     "PT013",
     "PLR0912", "PLR0913", "PLR0915"
 ]
-extend-exclude = [".git", ".github", ".idea", ".vscode"]
+extend-exclude = [".git", ".github", ".idea", ".vscode", "dj_pipeline", "__pycache__"]
 
 [tool.ruff.pydocstyle]
 convention = "google"


### PR DESCRIPTION
@jkbhagatio The recent [pr ](https://github.com/SainsburyWellcomeCentre/aeon_mecha/pull/246)reminded me that we might not want this pre-commit hooks to be applied to files under dj_pipeline, especially files containing schema and table definitions. Sometimes we want things to be imported in a specific order, which may conflict with tools like isort. Some schemas (e.g., streams.py) are dynamically generated so applying hooks may introduce unexpected errors.
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Chore: Updated the pre-commit configuration to improve code quality checks. The changes specifically exclude certain directories (`aeon/dj_pipeline` and `__pycache__`) from pre-commit hooks, ensuring that only relevant files are checked. This will help maintain a clean and efficient codebase.
- Refactor: Included `test` and `aeon` directories in pre-commit checks to ensure that all code modifications in these areas adhere to our coding standards. This enhances the reliability of our tests and core functionalities.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->