### PR TITLE
Rename single mouse foraging dataset

### DIFF
--- a/docs/examples/dj_querying_data.ipynb
+++ b/docs/examples/dj_querying_data.ipynb
@@ -20,7 +20,7 @@
     "To access it, go to the Notebook tab at the top and in the File Browser on the left, navigate to `ucl-swc_aeon > docs > examples`, where this notebook `dj_querying_data.ipynb` is located.\n",
     "\n",
     ":::{note}\n",
-    "The examples here use the [Single mouse in a foraging assay](sample-data-single-mouse-foraging:) dataset for the experiment named `social0.2-aeon3`. \n",
+    "The examples here use the [Single Mouse Foraging Assay – 2-Hour Sample](sample-data-single-mouse-foraging:) dataset for the experiment named `social0.2-aeon3`. \n",
     "If you are using a different dataset, be sure to replace the experiment name and  parameters in the code below accordingly.\n",
     ":::"
    ]

--- a/docs/examples/io_api_example.ipynb
+++ b/docs/examples/io_api_example.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Data access using the low-level API\n",
     "\n",
-    "This guide demonstrates how to access raw data using [`aeon_api`](target-aeon-api-reference), Aeon's low-level API. In this example, we are using the [Single mouse in a foraging assay](target-full-datasets) dataset."
+    "This guide demonstrates how to access raw data using [`aeon_api`](target-aeon-api-reference), Aeon's low-level API. In this example, we are using the [Single Mouse Foraging Assay – 2-Hour Sample](target-full-datasets) dataset."
    ]
   },
   {


### PR DESCRIPTION
We updated the dataset name on [zenodo](doi.org/10.5281/zenodo.13881884) from Sample data - 2hs to Single Mouse Foraging Assay – 2-Hour Sample