### PR TITLE
Allow forwarding of load function kwargs to reader

### DIFF
--- a/aeon/io/api.py
+++ b/aeon/io/api.py
@@ -60,7 +60,7 @@ def _empty(columns):
     return pd.DataFrame(columns=columns, index=pd.DatetimeIndex([], name="time"))
 
 
-def load(root, reader, start=None, end=None, time=None, tolerance=None, epoch=None):
+def load(root, reader, start=None, end=None, time=None, tolerance=None, epoch=None, **kwargs):
     """Extracts chunk data from the root path of an Aeon dataset using the specified data stream
     reader. A subset of the data can be loaded by specifying an optional time range, or a list
     of timestamps used to index the data on file. Returned data will be sorted chronologically.
@@ -73,6 +73,7 @@ def load(root, reader, start=None, end=None, time=None, tolerance=None, epoch=No
     :param datetime, optional tolerance:
     The maximum distance between original and new timestamps for inexact matches.
     :param str, optional epoch: A wildcard pattern to use when searching epoch data.
+    :param optional kwargs: Optional keyword arguments to forward to the reader when reading chunk data.
     :return: A pandas data frame containing epoch event metadata, sorted by time.
     """
     if isinstance(root, str):
@@ -102,7 +103,7 @@ def load(root, reader, start=None, end=None, time=None, tolerance=None, epoch=No
         for key, values in time.groupby(by=chunk):
             i = bisect.bisect_left(filetimes, key)
             if i < len(filetimes):
-                frame = reader.read(files[i])
+                frame = reader.read(files[i], **kwargs)
                 _set_index(frame)
             else:
                 frame = _empty(reader.columns)
@@ -113,7 +114,7 @@ def load(root, reader, start=None, end=None, time=None, tolerance=None, epoch=No
             if missing > 0 and i > 0:
                 # expand reindex to allow adjacent chunks
                 # to fill missing values
-                previous = reader.read(files[i - 1])
+                previous = reader.read(files[i - 1], **kwargs)
                 data = pd.concat([previous, frame])
                 data = data.reindex(values, tolerance=tolerance)
                 data.dropna(inplace=True)
@@ -134,7 +135,7 @@ def load(root, reader, start=None, end=None, time=None, tolerance=None, epoch=No
     if len(files) == 0:
         return _empty(reader.columns)
 
-    data = pd.concat([reader.read(file) for _, file in files])
+    data = pd.concat([reader.read(file, **kwargs) for _, file in files])
     _set_index(data)
     if start is not None or end is not None:
         try:


### PR DESCRIPTION
To allow more flexible parameterization of data readers, we introduce support for `kwargs` forwarding in the main `load` function. The idea is to have these extra optional arguments, if present, be forwarded to the provided `reader` object when loading raw data chunks, as a way of further parameterizing the reader functionality on a "per-load" basis.

The motivation for this is related to #396 and the need to simultaneously downsample wheel data for ingestion and analysis, and access the raw data for debugging and testing.