### PR TITLE
fix: :bug: fix KeyError in BlockDetection

### DIFF
--- a/aeon/dj_pipeline/analysis/block_analysis.py
+++ b/aeon/dj_pipeline/analysis/block_analysis.py
@@ -8,8 +8,10 @@ import plotly.graph_objs as go
 from matplotlib import path as mpl_path
 
 from aeon.analysis import utils as analysis_utils
-from aeon.dj_pipeline import acquisition, fetch_stream, get_schema_name, streams, tracking
-from aeon.dj_pipeline.analysis.visit import filter_out_maintenance_periods, get_maintenance_periods
+from aeon.dj_pipeline import (acquisition, fetch_stream, get_schema_name,
+                              streams, tracking)
+from aeon.dj_pipeline.analysis.visit import (filter_out_maintenance_periods,
+                                             get_maintenance_periods)
 
 schema = dj.schema(get_schema_name("block_analysis"))
 logger = dj.logger
@@ -516,7 +518,8 @@ class BlockDetection(dj.Computed):
         )
 
         block_query = acquisition.Environment.BlockState & chunk_restriction
-        block_df = fetch_stream(block_query)[previous_block_start:chunk_end]
+        block_df = fetch_stream(block_query)
+        block_df = block_df[block_df.index.to_series().between(previous_block_start, chunk_end)]
 
         block_ends = block_df[block_df.pellet_ct.diff() < 0]
 

--- a/aeon/dj_pipeline/analysis/block_analysis.py
+++ b/aeon/dj_pipeline/analysis/block_analysis.py
@@ -518,8 +518,7 @@ class BlockDetection(dj.Computed):
         )
 
         block_query = acquisition.Environment.BlockState & chunk_restriction
-        block_df = fetch_stream(block_query)
-        block_df = block_df[block_df.index.to_series().between(previous_block_start, chunk_end)]
+        block_df = fetch_stream(block_query).sort_index()[previous_block_start:chunk_end]
 
         block_ends = block_df[block_df.pellet_ct.diff() < 0]
 


### PR DESCRIPTION
This is to address the following KeyError:

```
block_df.index[1]
>> Timestamp('2024-02-01 22:55:41.001984119')

previous_block_start
>> datetime.datetime(2024, 2, 1, 22, 55, 41, 1984)

block_df[previous_block_start]

Traceback (most recent call last):
  File "/nfs/nhome/live/jaeronga/.conda/envs/aeon/lib/python3.11/site-packages/pandas/core/indexes/base.py", line 3802, in get_loc
    return self._engine.get_loc(casted_key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "pandas/_libs/index.pyx", line 138, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 165, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 5745, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 5753, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: datetime.datetime(2024, 2, 1, 22, 55, 41, 1984)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/nfs/nhome/live/jaeronga/.conda/envs/aeon/lib/python3.11/site-packages/pandas/core/frame.py", line 3807, in __getitem__
    indexer = self.columns.get_loc(key)
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nfs/nhome/live/jaeronga/.conda/envs/aeon/lib/python3.11/site-packages/pandas/core/indexes/base.py", line 3804, in get_loc
    raise KeyError(key) from err
KeyError: datetime.datetime(2024, 2, 1, 22, 55, 41, 1984)
```

Acceesing/slicing dataframe with timestamp index yielded a KeyError due to the mismatch in timestamp precision (the timestamp in the dataframe was in nanosecond precision whereas `previous_block_start` was in microsecond precision. This fix will use `between` method instead of looking for the exact timestamp index value.
