### PR TITLE
Add `model_root` in social_01, social_02, and social_03 Pose readers

### DIFF
--- a/aeon/schema/social_01.py
+++ b/aeon/schema/social_01.py
@@ -17,4 +17,4 @@ class RfidEvents(Stream):
 class Pose(Stream):
     def __init__(self, path):
         """Initializes the Pose stream."""
-        super().__init__(reader.Pose(f"{path}_node-0*"))
+        super().__init__(reader.Pose(f"{path}_node-0*", "/ceph/aeon/aeon/data/processed"))

--- a/aeon/schema/social_02.py
+++ b/aeon/schema/social_02.py
@@ -57,13 +57,13 @@ class SubjectData(StreamGroup):
 class Pose(Stream):
     def __init__(self, path):
         """Initializes the Pose stream."""
-        super().__init__(reader.Pose(f"{path}_test-node1*"))
+        super().__init__(reader.Pose(f"{path}_test-node1*", "/ceph/aeon/aeon/data/processed"))
 
 
 class Pose03(Stream):
     def __init__(self, path):
         """Initializes the Pose stream."""
-        super().__init__(reader.Pose(f"{path}_222*"))
+        super().__init__(reader.Pose(f"{path}_222*", "/ceph/aeon/aeon/data/ingest"))
 
 
 class WeightRaw(Stream):

--- a/aeon/schema/social_03.py
+++ b/aeon/schema/social_03.py
@@ -7,7 +7,7 @@ from swc.aeon.schema import Stream
 class Pose(Stream):
     def __init__(self, path):
         """Initializes the Pose stream."""
-        super().__init__(reader.Pose(f"{path}_222*"))
+        super().__init__(reader.Pose(f"{path}_222*", "/ceph/aeon/aeon/data/ingest"))
 
 
 class EnvironmentActiveConfiguration(Stream):


### PR DESCRIPTION
In [aeon_api/PR#21](https://github.com/SainsburyWellcomeCentre/aeon_api/pull/21) , the default value for `model_root` in the Pose reader is removed. This PR adds `model_root` when initialising Pose readers in social_01, social_02, and social_03 Pose streams. 