### PR TITLE
Use "all-versions" Zenodo DOI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,6 @@ Ensure you stay in the `~/ProjectAeon/aeon_mecha` directory for the rest of the 
 
 If you use this software, please cite it as below:
 
-Sainsbury Wellcome Centre Foraging Behaviour Working Group. (2023). Aeon: An open-source platform to study the neural basis of ethological behaviours over naturalistic timescales,  https://doi.org/10.5281/zenodo.8413142
+Sainsbury Wellcome Centre Foraging Behaviour Working Group. (2023). Aeon: An open-source platform to study the neural basis of ethological behaviours over naturalistic timescales,  https://doi.org/10.5281/zenodo.8411157
 
-[![DOI](https://zenodo.org/badge/485512362.svg)](https://zenodo.org/badge/latestdoi/485512362)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.8411157.svg)](https://zenodo.org/doi/10.5281/zenodo.8411157)


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Documentation: Updated the Zenodo DOI link in the README file. The old DOI has been replaced with a new one, and the badge URL and DOI link have been adjusted accordingly. This change ensures that users are directed to the correct location for the project's digital object identifier (DOI).
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->