### PR TITLE
shift the write_binary_recording step from SpikeSorting to PreProcessing 

### DIFF
--- a/aeon/dj_pipeline/__init__.py
+++ b/aeon/dj_pipeline/__init__.py
@@ -13,7 +13,7 @@ _default_database_prefix = os.getenv("DJ_DB_PREFIX") or "aeon_"
 _default_repository_config = {"ceph_aeon": "/ceph/aeon"}
 
 os.environ["DJ_SUPPORT_FILEPATH_MANAGEMENT"] = "TRUE"
-dj.config["filepath_checksum_size_limit"] = 500000000  # 500 MB
+dj.config["filepath_checksum_size_limit"] = 500 * 1024**2  # Skip checksum for files > 500 MB
 
 # safe-guard in case `custom` is not provided
 if "custom" not in dj.config:

--- a/aeon/dj_pipeline/__init__.py
+++ b/aeon/dj_pipeline/__init__.py
@@ -13,6 +13,7 @@ _default_database_prefix = os.getenv("DJ_DB_PREFIX") or "aeon_"
 _default_repository_config = {"ceph_aeon": "/ceph/aeon"}
 
 os.environ["DJ_SUPPORT_FILEPATH_MANAGEMENT"] = "TRUE"
+dj.config["filepath_checksum_size_limit"] = 500000000  # 500 MB
 
 # safe-guard in case `custom` is not provided
 if "custom" not in dj.config:

--- a/aeon/dj_pipeline/ephys.py
+++ b/aeon/dj_pipeline/ephys.py
@@ -138,10 +138,12 @@ class EphysChunk(dj.Manual):
                     chunk_start = r.model.predict(
                         np.array(onix_ts[0]).reshape(-1, 1)
                     ).flatten()[0]
+                    chunk_start = io_api.to_datetime(chunk_start)
                 if idx == len(matched_sync) - 1:
                     chunk_end = r.model.predict(
                         np.array(onix_ts[-1]).reshape(-1, 1)
                     ).flatten()[0]
+                    chunk_end = io_api.to_datetime(chunk_end)
 
                 model_path = Path(tmpdir.name) / (
                     ephys_file.stem + f"_{r.clock_start}.joblib"

--- a/aeon/dj_pipeline/ephys.py
+++ b/aeon/dj_pipeline/ephys.py
@@ -3,6 +3,8 @@ import numpy as np
 from pathlib import Path
 import joblib
 import tempfile
+from typing import Dict, List, Tuple, Any
+from datetime import datetime
 
 from swc.aeon.io import api as io_api
 from aeon.schema.ephys import social_ephys
@@ -89,13 +91,17 @@ class EphysChunk(dj.Manual):
         """
 
     @classmethod
-    def ingest_chunks(cls, experiment_name):
-        """
+    def ingest_chunks(cls, experiment_name: str) -> None:
+        """Ingest ephys recording chunks with clock synchronization.
+        
         For each ephys file:
-        1. look for start/end in ONIX
-        2. map to start/end in HARP
-        3. store the HARP start/end
-        4. infer the probe type and electrode config
+        1. Extract ONIX timestamps from clock files
+        2. Map to HARP timestamps using sync models
+        3. Store chunk metadata and sync models
+        4. Infer probe type and electrode configuration
+        
+        Args:
+            experiment_name: Name of the experiment to process
         """
         key = {"experiment_name": experiment_name}
         raw_dir = acquisition.Experiment.get_data_directory(key, directory_type="raw")
@@ -105,8 +111,13 @@ class EphysChunk(dj.Manual):
         )
         sync_models = {}
 
-        def ephys_chunk_from_file(ephys_file):
-            # hardcoded probe/electrode info here, should be retrieved from the file metadata
+        def ephys_chunk_from_file(ephys_file: Path) -> None:
+            """Process a single ephys file into a chunk entry.
+            
+            Args:
+                ephys_file: Path to the ephys amplifier data file
+            """
+            # TODO: Retrieve probe/electrode info from file metadata instead of hardcoding
             probe_name = "NP2004-001"
             probe_type = "neuropixels - NP2004"
             electrode_config_name = "0-383"
