### PR TITLE
Remove merge conflict markers

### DIFF
--- a/aeon/schema/social.py
+++ b/aeon/schema/social.py
@@ -33,15 +33,9 @@ class Pose(_reader.Harp):
         """Reads data from the Harp-binarized tracking file."""
         # Get config file from `file`, then bodyparts from config file.
         model_dir = Path(file.stem.replace("_", "/")).parent
-<<<<<<< HEAD
         config_file_dir = ceph_proc_dir / model_dir
         if not config_file_dir.exists():
             raise FileNotFoundError(f"Cannot find model dir {config_file_dir}")
-=======
-        # `ceph_proc_dir` typically
-        config_file_dir = Path(ceph_proc_dir) / model_dir
-        assert config_file_dir.exists(), f"Cannot find model dir {config_file_dir}"
->>>>>>> b9a1e3f... Blackened and ruffed
         config_file = get_config_file(config_file_dir)
         parts = self.get_bodyparts(config_file)
 
@@ -52,7 +46,6 @@ class Pose(_reader.Harp):
         self.columns = columns
         data = super().read(file)
 
-<<<<<<< HEAD
         # Drop any repeat parts.
         unique_parts, unique_idxs = np.unique(parts, return_index=True)
         repeat_idxs = np.setdiff1d(np.arange(len(parts)), unique_idxs)
@@ -63,8 +56,6 @@ class Pose(_reader.Harp):
             data = data.iloc[:, keep_part_col_idxs]
             parts = unique_parts
 
-=======
->>>>>>> b9a1e3f... Blackened and ruffed
         # Set new columns, and reformat `data`.
         n_parts = len(parts)
         part_data_list = [pd.DataFrame()] * n_parts
@@ -102,21 +93,13 @@ def get_config_file(
     """Returns the config file from a model's config directory."""
     if config_file_names is None:
         config_file_names = ["confmap_config.json"]  # SLEAP (add for other trackers to this list)
-<<<<<<< HEAD
     config_file = None
-=======
-    config_file = Path()
->>>>>>> b9a1e3f... Blackened and ruffed
     for f in config_file_names:
         if (config_file_dir / f).exists():
             config_file = config_file_dir / f
             break
-<<<<<<< HEAD
     if config_file is None:
-         raise FileNotFoundError(f"Cannot find config file in {config_file_dir}")
-=======
-    assert config_file.is_file(), f"Cannot find config file in {config_file_dir}"
->>>>>>> b9a1e3f... Blackened and ruffed
+        raise FileNotFoundError(f"Cannot find config file in {config_file_dir}")
     return config_file
 
 

--- a/tests/io/test_api.py
+++ b/tests/io/test_api.py
@@ -1,13 +1,9 @@
-<<<<<<< HEAD
 from pathlib import Path
 
-=======
->>>>>>> b9a1e3f... Blackened and ruffed
 import pandas as pd
 import pytest
 from pytest import mark
 
-<<<<<<< HEAD
 import aeon
 from aeon.schema.dataset import exp02
 
@@ -18,63 +14,34 @@ monotonic_path = Path(__file__).parent.parent / "data" / "monotonic"
 @mark.api
 def test_load_start_only():
     data = aeon.load(nonmonotonic_path, exp02.Patch2.Encoder, start=pd.Timestamp("2022-06-06T13:00:49"))
-=======
-import aeon.io.api as aeon
-from aeon.schema.dataset import exp02
-
-
-@mark.api
-def test_load_start_only():
-    data = aeon.load(
-        "./tests/data/nonmonotonic", exp02.Patch2.Encoder, start=pd.Timestamp("2022-06-06T13:00:49")
-    )
->>>>>>> b9a1e3f... Blackened and ruffed
     assert len(data) > 0
 
 
 @mark.api
 def test_load_end_only():
     data = aeon.load(
-<<<<<<< HEAD
         nonmonotonic_path, exp02.Patch2.Encoder, end=pd.Timestamp("2022-06-06T13:00:49")
-=======
-        "./tests/data/nonmonotonic", exp02.Patch2.Encoder, end=pd.Timestamp("2022-06-06T13:00:49")
->>>>>>> b9a1e3f... Blackened and ruffed
     )
     assert len(data) > 0
 
 
 @mark.api
 def test_load_filter_nonchunked():
-<<<<<<< HEAD
     data = aeon.load(
         nonmonotonic_path, exp02.Metadata, start=pd.Timestamp("2022-06-06T09:00:00")
     )
-=======
-    data = aeon.load("./tests/data/nonmonotonic", exp02.Metadata, start=pd.Timestamp("2022-06-06T09:00:00"))
->>>>>>> b9a1e3f... Blackened and ruffed
     assert len(data) > 0
 
 
 @mark.api
 def test_load_monotonic():
-<<<<<<< HEAD
     data = aeon.load(monotonic_path, exp02.Patch2.Encoder)
     assert len(data) > 0 and data.index.is_monotonic_increasing
-
-=======
-    data = aeon.load("./tests/data/monotonic", exp02.Patch2.Encoder)
-    assert data.index.is_monotonic_increasing
->>>>>>> b9a1e3f... Blackened and ruffed
 
 
 @mark.api
 def test_load_nonmonotonic():
-<<<<<<< HEAD
     data = aeon.load(nonmonotonic_path, exp02.Patch2.Encoder)
-=======
-    data = aeon.load("./tests/data/nonmonotonic", exp02.Patch2.Encoder)
->>>>>>> b9a1e3f... Blackened and ruffed
     assert not data.index.is_monotonic_increasing
 
 


### PR DESCRIPTION
Removed merge conflict markers by checking out the last good commit for the following files:
- aeon/schema/social.py aaacd53f1995fd20ab2e9646ad63767707398718
- tests/io/test_api.py 7f6b3534854131eaceef7cffea9783af545c9134

and re-ran pre-commit.

Fixes #259 

