### PR TITLE
Drop importlib_metadata dependency

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,8 @@
+cff-version: 1.0.0
+message: "If you use this software, please cite it as below."
+authors: 
+-  family-names: "Sainsbury Wellcome Centre Foraging Behaviour Working Group"
+title: "Aeon: An open-source platform to study the neural basis of ethological behaviours over naturalistic timescales"
+doi: 10.5281/zenodo.8413142
+date-released: 2023-10-05
+url: https://github.com/SainsburyWellcomeCentre/aeon_docs

--- a/aeon/__init__.py
+++ b/aeon/__init__.py
@@ -1,4 +1,4 @@
-from importlib_metadata import PackageNotFoundError, version
+from importlib.metadata import PackageNotFoundError, version
 
 try:
     # Change here if project is renamed and does not equal the package name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
   "dotmap",
   "fastparquet",
   "graphviz",
-  "importlib_metadata",
   "ipykernel",
   "jupyter",
   "jupyterlab",

--- a/readme.md
+++ b/readme.md
@@ -74,3 +74,11 @@ Ensure you stay in the `~/ProjectAeon/aeon_mecha` directory for the rest of the 
 - `env_config/` : Configuration files for the Aeon Python environment
 - `tests/` : Unit and integration tests
     - `tests/data` : Data used by tests
+
+## Citation Policy
+
+If you use this software, please cite it as below:
+
+Sainsbury Wellcome Centre Foraging Behaviour Working Group. (2023). Aeon: An open-source platform to study the neural basis of ethological behaviours over naturalistic timescales,  https://doi.org/10.5281/zenodo.8413142
+
+[![DOI](https://zenodo.org/badge/485512362.svg)](https://zenodo.org/badge/latestdoi/485512362)


### PR DESCRIPTION
Since aeon_mecha supports only Python >=3.11, it makes sense to drop the `importlib_metadata` dependency and use the Python built-in `importlib.metadata` module 

This PR resolves #280. 
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Replaced the `importlib_metadata` dependency with the built-in Python `importlib.metadata` module in `aeon/__init__.py`. This change enhances the maintainability of the code by reducing external dependencies. The update does not affect any existing functionalities or interfaces, ensuring a seamless experience for end-users.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->