### PR TITLE
Add `ExperimentTimeline`, fix SLEAP `anchor_part` ingestion, fix pyrat API

### DIFF
--- a/aeon/dj_pipeline/acquisition.py
+++ b/aeon/dj_pipeline/acquisition.py
@@ -166,6 +166,24 @@ class Experiment(dj.Manual):
         ]
 
 
+@schema
+class ExperimentTimeline(dj.Manual):
+    definition = """  # different parts of an experiment timeline
+    -> Experiment
+    name: varchar(32)  # e.g. presocial, social, postsocial
+    ---
+    start: datetime
+    end: datetime
+    note='': varchar(1000)
+    """
+
+    class Subject(dj.Part):
+        definition = """  # the subjects participating in this part of the experiment timeline
+        -> master
+        -> Experiment.Subject
+        """
+
+
 # ------------------- ACQUISITION EPOCH --------------------
 
 

--- a/aeon/dj_pipeline/webapps/sciviz/specsheet.yaml
+++ b/aeon/dj_pipeline/webapps/sciviz/specsheet.yaml
@@ -214,6 +214,50 @@ SciViz:
                 - type: attribute
                   input: Experiment Type
                   destination: experiment_type
+
+            New Experiment Timeline:
+              route: /exp_timeline_form
+              x: 0
+              y: 1.6
+              height: 0.4
+              width: 1
+              type: form
+              tables:
+                - aeon_acquisition.ExperimentTimeline
+              map:
+                - type: table
+                  input: Experiment Name
+                  destination: aeon_acquisition.Experiment
+                - type: attribute
+                  input: Timeline Name
+                  destination: name
+                - type: attribute
+                  input: Start Time
+                  destination: start
+                - type: attribute
+                  input: End Time
+                  destination: end
+                - type: attribute
+                  input: Note
+                  destination: note
+
+            New Timeline Subject:
+              route: /exp_timeline_subject_form
+              x: 0
+              y: 2.0
+              height: 0.3
+              width: 1
+              type: form
+              tables:
+                - aeon_acquisition.ExperimentTimeline.Subject
+              map:
+                - type: table
+                  input: Experiment Name
+                  destination: aeon_acquisition.ExperimentTimeline
+                - type: table
+                  input: Subject participating in this timeline
+                  destination: aeon_acquisition.Experiment.Subject
+
     Subjects:
       route: /subjects
       grids:


### PR DESCRIPTION
- Add new manual table to keep track of `ExperimentTimeline`
- Add new SciViz manual entry forms for `ExperimentTimeline`
- Fix pyrat subject sync with the new pyrat API changes (default `live` animals only)
- Improve reliability with extracting `anchor_part` from SLEAP reader for a given chunk