### PR TITLE
Add Bno055 binary stream readers

### DIFF
--- a/aeon/schema/ephys.py
+++ b/aeon/schema/ephys.py
@@ -74,6 +74,22 @@ class Bno055(StreamGroup):
         def __init__(self, pattern):
             super().__init__(f"{pattern}_Bno055_Clock_*")
 
+    class Bno055Euler(Stream):
+        def __init__(self, pattern):
+            super().__init__(Binary(f"{pattern}_Bno055_Euler_*", dtype=np.float32, columns=['x', 'y', 'z']))
+
+    class Bno055GravityVector(Stream):
+        def __init__(self, pattern):
+            super().__init__(Binary(f"{pattern}_Bno055_GravityVector_*", dtype=np.float32, columns=['x', 'y', 'z']))
+
+    class Bno055LinearAcceleration(Stream):
+        def __init__(self, pattern):
+            super().__init__(Binary(f"{pattern}_Bno055_LinearAcceleration_*", dtype=np.float32, columns=['x', 'y', 'z']))
+
+    class Bno055Quaternion(Stream):
+        def __init__(self, pattern):
+            super().__init__(Binary(f"{pattern}_Bno055_Quaternion_*", dtype=np.float32, columns=['w', 'x', 'y', 'z']))
+
 
 class NeuropixelsV2Beta(StreamGroup):
     def __init__(self, path):


### PR DESCRIPTION
The `Binary` base reader is configured to access each of the raw flat-binary chunks for the BNO0055 device in the Neuropixels V2 beta headstage. These streams are not natively chunked nor timestamped so currently they cannot be used directly with `aeon.load`. Instead, explicit chunk paths should be used to access each chunk.

Afterwards, we can extract the corresponding ONIX clock stream, and convert ONIX time to Aeon time using the `HarpSyncModel`.

Example code below:

```python
root = Path(r'/ceph/aeon/aeon/data/raw/AEONX1/social-ephys0.1/')
epoch = '2025-06-04T16-28-57'
epoch_path = root / epoch

# Data schema
social_ephys = DotMap(
    [
        Device("Metadata", core.Metadata),
        Device("NeuropixelsV2Beta", ephys.HarpSync, ephys.HarpSyncModel, ephys.Bno055)
    ]

# Raw data
euler = social_ephys.NeuropixelsV2Beta.Bno055Euler.read(epoch_path / 'NeuropixelsV2Beta/NeuropixelsV2Beta_Bno055_Euler_0.bin')
gravity = social_ephys.NeuropixelsV2Beta.Bno055GravityVector.read(epoch_path / 'NeuropixelsV2Beta/NeuropixelsV2Beta_Bno055_GravityVector_0.bin')
accel = social_ephys.NeuropixelsV2Beta.Bno055LinearAcceleration.read(epoch_path / 'NeuropixelsV2Beta/NeuropixelsV2Beta_Bno055_LinearAcceleration_0.bin')
quat = social_ephys.NeuropixelsV2Beta.Bno055Quaternion.read(epoch_path / 'NeuropixelsV2Beta/NeuropixelsV2Beta_Bno055_Quaternion_0.bin')

# Convert ONIX clock to Aeon time
clock = social_ephys.NeuropixelsV2Beta.Bno055Clock.read(epoch_path / 'NeuropixelsV2Beta/NeuropixelsV2Beta_Bno055_Clock_0.bin')
sync_model = aeon.load(root, social_ephys.NeuropixelsV2Beta.HarpSyncModel, epoch=epoch)
harp_seconds = sync_model.model.iloc[0].predict(clock.values)
aeon_time = aeon.io.api.to_datetime(harp_seconds.reshape(-1))

# Assign new index
euler.index = aeon_time
gravity.index = aeon_time
accel.index = aeon_time
quat.index = aeon_time

# Plot data
fig, (e,g,a,q) = plt.subplots(4, 1, sharex=True)
e.plot(euler)
e.set_ylabel('euler')
g.plot(gravity)
g.set_ylabel('gravity')
a.plot(accel)
a.set_ylabel('acceleration')
q.plot(quat)
q.set_ylabel('quaternion')
fig.show()
```