### PR TITLE
update: more robust check for subjects in a given block

### DIFF
--- a/aeon/dj_pipeline/docs/notebooks/social_experiments_block_analysis.ipynb
+++ b/aeon/dj_pipeline/docs/notebooks/social_experiments_block_analysis.ipynb
@@ -14,8 +14,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "## Create VirtualModule to access `aeon_test_analysis` schema\n",
-    "Currently, the analysis is on `aeon_test_`, will move to `aeon_` soon (once ready for production)"
+    "## Create VirtualModule to access `aeon_block_analysis` schema"
    ],
    "metadata": {
     "collapsed": false,
@@ -29,7 +28,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "analysis_vm = dj.create_virtual_module('aeon_test_analysis', 'aeon_test_analysis')"
+    "analysis_vm = dj.create_virtual_module('aeon_block_analysis', 'aeon_block_analysis')"
    ],
    "metadata": {
     "collapsed": false,

--- a/aeon/dj_pipeline/webapps/sciviz/specsheet.yaml
+++ b/aeon/dj_pipeline/webapps/sciviz/specsheet.yaml
@@ -686,7 +686,7 @@ SciViz:
               dj_query: >
                 def dj_query(aeon_archived_exp02_acquisition):
                     acquisition = aeon_archived_exp02_acquisition
-                    return {'query': aeon_acquisition.Experiment(), 'fetch_args': ['experiment_name']}
+                    return {'query': acquisition.Experiment(), 'fetch_args': ['experiment_name']}
             camera_dropdown:
               x: 0
               y: 1

--- a/aeon/schema/social.py
+++ b/aeon/schema/social.py
@@ -50,7 +50,7 @@ subject_state_b = lambda pattern: {
 
 # SubjectVisits
 subject_visits_b = lambda pattern: {
-    "SubjectVisits": reader.Csv(f"{pattern}_SubjectVisit_*", ["id", "type", "region"])
+    "SubjectVisits": reader.Csv(f"{pattern}_SubjectVisits_*", ["id", "type", "region"])
 }
 
 # SubjectWeight


### PR DESCRIPTION
Implemented a more robust check for subjects in a given block, per Jai's suggestion

      # Get all unique subjects that visited the environment over the entire exp;
      # For each subject, see 'type' of visit most recent to start of block
      # If "Exit", this animal was not in the block.