@@ -235,23 +246,29 @@ class EphysBlockInfo(dj.Imported):
         channel_name="": varchar(64)  # alias of the channel
         """
 
-    def make(self, key):
-        """
-        - Find relevant ephys chunks for the given ephys block.
-        - For each chunk, extract the start and end times in the native clock (i.e. ONIX clock).
-            - For example: ephys block spans 3 chunks (3 hours)
-            - Start/end of block is 2025-01-01 07:00:00, 2025-01-01 10:00:00
-            - But due to the clock synchronization, there are actually 5 ephys chunks involved
-            - So the start/end of the ephys block in the native clock is:
-              2025-01-01 06:59:11 (start of first chunk), 2025-01-01 10:02:05 (end of last chunk)
-        - Retrieve & confirm the electrode configuration for the given ephys block.
-            - Ensure all associated ephys chunks have the same electrode configuration.
-        - Extract electrode-channel mapping
-        - Extract other metadata for this ephys block.
+    def make(self, key: Dict[str, Any]) -> None:
+        """Compute ephys block metadata and channel mappings.
+        
+        Finds relevant ephys chunks for the given block and extracts:
+        - Chunk associations (may span more chunks due to clock sync)
+        - Electrode configuration validation
+        - Channel-to-electrode mappings
+        - Block duration calculations
+        
+        Args:
+            key: Dictionary containing experiment_name, probe, block_start, block_end
         """
 
-        def create_ephys_chunk_restriction(start_time, end_time):
-            """Create a time restriction string for the chunks between the specified "start" and "end" times."""
+        def create_ephys_chunk_restriction(start_time: datetime, end_time: datetime) -> str:
+            """Create SQL restriction for chunks overlapping the time window.
+            
+            Args:
+                start_time: Block start time
+                end_time: Block end time
+                
+            Returns:
+                SQL WHERE clause string for chunk filtering
+            """
             start_restriction = f'"{start_time}" BETWEEN chunk_start AND chunk_end'
             end_restriction = f'"{end_time}" BETWEEN chunk_start AND chunk_end'
             start_query = EphysChunk & key & start_restriction
@@ -324,7 +341,14 @@ class EphysBlockInfo(dj.Imported):
         )
 
 
