### PR TITLE
modify `subject` schema to align with pyrat - added pyrat sync routine

### DIFF
--- a/aeon/dj_pipeline/lab.py
+++ b/aeon/dj_pipeline/lab.py
@@ -74,10 +74,10 @@ class UserRole(dj.Lookup):
 @schema
 class User(dj.Lookup):
     definition = """
-    user                : varchar(32)
+    user                    : varchar(32)  # swc username
     ---
-    user_email=''       : varchar(128)
-    user_cellphone=''   : varchar(32)
+    responsible_owner=''    : varchar(32)  # pyrat username
+    responsible_id=''       : varchar(32)  # pyrat `responsible_id`
     """
 
 

--- a/aeon/dj_pipeline/populate/worker.py
+++ b/aeon/dj_pipeline/populate/worker.py
@@ -2,7 +2,7 @@ import datajoint as dj
 from datajoint_utilities.dj_worker import DataJointWorker, ErrorLog, WorkerLog
 from datajoint_utilities.dj_worker.worker_schema import is_djtable
 
-from aeon.dj_pipeline import acquisition, analysis, db_prefix, qc, report, tracking
+from aeon.dj_pipeline import subject, acquisition, analysis, db_prefix, qc, report, tracking
 from aeon.dj_pipeline.utils import load_metadata, streams_maker
 
 streams = streams_maker.main()
@@ -95,7 +95,20 @@ mid_priority(report.SubjectWheelTravelledDistance)
 mid_priority(report.ExperimentTimeDistribution)
 mid_priority(report.VisitDailySummaryPlot)
 
