### PR TITLE
Add support for downsampling encoder data

### DIFF
--- a/tests/io/test_api.py
+++ b/tests/io/test_api.py
@@ -49,7 +49,18 @@ def test_load_nonmonotonic():
 def test_load_encoder_with_downsampling():
     data = aeon.load(monotonic_path, exp02.Patch2.Encoder, downsample=True)
     raw_data = aeon.load(monotonic_path, exp02.Patch2.Encoder, downsample=None)
+
+    # Check that the length of the downsampled data is less than the raw data
     assert len(data) < len(raw_data)
+
+    # Check that the first timestamp of the downsampled data is within 20ms of the raw data
+    assert abs(data.index[0] - raw_data.index[0]).total_seconds() <= 0.02
+
+    # Check that the last timestamp of the downsampled data is within 20ms of the raw data
+    assert abs(data.index[-1] - raw_data.index[-1]).total_seconds() <= 0.02
+
+    # Check that the minimum difference between consecutive timestamps in the downsampled data
+    # is at least 20ms (50Hz)
     assert data.index.to_series().diff().dt.total_seconds().min() >= 0.02
 
 

--- a/tests/io/test_api.py
+++ b/tests/io/test_api.py
@@ -29,9 +29,7 @@ def test_load_end_only():
 
 @mark.api
 def test_load_filter_nonchunked():
-    data = aeon.load(
-        nonmonotonic_path, exp02.Metadata, start=pd.Timestamp("2022-06-06T09:00:00"), downsample=None
-    )
+    data = aeon.load(nonmonotonic_path, exp02.Metadata, start=pd.Timestamp("2022-06-06T09:00:00"))
     assert len(data) > 0
 
 
@@ -45,6 +43,14 @@ def test_load_monotonic():
 def test_load_nonmonotonic():
     data = aeon.load(nonmonotonic_path, exp02.Patch2.Encoder, downsample=None)
     assert not data.index.is_monotonic_increasing
+
+
+@mark.api
+def test_load_encoder_with_downsampling():
+    data = aeon.load(monotonic_path, exp02.Patch2.Encoder, downsample=True)
+    raw_data = aeon.load(monotonic_path, exp02.Patch2.Encoder, downsample=None)
+    assert len(data) < len(raw_data)
+    assert data.index.to_series().diff().dt.total_seconds().min() >= 0.02
 
 
 if __name__ == "__main__":

--- a/tests/io/test_api.py
+++ b/tests/io/test_api.py
@@ -13,31 +13,37 @@ monotonic_path = Path(__file__).parent.parent / "data" / "monotonic"
 
 @mark.api
 def test_load_start_only():
-    data = aeon.load(nonmonotonic_path, exp02.Patch2.Encoder, start=pd.Timestamp("2022-06-06T13:00:49"))
+    data = aeon.load(
+        nonmonotonic_path, exp02.Patch2.Encoder, start=pd.Timestamp("2022-06-06T13:00:49"), downsample=None
+    )
     assert len(data) > 0
 
 
 @mark.api
 def test_load_end_only():
-    data = aeon.load(nonmonotonic_path, exp02.Patch2.Encoder, end=pd.Timestamp("2022-06-06T13:00:49"))
+    data = aeon.load(
+        nonmonotonic_path, exp02.Patch2.Encoder, end=pd.Timestamp("2022-06-06T13:00:49"), downsample=None
+    )
     assert len(data) > 0
 
 
 @mark.api
 def test_load_filter_nonchunked():
-    data = aeon.load(nonmonotonic_path, exp02.Metadata, start=pd.Timestamp("2022-06-06T09:00:00"))
+    data = aeon.load(
+        nonmonotonic_path, exp02.Metadata, start=pd.Timestamp("2022-06-06T09:00:00"), downsample=None
+    )
     assert len(data) > 0
 
 
 @mark.api
 def test_load_monotonic():
-    data = aeon.load(monotonic_path, exp02.Patch2.Encoder)
+    data = aeon.load(monotonic_path, exp02.Patch2.Encoder, downsample=None)
     assert len(data) > 0 and data.index.is_monotonic_increasing
 
 
 @mark.api
 def test_load_nonmonotonic():
-    data = aeon.load(nonmonotonic_path, exp02.Patch2.Encoder)
+    data = aeon.load(nonmonotonic_path, exp02.Patch2.Encoder, downsample=None)
     assert not data.index.is_monotonic_increasing
 
 

--- a/tests/io/test_api.py
+++ b/tests/io/test_api.py
@@ -63,6 +63,9 @@ def test_load_encoder_with_downsampling():
     # is at least 20ms (50Hz)
     assert data.index.to_series().diff().dt.total_seconds().min() >= 0.02
 
+    # Check that the timestamps in the downsampled data are strictly increasing
+    assert data.index.is_monotonic_increasing
+
 
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
As described in #396, we introduce support for downsampling raw encoder data to 50Hz. Because the magnetic encoder reports absolute angular position, it is sufficient to decimate the data by resampling periodically in bins of 20ms and taking the first value.

In this version I have set the `downsample` parameter to `True`. This change may break old data analysis scripts so we should consider whether this is the right choice.

If ensuring backwards compatibility is important, we couls also set `downsample=None` as the default, and set `downsample=True` in the ingestion scripts.






<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added a downsampling feature to the `Encoder` class in `aeon/io/reader.py`. This allows users to downsample encoder data to 50Hz, improving performance and reducing memory usage for large datasets.
- Test: Extended test coverage in `tests/io/test_api.py` to include the new downsampling functionality. This ensures the feature works as expected and maintains the integrity of the data.
- Refactor: Updated function calls within tests to include the new `downsample` parameter, enhancing the flexibility and usability of the testing suite.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->