-def create_probe_type(probe_type: str, manufacturer: str, probe_name: str):
+def create_probe_type(probe_type: str, manufacturer: str, probe_name: str) -> None:
+    """Create a new probe type with electrode geometry from probeinterface.
+    
+    Args:
+        probe_type: Unique identifier for the probe type
+        manufacturer: Probe manufacturer (e.g., "neuropixels")
+        probe_name: Specific probe model name (e.g., "NP2004")
+    """
     import probeinterface as pi
 
     electrode_df = pi.get_probe(

--- a/aeon/dj_pipeline/scripts/ephys_mock_ingestion.py
+++ b/aeon/dj_pipeline/scripts/ephys_mock_ingestion.py
@@ -154,12 +154,12 @@ ephys.EphysBlockInfo.Channel.insert(
     allow_direct_insert=True
 )
 
-# Ephys Block - 24 hour
+# Ephys Block - 7 days
 eblock = dict(
     experiment_name=experiment_name,
     probe=probe_name,
     block_start=pd.Timestamp('2024-06-04 11:00:00'),
-    block_end=pd.Timestamp('2024-06-05 13:00:00'),
+    block_end=pd.Timestamp('2024-06-10 12:00:00'),
 )
 ephys.EphysBlock.insert1(eblock)
 ephys.EphysBlockInfo.populate(eblock)
@@ -391,7 +391,7 @@ ephys_block_dict = dict(
     experiment_name=experiment_name,
     probe=probe_name,
     block_start=pd.Timestamp('2024-06-04 11:00:00'),
-    block_end=pd.Timestamp('2024-06-05 13:00:00'),
+    block_end=pd.Timestamp('2024-06-10 12:00:00'),
 )
 
 electrode_group_dict = dict(

--- a/aeon/dj_pipeline/scripts/ephys_mock_ingestion.py
+++ b/aeon/dj_pipeline/scripts/ephys_mock_ingestion.py
@@ -349,7 +349,6 @@ params["SI_PREPROCESSING_METHOD"] = "ephys_preproc"
 params["SI_SORTING_PARAMS"] = {
     "n_pcs": 3,
     "do_CAR": False,
-    "skip_kilosort_preprocessing": True,
     "keep_good_only": True,
     "use_binary_file": True,
 }

--- a/aeon/dj_pipeline/scripts/run_aeon_spike_sorting.py
+++ b/aeon/dj_pipeline/scripts/run_aeon_spike_sorting.py
@@ -12,7 +12,7 @@ from aeon.dj_pipeline import acquisition, ephys, spike_sorting
 key = {'experiment_name': 'social-ephys0.1-aeon3',
        'probe': 'NP2004-001',
        'block_start': "2024-06-04 11:00:00",
-       'block_end': "2024-06-05 13:00:00",
+       'block_end': "2024-06-10 12:00:00",
        'probe_type': 'neuropixels - NP2004',
        'electrode_config_name': '0-383',
        'electrode_group': '0-143',

--- a/aeon/dj_pipeline/scripts/run_aeon_spike_sorting.py
+++ b/aeon/dj_pipeline/scripts/run_aeon_spike_sorting.py
@@ -9,6 +9,9 @@ Change the value of `key` below if you want to run spike sorting on a different 
 import datajoint as dj
 from aeon.dj_pipeline import acquisition, ephys, spike_sorting
 
+# Specify which table to populate: "PreProcessing", "SpikeSorting", or "PostProcessing"
+table_name = "PreProcessing"
+# Specify the key to be populated
 key = {'experiment_name': 'social-ephys0.1-aeon3',
        'probe': 'NP2004-001',
        'block_start': "2024-06-04 11:00:00",
@@ -17,21 +20,29 @@ key = {'experiment_name': 'social-ephys0.1-aeon3',
        'electrode_config_name': '0-383',
        'electrode_group': '0-143',
        'paramset_id': '250'}
-_CLEAR_JOB = True
+_CLEAR_JOB = True  # Whether to clear any existing 'error' job for this key before populating
 
-
-def clear_job():
+def clear_job(dj_table):
     """
     Clear this `key` from the jobs table (if any) to allow re-running the job 
     E.g. if this job previously failed with `error` status
     """
-    (spike_sorting.schema.jobs & {"key_hash": dj.key_hash(key), "status": "error"}).delete()
+    (spike_sorting.schema.jobs & {
+        "table_name": dj_table.table_name,
+        "key_hash": dj.key_hash(key),
+        "status": "error"}).delete()
 
 
 def main():
+    populate_table = {
+        "PreProcessing": spike_sorting.PreProcessing,
+        "SpikeSorting": spike_sorting.SpikeSorting,
+        "PostProcessing": spike_sorting.PostProcessing,
+    }[table_name]
+
     if _CLEAR_JOB:
-        clear_job()
-    spike_sorting.SpikeSorting.populate(key, reserve_jobs=True, display_progress=True)
+        clear_job(populate_table)
+    populate_table.populate(key, reserve_jobs=True, display_progress=True)
 
 
 if __name__ == '__main__':

--- a/aeon/dj_pipeline/scripts/run_aeon_spike_sorting.py
+++ b/aeon/dj_pipeline/scripts/run_aeon_spike_sorting.py
@@ -22,6 +22,7 @@ key = {'experiment_name': 'social-ephys0.1-aeon3',
        'paramset_id': '250'}
 _CLEAR_JOB = True  # Whether to clear any existing 'error' job for this key before populating
 
+
 def clear_job(dj_table):
     """
     Clear this `key` from the jobs table (if any) to allow re-running the job 

--- a/aeon/dj_pipeline/scripts/start_resource_profiler.py
+++ b/aeon/dj_pipeline/scripts/start_resource_profiler.py
@@ -138,6 +138,7 @@ def main():
     except KeyboardInterrupt:
         print("\nScript stopped manually.")
 
+
 if __name__ == "__main__":
     main()
     

--- a/aeon/dj_pipeline/scripts/start_resource_profiler.py
+++ b/aeon/dj_pipeline/scripts/start_resource_profiler.py
@@ -44,15 +44,19 @@ def get_usage_sample(prev_net=None):
         delta_sent = net.bytes_sent - prev_net.bytes_sent
         delta_recv = net.bytes_recv - prev_net.bytes_recv
     
-    # GPU
-    gpu_stats = subprocess.check_output(
-                [
-                    "nvidia-smi",
-                    "--query-gpu=utilization.gpu,memory.used,memory.total,temperature.gpu,power.draw",
-                    "--format=csv,noheader,nounits",
-                ],
-                text=True,
-            ).strip().split(', ')   # returns e.g. ['0', '0', '40536', '25', '48.29']
+    # GPU - handle gracefully if nvidia-smi not available
+    try:
+        gpu_stats = subprocess.check_output(
+                    [
+                        "nvidia-smi",
+                        "--query-gpu=utilization.gpu,memory.used,memory.total,temperature.gpu,power.draw",
+                        "--format=csv,noheader,nounits",
+                    ],
+                    text=True,
+                ).strip().split(', ')   # returns e.g. ['0', '0', '40536', '25', '48.29']
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        # No GPU or nvidia-smi not available - set all GPU stats to 0
+        gpu_stats = ['0', '0', '0', '0', '0']
 
     # Create comma-separated row
     row = [

--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -149,17 +149,15 @@ class PreProcessing(dj.Computed):
         ).fetch("file_path", "directory_type", order_by="chunk_start")
 
         # Channels
-        electrodes_df = (
-            (
+        electrodes_query = (
                 ephys.EphysBlockInfo.Channel
                 * ephys.ElectrodeConfig.Electrode
                 * ElectrodeGroup.Electrode
                 * ephys.ProbeType.Electrode
                 & key
             )
-            .fetch(format="frame")
-            .reset_index()
-        )
+        electrodes_df = electrodes_query.fetch(format="frame").reset_index()
+        electrodes_df.drop(columns=list(key), inplace=True, errors="ignore")
 
         num_channels = len(ephys.ElectrodeConfig.Electrode & key)
         # Neuropixels 2.0 constants - TODO: read this from the metadata
@@ -183,6 +181,7 @@ class PreProcessing(dj.Computed):
         import probeinterface as pi
         import spikeinterface as si
         import spikeinterface.extractors as se
+        from spikeinterface import sorters
 
         execution_time = datetime.now(UTC)
 
@@ -228,6 +227,23 @@ class PreProcessing(dj.Computed):
         # Run preprocessing and save results to output folder
         si_recording = ephys_preproc(si_recording)
         si_recording.dump_to_pickle(file_path=recording_file, relative_to=output_dir)
+
+        # write binary into recording.dat
+        job_kwargs = {"n_jobs": 0.8, "chunk_duration": "2s"}
+        binary_file_path = recording_file.parent / "recording.dat"
+        if binary_file_path.exists():
+            load_and_verify_binary_file(
+                binary_file_path=binary_file_path,
+                se_recording_obj=si_recording)
+            logger.info(f"{binary_file_path} already exists. Skipping writing binary file.")
+        else:
+            logger.info(f"Writing binary recording to {binary_file_path}...")
+            si.core.write_binary_recording(
+                    recording=si_recording,
+                    file_paths=[binary_file_path],
+                    dtype="int16",
+                    **sorters.basesorter.get_job_kwargs(job_kwargs, True),
+                )
 
         return output_dir, execution_time, recording_dir
 
@@ -296,11 +312,20 @@ class SpikeSorting(dj.Computed):
         si_recording: si.BaseRecording = si.load(
             recording_file, base_folder=output_dir
         )
+        # load the pre-generated binary file - recording.dat
+        binary_rec = load_and_verify_binary_file(
+            binary_file_path=Path(recording_file).parent / "recording.dat",
+            se_recording_obj=si_recording)
+
         sorting_params = params["SI_SORTING_PARAMS"]
+
+        # explicitly set `skip_kilosort_preprocessing` to False
+        # to avoid SpikeInterface rerunning the `write_binary_recording` step
+        sorting_params["skip_kilosort_preprocessing"] = False
 
         si_sorting: si.sorters.BaseSorter = si.sorters.run_sorter(
             sorter_name=sorter_name,
-            recording=si_recording,
+            recording=binary_rec,
             folder=sorting_output_dir,
             remove_existing_folder=True,
             verbose=True,
@@ -878,3 +903,22 @@ def ephys_preproc(recording):
         recording=recording, operator="median"
     )
     return recording
+
+
+def load_and_verify_binary_file(binary_file_path, se_recording_obj):
+    import spikeinterface.extractors as se
+
+    binary_rec = se.read_binary(
+        binary_file_path,
+        sampling_frequency=se_recording_obj.get_sampling_frequency(),
+        dtype=np.uint16,
+        num_channels=se_recording_obj.get_num_channels(),
+        gain_to_uV=se_recording_obj.get_channel_gains()[0])
+    if binary_rec.get_num_samples() != se_recording_obj.get_num_samples():
+        raise ValueError(f"Number of samples in binary file ({binary_rec.get_num_samples()})"
+                         f" does not match the original recording ({se_recording_obj.get_num_samples()}).")
+
+    binary_rec.set_probe(probe=se_recording_obj.get_probe(), in_place=True)
+    # force rename channel_ids?
+    # binary_rec._main_ids = se_recording_obj.get_channel_ids()
+    return binary_rec

--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -825,6 +825,10 @@ class SyncedSpikes(dj.Imported):
                     spk_ind = spike_indices[spike_indices <= onix_bound]
                 else:
                     spk_ind = spike_indices[(spike_indices > onix_lengths[idx - 1]) & (spike_indices <= onix_bound)]
+
+                if not len(spk_ind):  # no spikes in this chunk
+                    continue
+
                 spk_ind -= spk_ind[0]  # make the spike indices relative to the start of the onix_times
                 spk_times = onix_times[idx][spk_ind]
                 # sync the spike times to the HARP clock

--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -6,6 +6,7 @@ import json
 from datetime import datetime, UTC
 import joblib
 import tempfile
+from typing import Dict, List, Tuple, Any, Optional
 
 from aeon.dj_pipeline import acquisition, ephys, get_schema_name
 from aeon.dj_pipeline.utils.paths import get_sorting_root_dir
@@ -117,9 +118,18 @@ class PreProcessing(dj.Computed):
         """
 
     @classmethod
-    def infer_output_dir(cls, key, relative=False, mkdir=False):
+    def infer_output_dir(cls, key: Dict[str, Any], relative: bool = False, mkdir: bool = False) -> Path:
+        """Generate standardized output directory path for sorting results.
+        
+        Args:
+            key: Sorting task key with experiment, block, and parameter info
+            relative: Return path relative to sorting root directory
+            mkdir: Create directory if it doesn't exist
+            
+        Returns:
+            Path to the sorting output directory
+        """
         sorting_root_dir = get_sorting_root_dir()
-        # Infer output directory
         sorting_method = (SortingMethod * SortingParamSet & key).fetch1("sorting_method")
         start_str = key["block_start"].strftime("%Y-%m-%dT%H-%M-%S")
         end_str = key["block_end"].strftime("%Y-%m-%dT%H-%M-%S")
@@ -167,16 +177,29 @@ class PreProcessing(dj.Computed):
 
         return ephys_files, dir_types, electrodes_df, num_channels, fs_hz, gain_to_uV, offset_to_uV, output_dir, recording_file, recording_dir
 
-    def make_compute(self, key, ephys_files, dir_types, electrodes_df,
-             num_channels, fs_hz, gain_to_uV, offset_to_uV,
-             output_dir, recording_file, recording_dir):
-        """ Pre-processing the ephys data, before spike sorting. E.g.:
-        - data concatenation (based on EphysBlock)
-        - channel selection (based on ElectrodeGroup)
-        - bad channel detection/removal
-        - band-pass filtering
-        - common average referencing
-        - etc.
+    def make_compute(self, key: Dict[str, Any], ephys_files: List[str], dir_types: List[str], 
+                     electrodes_df: pd.DataFrame, num_channels: int, fs_hz: float, 
+                     gain_to_uV: float, offset_to_uV: float, output_dir: Path, 
+                     recording_file: Path, recording_dir: Path) -> Tuple[Path, datetime, Path]:
+        """Preprocess ephys data for spike sorting.
+        
+        Performs data concatenation, channel selection, filtering, and probe setup.
+        
+        Args:
+            key: Sorting task key
+            ephys_files: List of ephys file paths
+            dir_types: Directory types for each file
+            electrodes_df: Electrode configuration dataframe
+            num_channels: Total number of channels
+            fs_hz: Sampling frequency
+            gain_to_uV: Gain conversion factor
+            offset_to_uV: Offset conversion factor
+            output_dir: Output directory path
+            recording_file: Path to save recording object
+            recording_dir: Directory for recording files
+            
+        Returns:
+            Tuple of (output_dir, execution_time, recording_dir)
         """
         import probeinterface as pi
         import spikeinterface as si
@@ -264,7 +287,7 @@ class PreProcessing(dj.Computed):
             [
                 {**key, "file_name": f.relative_to(output_dir.parent).as_posix(), "file": f}
                 for f in recording_dir.rglob("*")
-                if f.is_file() and not f.name == "recording.dat"  # exclude the large binary file (too long for hashing)
+                if f.is_file() and f.name != "recording.dat"  # exclude the large binary file (too long for hashing)
             ]
         )
 
@@ -299,16 +322,26 @@ class SpikeSorting(dj.Computed):
 
         return recording_file, output_dir, params, sorting_method
 
-    def make_compute(self, key, recording_file, output_dir, params, sorting_method):
+    def make_compute(self, key: Dict[str, Any], recording_file: Path, output_dir: Path, 
+                     params: Dict[str, Any], sorting_method: str) -> Tuple[Path, datetime, float]:
+        """Run spike sorting using specified algorithm and parameters.
+        
+        Args:
+            key: Sorting task key
+            recording_file: Path to preprocessed recording
+            output_dir: Base output directory
+            params: Sorting parameters dictionary
+            sorting_method: Name of sorting algorithm (e.g., kilosort2)
+            
+        Returns:
+            Tuple of (sorting_output_dir, execution_time, execution_duration)
+        """
         import spikeinterface as si
         from spikeinterface import sorters
 
         execution_time = datetime.now(UTC)
-
         sorter_name = sorting_method.replace(".", "_")
         sorting_output_dir = output_dir / "spike_sorting"
-
-        """ Run spike sorting using the specified method and parameters. """
         si_recording: si.BaseRecording = si.load(
             recording_file, base_folder=output_dir
         )
@@ -321,6 +354,7 @@ class SpikeSorting(dj.Computed):
 
         # explicitly set `skip_kilosort_preprocessing` to False
         # to avoid SpikeInterface rerunning the `write_binary_recording` step
+        # https://github.com/SpikeInterface/spikeinterface/blob/813d9640eed6e4e28a411e37efaef67026b790e3/src/spikeinterface/sorters/external/kilosortbase.py#L131
         sorting_params["skip_kilosort_preprocessing"] = False
 
         si_sorting: si.sorters.BaseSorter = si.sorters.run_sorter(
@@ -391,11 +425,21 @@ class PostProcessing(dj.Computed):
 
         return recording_file, sorting_file, output_dir, params
 
-    def make_compute(self, key, recording_file, sorting_file, output_dir, params):
-        """ Post-processing the ephys data, after spike sorting. E.g.:
-        - quality assessment
-        - waveform extraction
-        - etc.
+    def make_compute(self, key: Dict[str, Any], recording_file: Path, sorting_file: Path, 
+                     output_dir: Path, params: Dict[str, Any]) -> Tuple[Path, datetime, float]:
+        """Post-process spike sorting results with quality assessment.
+        
+        Runs SpikeInterface sorting analyzer to compute quality metrics and extensions.
+        
+        Args:
+            key: Sorting task key
+            recording_file: Path to recording object
+            sorting_file: Path to sorting results
+            output_dir: Base output directory
+            params: Post-processing parameters
+            
+        Returns:
+            Tuple of (analyzer_output_dir, execution_time, execution_duration)
         """
         import spikeinterface as si
         from spikeinterface import sorters
@@ -815,9 +859,23 @@ class SyncedSpikes(dj.Imported):
         spike_times: longblob  # (s) synchronized spike times (i.e. in HARP clock) for the respective EphysChunk
         """
 
-    def make(self, key):
-        """
-        Synchronize the spike times to the HARP clock.
+    def make(self, key: Dict[str, Any]) -> None:
+        """Synchronize spike indices to HARP timestamps and organize by ephys chunks.
+        
+        This method performs the critical step of converting spike indices (from concatenated
+        binary data) back to actual timestamps synchronized to the HARP clock system.
+        
+        Process:
+        1. Load sync models for ONIX→HARP timestamp conversion
+        2. Load ONIX clock data from all ephys chunks in the block
+        3. For each unit's spike indices:
+           - Map indices to corresponding ephys chunks
+           - Convert indices to ONIX timestamps using clock data
+           - Apply sync models to convert ONIX→HARP timestamps
+           - Group results by ephys chunk for downstream analysis
+        
+        Args:
+            key: Dictionary containing sorting task identifiers
         """
         # Load ephys sync models
         sync_models = {}
@@ -842,10 +900,20 @@ class SyncedSpikes(dj.Imported):
             onix_times.append(onix_ts)
         onix_lengths = np.cumsum([len(s) for s in onix_times])
 
-        def indices2syncedtimes(spike_indices):
-            # loop through the onix_times and index the spikes within bound of each onix_times
-            # the nested loop - seemingly inefficient - is to make use of `memmap` to avoid memory issues
+        def indices2syncedtimes(spike_indices: np.ndarray) -> Tuple[Dict[str, Any], np.ndarray]:
+            """Convert spike indices to HARP-synchronized timestamps by ephys chunk.
+            
+            Maps spike indices (from concatenated binary data) back to their original
+            ephys chunks and converts to HARP timestamps using sync models.
+            
+            Args:
+                spike_indices: Array of spike indices in concatenated recording
+                
+            Yields:
+                Tuple of (chunk_key, synced_timestamps) for each ephys chunk
+            """
             for idx, onix_bound in enumerate(onix_lengths):
+                # Find spikes belonging to this ephys chunk
                 if idx == 0:
                     spk_ind = spike_indices[spike_indices <= onix_bound]
                 else:
@@ -854,14 +922,18 @@ class SyncedSpikes(dj.Imported):
                 if not len(spk_ind):  # no spikes in this chunk
                     continue
 
-                spk_ind -= spk_ind[0]  # make the spike indices relative to the start of the onix_times
-                spk_times = onix_times[idx][spk_ind]
-                # sync the spike times to the HARP clock
+                # Convert absolute indices to relative indices within this chunk
+                spk_ind -= spk_ind[0]  # make relative to chunk start
+                spk_times = onix_times[idx][spk_ind]  # get ONIX timestamps
+                
+                # Apply sync models to convert ONIX→HARP timestamps
                 synced_ts = []
                 for (start, end), model in sync_models.items():
+                    # Find spikes within this sync model's time window
                     ind = np.logical_and(spk_times >= start, spk_times <= end)
                     if not np.any(ind):
                         continue
+                    # Convert ONIX timestamps to HARP timestamps
                     sync_t = model.predict(spk_times[ind].reshape(-1, 1))
                     synced_ts.extend(sync_t.flatten())
 
@@ -886,11 +958,17 @@ class SyncedSpikes(dj.Imported):
 
 # ---- Ephys preprocessing with spike interface ----
 
-def ephys_preproc(recording):
-    """
-    Basic ephys preprocessing using SpikeInterface.
-    1. Bandpass filter the recording between 300 Hz and 6000 Hz.
-    2. Common average reference the recording using median.
+def ephys_preproc(recording) -> Any:
+    """Apply standard ephys preprocessing pipeline.
+    
+    Performs unsigned-to-signed conversion, bandpass filtering (300-6000 Hz),
+    and common average referencing using median.
+    
+    Args:
+        recording: SpikeInterface recording object
+        
+    Returns:
+        Preprocessed recording object
     """
     import spikeinterface as si
     from spikeinterface import preprocessing
@@ -905,7 +983,19 @@ def ephys_preproc(recording):
     return recording
 
 
-def load_and_verify_binary_file(binary_file_path, se_recording_obj):
+def load_and_verify_binary_file(binary_file_path: Path, se_recording_obj: Any) -> Any:
+    """Load and verify binary recording file matches original recording.
+    
+    Args:
+        binary_file_path: Path to binary recording file
+        se_recording_obj: Original SpikeInterface recording object
+        
+    Returns:
+        Binary recording object with probe geometry
+        
+    Raises:
+        ValueError: If sample counts don't match between files
+    """
     import spikeinterface.extractors as se
 
     binary_rec = se.read_binary(

--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -264,7 +264,7 @@ class PreProcessing(dj.Computed):
             [
                 {**key, "file_name": f.relative_to(output_dir.parent).as_posix(), "file": f}
                 for f in recording_dir.rglob("*")
-                if f.is_file()
+                if f.is_file() and not f.name == "recording.dat"  # exclude the large binary file (too long for hashing)
             ]
         )
 

--- a/run_aeon_spike_sorting.sh
+++ b/run_aeon_spike_sorting.sh
@@ -3,14 +3,12 @@
 # =============================================================================
 # AEON Spike Sorting SLURM Script
 # =============================================================================
-# Usage:
-#   GPU mode:    sbatch run_aeon_spike_sorting.sh
-#   CPU mode:    sbatch --partition=cpu run_aeon_spike_sorting.sh
-#   Custom GPU:  sbatch --gres=gpu:a100:1 run_aeon_spike_sorting.sh
+# Usage:  sbatch run_aeon_spike_sorting.sh
 # =============================================================================
 
 #SBATCH --job-name=aeon-spike-sorting         # job name
-#SBATCH --partition=cpu                       # Change to 'cpu' for CPU-only mode
+#SBATCH --partition=gpu                       # Change to 'cpu' for CPU-only mode
+#SBATCH --gres=gpu:p5000:1                    # Remove this line for CPU-only mode
 #SBATCH --nodes=1                             # node count
 #SBATCH --ntasks=1                            # total number of tasks across all nodes
 #SBATCH --mem=128G                            # total memory per node

--- a/run_aeon_spike_sorting.sh
+++ b/run_aeon_spike_sorting.sh
@@ -46,7 +46,7 @@ fi
 
 # Start resource profiler in the background
 echo "Starting resource profiler..."
-python ./aeon/dj_pipeline/scripts/start_resource_profiler.py -o ./slurm_output/resource_use.csv & PROFILER_PID=$!
+python ./aeon/dj_pipeline/scripts/start_resource_profiler.py -o "./slurm_output/resource_use_${SLURM_JOB_ID}.csv" & PROFILER_PID=$!
 echo "Resource profiler started with PID: $PROFILER_PID"
 
 # Verify Python script exists

--- a/run_aeon_spike_sorting.sh
+++ b/run_aeon_spike_sorting.sh
@@ -1,12 +1,20 @@
 #!/bin/bash
 
+# =============================================================================
+# AEON Spike Sorting SLURM Script
+# =============================================================================
+# Usage:
+#   GPU mode:    sbatch run_aeon_spike_sorting.sh
+#   CPU mode:    sbatch --partition=cpu run_aeon_spike_sorting.sh
+#   Custom GPU:  sbatch --gres=gpu:a100:1 run_aeon_spike_sorting.sh
+# =============================================================================
+
 #SBATCH --job-name=aeon-spike-sorting         # job name
-#SBATCH --partition=gpu                       # partition (queue) gpu_branco
-#SBATCH --gres=gpu:a100:1                     # request specific gpu type
+#SBATCH --partition=cpu                       # Change to 'cpu' for CPU-only mode
 #SBATCH --nodes=1                             # node count
 #SBATCH --ntasks=1                            # total number of tasks across all nodes
 #SBATCH --mem=128G                            # total memory per node
-#SBATCH --time=0-01:00:00                     # total run time limit (DD-HH:MM:SS)
+#SBATCH --time=7-01:00:00                     # total run time limit (DD-HH:MM:SS)
 #SBATCH --output=slurm_output/%N_%j.out       # output file path
 #SBATCH --error=slurm_output/%N_%j.err        # error file path
 


### PR DESCRIPTION
The `write_binary_recording`, currently deeply nested within the SpikeInterface `run_sorter` step, does not require GPU and doesn't have to be run as part of the `run_sorter` step.
This PR decouple the `write_binary_recording` step and run it as part of the `PreProcessing` table (CPU only)