### PR TITLE
Ensure CI runs on push to main

### DIFF
--- a/.github/workflows/build_env_run_tests.yml
+++ b/.github/workflows/build_env_run_tests.yml
@@ -3,6 +3,8 @@
 
 name: build_env_run_tests
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
     types: [opened, reopened, synchronize]


### PR DESCRIPTION
Adds a CI workflow trigger on push to main to ensure the action runs when merging pull requests. This should also enable the CI badge on the main README file.
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Chore: Implemented a Continuous Integration (CI) workflow. This update will automatically trigger the build environment and run tests whenever changes are pushed to the main branch. This ensures that all new code is properly tested, improving the reliability of our software for end-users.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->