### PR TITLE
Ensure all aeon submodules included in wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,8 +75,8 @@ Repository = "https://github.com/sainsburyWellcomeCentre/aeon_mecha"
 Documentation = "https://sainsburywellcomecentre.github.io/aeon_docs/"
 DataJoint = "https://docs.datajoint.org/"
 
-[tool.setuptools]
-packages = ["aeon"]
+[tool.setuptools.packages.find]
+include = ["aeon*"]
 
 [tool.black]
 line-length = 108


### PR DESCRIPTION
As explained in the [package discovery docs for setuptools](https://setuptools.pypa.io/en/latest/userguide/package_discovery.html) each submodule needs to be either explicitly added, or the `find` feature should be used to automatically discover all relevant packages.

This PR replaces the `setuptools` declaration in `pyproject.toml` to automatically include all submodules inside the `aeon` folder when building the wheel, e.g. when installing the repo from `pip` in non-editable mode.

We can consider whether we want to further split the package into different sub-wheels or features for the datajoint pipeline, or other optional functionality, but this can be done in a separate discussion / PR.

Fixes #375 