-# ---- Define worker(s) ----
+# configure a worker to handle pyrat sync
+pyrat_worker = DataJointWorker(
+    "pyrat_worker",
+    worker_schema_name=worker_schema_name,
+    db_prefix=db_prefix,
+    run_duration=-1,
+    sleep_duration=1200,
+)
+
+pyrat_worker(subject.CreatePyratIngestionTask)
+pyrat_worker(subject.PyratIngestion)
+pyrat_worker(subject.SubjectDetail)
+pyrat_worker(subject.PyratCommentWeightProcedure)
+
 # configure a worker to ingest all data streams
 streams_worker = DataJointWorker(
     "streams_worker",

--- a/aeon/dj_pipeline/subject.py
+++ b/aeon/dj_pipeline/subject.py
@@ -300,6 +300,7 @@ class CreatePyratIngestionTask(dj.Computed):
         Create one new PyratIngestionTask for every newly added user
         """
         PyratIngestionTask.insert1({"pyrat_task_scheduled_time": datetime.utcnow()})
+        self.insert1(key)
 
 
 _pyrat_animal_attributes = [

--- a/aeon/dj_pipeline/subject.py
+++ b/aeon/dj_pipeline/subject.py
@@ -1,55 +1,29 @@
+import os
+import requests
 import datajoint as dj
+from datetime import datetime, timedelta
 
-from . import get_schema_name
+from . import get_schema_name, lab
 
 schema = dj.schema(get_schema_name("subject"))
 
 
 @schema
-class Strain(dj.Lookup):
+class Strain(dj.Manual):
     definition = """
-    # Strain of animal, e.g. C57Bl/6
-    strain              : varchar(32)	# abbreviated strain name
+    strain_id: int
     ---
-    strain_standard_name  : varchar(32)   # formal name of a strain
-    strain_desc=''      : varchar(255)	# description of this strain
+    strain_name: varchar(64)
     """
 
 
 @schema
-class Allele(dj.Lookup):
+class GeneticBackground(dj.Manual):
     definition = """
-    allele                      : varchar(32)    # abbreviated allele name
+    gen_bg_id: int
     ---
-    allele_standard_name=''     : varchar(255)	  # standard name of an allele
+    gen_bg: varchar(64)
     """
-
-    class Source(dj.Part):
-        definition = """
-        -> master
-        ---
-        -> lab.Source
-        source_identifier=''        : varchar(255)    # id inside the line provider
-        source_url=''               : varchar(255)    # link to the line information
-        expression_data_url=''      : varchar(255)    # link to the expression pattern from Allen institute brain atlas
-        """
-
-
-@schema
-class Line(dj.Lookup):
-    definition = """
-    line                    : varchar(32)	# abbreviated name for the line
-    ---
-    line_description=''     : varchar(2000)
-    target_phenotype=''     : varchar(255)
-    is_active               : boolean		# whether the line is in active breeding
-    """
-
-    class Allele(dj.Part):
-        definition = """
-        -> master
-        -> Allele
-        """
 
 
 @schema
@@ -63,81 +37,259 @@ class Subject(dj.Manual):
     subject_description=''  : varchar(1024)
     """
 
-    class Protocol(dj.Part):
-        definition = """
-        -> master
-        -> lab.Protocol
-        """
-
-    class User(dj.Part):
-        definition = """
-        -> master
-        -> lab.User
-        """
-
-    class Line(dj.Part):
-        definition = """
-        -> master
-        ---
-        -> Line
-        """
-
-    class Strain(dj.Part):
-        definition = """
-        -> master
-        ---
-        -> Strain
-        """
-
-    class Source(dj.Part):
-        definition = """
-        -> master
-        ---
-        -> lab.Source
-        """
-
-    class Lab(dj.Part):
-        definition = """
-        -> master
-        -> lab.Lab
-        ---
-        subject_alias=''    : varchar(32)  # alias of the subject in this lab, if different from the id
-        """
-
 
 @schema
-class SubjectDeath(dj.Manual):
+class SubjectDetail(dj.Imported):
     definition = """
     -> Subject
     ---
-    death_date      : date       # death date
+    -> lab.User.proj(responsible_user="user")
+    -> GeneticBackground
+    -> Strain
+    cage_number: varchar(32)
+    """
+
+    def make(self, key):
+        eartag_or_id = key["subject"]
+        # cage id, sex, line/strain, genetic background, dob, weight history
+        params = {
+            "k": _pyrat_animal_attributes,
+            "s": "eartag_or_id:asc",
+            "o": 0,
+            "l": 10,
+            "eartag": eartag_or_id,
+        }
+        animal_resp = get_pyrat_data(endpoint=f"animals", params=params)
+        assert (
+            len(animal_resp) == 1
+        ), f"Found {len(animal_resp)} with eartag {eartag_or_id}, expect only one"
+        animal_resp = animal_resp[0]
+        # Insert new subject
+        subj_key = {"subject": eartag_or_id}
+        Subject.update1(
+            {
+                **subj_key,
+                "sex": {"f": "F", "m": "M", "?": "U"}[animal_resp["sex"]],
+                "subject_birth_date": animal_resp["dateborn"],
+            }
+        )
+        user = (lab.User & {"responsible_id": animal_resp["responsible_id"]}).fetch1("user")
+        Strain.insert1(
+            {"strain_id": animal_resp["strain_id"], "strain_name": animal_resp["strain_id"]},
+            skip_duplicates=True,
+        )
+        if animal_resp["gen_bg_id"] is not None:
+            GeneticBackground.insert1(
+                {"gen_bg_id": animal_resp["gen_bg_id"], "gen_bg": animal_resp["gen_bg"]},
+                skip_duplicates=True,
+            )
+        self.insert1(
+            {
+                **key,
+                "responsible_user": user,
+                "strain_id": animal_resp["strain_id"],
+                "cage_number": animal_resp["cagenumber"],
+                "gen_bg_id": animal_resp["gen_bg_id"],
+            }
+        )
+
+
+# ------------------- PYRAT SYNCHRONIZATION --------------------
+
+
+@schema
+class PyratIngestionTask(dj.Manual):
+    """Task to sync new animals from PyRAT"""
+
+    definition = """
+    pyrat_task_scheduled_time: datetime  # (UTC) scheduled time for task execution
     """
 
 
 @schema
-class SubjectCullMethod(dj.Manual):
+class PyratIngestion(dj.Imported):
+    """Ingestion of new animals from PyRAT"""
+
     definition = """
-    -> Subject
+    -> PyratIngestionTask
     ---
-    cull_method:    varchar(255)
+    execution_time: datetime  # (UTC) time of task execution
+    execution_duration: float  # (s) duration of task execution
+    new_pyrat_entry_count: int  # number of new PyRAT subject ingested in this round of ingestion 
     """
+
+    key_source = (
+        PyratIngestionTask.proj(
+            seconds_since_scheduled="TIMESTAMPDIFF(SECOND, pyrat_task_scheduled_time, UTC_TIMESTAMP())"
+        )
+        & "seconds_since_scheduled >= 0"
+    )
+
+    auto_schedule = True
+    schedule_interval = 2  # schedule interval in number of days
+
+    def _auto_schedule(self):
+        utc_now = datetime.utcnow()
+
+        next_task_schedule_time = utc_now + timedelta(days=self.schedule_interval)
+        if (
+            PyratIngestionTask
+            & f"pyrat_task_scheduled_time BETWEEN '{utc_now}' AND '{next_task_schedule_time}'"
+        ):
+            return
+
+        PyratIngestionTask.insert1({"pyrat_task_scheduled_time": next_task_schedule_time})
+
+    def make(self, key):
+        execution_time = datetime.utcnow()
+        """Automatically import or update entries in the Subject table."""
+        new_eartags = []
+        for responsible_id in lab.User.fetch("responsible_id"):
+            # 1 - retrieve all animals from this user
+            animal_resp = get_pyrat_data(endpoint="animals", params=dict(responsible_id=responsible_id))
+            for animal_entry in animal_resp:
+                # 2 - find animal with comment - Project Aeon
+                eartag_or_id = animal_entry["eartag_or_id"]
+                comment_resp = get_pyrat_data(endpoint=f"animals/{eartag_or_id}/comments")
+                for comment in comment_resp:
+                    if comment["content"] is None:
+                        first_attr = comment["attributes"][0]
+                        if (
+                            first_attr["label"].lower() == "project"
+                            and first_attr["content"].lower() == "aeon"
+                        ):
+                            new_eartags.append(eartag_or_id)
+
+        new_entry_count = 0
+        for eartag_or_id in new_eartags:
+            if Subject & {"subject": eartag_or_id}:
+                continue
+            Subject.insert1(
+                {
+                    "subject": eartag_or_id,
+                    "sex": "U",
+                    "subject_birth_date": "1900-01-01",
+                }
+            )
+            new_entry_count += 1
+
+        completion_time = datetime.utcnow()
+        self.insert1(
+            {
+                **key,
+                "execution_time": execution_time,
+                "execution_duration": (completion_time - execution_time).total_seconds(),
+                "new_pyrat_entry_count": new_entry_count,
+            }
+        )
+
+        # auto schedule next task
+        if self.auto_schedule:
+            self._auto_schedule()
 
 
 @schema
-class Zygosity(dj.Manual):
-    definition = """
-    -> Subject
-    -> Allele
-    ---
-    zygosity        : enum("Present", "Absent", "Homozygous", "Heterozygous")  # zygosity
+class CreatePyratIngestionTask(dj.Computed):
+    definition = """ 
+    -> lab.User
     """
 
+    def make(self, key):
+        """
+        Create one new PyratIngestionTask for every newly added user
+        """
+        PyratIngestionTask.insert1({"pyrat_task_scheduled_time": datetime.utcnow()})
 
-@schema
-class FoodDeprivationWeight(dj.Manual):
-    definition = """
-    -> Subject
-    weight_time: datetime
-    ---
-    weight: float
-    """
+
+_pyrat_animal_attributes = [
+    "animalid",
+    "pupid",
+    "eartag_or_id",
+    "prefix",
+    "state",
+    "labid",
+    "cohort_id",
+    "rfid",
+    "origin_name",
+    "sex",
+    "species_name",
+    "species_weight_unit",
+    "sacrifice_reason_name",
+    "sacrifice_comment",
+    "sacrifice_actor_username",
+    "sacrifice_actor_fullname",
+    "datesacrificed",
+    "cagenumber",
+    "cagetype",
+    "cagelabel",
+    "cage_owner_username",
+    "cage_owner_fullname",
+    "rack_description",
+    "room_name",
+    "area_name",
+    "building_name",
+    "responsible_id",
+    "responsible_fullname",
+    "owner_userid",
+    "owner_username",
+    "owner_fullname",
+    "age_days",
+    "age_weeks",
+    "dateborn",
+    "comments",
+    "date_last_comment",
+    "generation",
+    "gen_bg_id",
+    "gen_bg",
+    "strain_id",
+    "strain_name",
+    "strain_name_id",
+    "strain_name_with_id",
+    "mutations",
+    "genetically_modified",
+    "parents",
+    "licence_title",
+    "licence_id",
+    "licence_number",
+    "classification_id",
+    "classification",
+    "pregnant_days",
+    "plug_date",
+    "wean_date",
+    "projects",
+    "requests",
+    "weight",
+    "animal_color",
+    "animal_user_color",
+    "import_order_request_id",
+]
+
+
+def get_pyrat_data(endpoint: str, params: dict = None, **kwargs):
+    base_url = "https://swc.pyrat.cloud/api/v3/"
+    pyrat_system_token = os.getenv("PYRAT_SYSTEM_TOKEN")
+    pyrat_user_token = os.getenv("PYRAT_USER_TOKEN")
+
+    if pyrat_system_token is None or pyrat_user_token is None:
+        raise ValueError(
+            f"The PYRAT tokens must be defined as an environment variable named 'PYRAT_SYSTEM_TOKEN' and 'PYRAT_USER_TOKEN'"
+        )
+
+    session = requests.Session()
+    session.auth = (pyrat_system_token, pyrat_user_token)
+
+    if params is not None:
+        params_str_list = []
+        for k, v in params.items():
+            if isinstance(v, (list, tuple)):
+                for i in v:
+                    params_str_list.append(f"{k}={i}")
+            else:
+                params_str_list.append(f"{k}={v}")
+        params_str = "?" + "&".join(params_str_list)
+    else:
+        params_str = ""
+
+    response = session.get(base_url + endpoint + params_str, **kwargs)
+
+    return response.json() if response.status_code == 200 else {"reponse code": response.status_code}

--- a/aeon/dj_pipeline/subject.py
+++ b/aeon/dj_pipeline/subject.py
@@ -117,10 +117,10 @@ class SubjectProcedure(dj.Imported):
     procedure_id: int
     procedure_name: varchar(200)
     procedure_date: date
-    license_id: int
-    license_number: varchar(200)
-    classification_id: int
-    classification_name: varchar(200)
+    license_id=null: int
+    license_number=null: varchar(200)
+    classification_id=null: int
+    classification_name=null: varchar(200)
     actor_fullname: varchar(200)
     comment=null: varchar(1000)
     """

--- a/aeon/dj_pipeline/subject.py
+++ b/aeon/dj_pipeline/subject.py
@@ -1,4 +1,6 @@
 import os
+import time
+
 import requests
 import json
 import datajoint as dj
@@ -230,11 +232,6 @@ class PyratIngestion(dj.Imported):
             }
         )
 
-        logger.info(f"Extracting weights/comments/procedures")
-        comment_resp = get_pyrat_data(endpoint=f"animals/{eartag_or_id}/comments")
-        weight_resp = get_pyrat_data(endpoint=f"animals/{eartag_or_id}/weights")
-        procedure_resp = get_pyrat_data(endpoint=f"animals/{eartag_or_id}/procedures")
-
         # auto schedule next task
         if self.auto_schedule:
             self._auto_schedule()
@@ -300,6 +297,7 @@ class CreatePyratIngestionTask(dj.Computed):
         Create one new PyratIngestionTask for every newly added user
         """
         PyratIngestionTask.insert1({"pyrat_task_scheduled_time": datetime.utcnow()})
+        time.sleep(1)
         self.insert1(key)
 
 


### PR DESCRIPTION
First prototype for PyRAT integration

1. remove irrelevant tables from `subject` schema
2. modify tables from `subject` schema to align better with PyRAT data
3. added routines to sync data from PyRAT
    - `PyratIngestion` - table to check for and insert new animals from PyRAT (for all responsible users present in the `lab.User` table
    - `SubjectDetail` - table containing additional information of the subject, to be pulled and inserted from PyRAT on a per-subject basis
    
Fix #263 