### PR TITLE
Fix timezone mismatch in epoch/chunk ingestion

### DIFF
--- a/aeon/dj_pipeline/acquisition.py
+++ b/aeon/dj_pipeline/acquisition.py
@@ -215,7 +215,9 @@ class Epoch(dj.Manual):
         for i, (_, chunk) in enumerate(all_chunks.iterrows()):
             chunk_rep_file = pathlib.Path(chunk.path)
             epoch_dir = pathlib.Path(chunk_rep_file.as_posix().split(device_name)[0])
-            epoch_start = datetime.datetime.strptime(epoch_dir.name, "%Y-%m-%dT%H-%M-%S")
+            epoch_start = datetime.datetime.strptime(epoch_dir.name, "%Y-%m-%dT%H-%M-%S").replace(
+                tzinfo=datetime.timezone.utc
+            )
             # --- insert to Epoch ---
             epoch_key = {"experiment_name": experiment_name, "epoch_start": epoch_start}
 
@@ -237,7 +239,7 @@ class Epoch(dj.Manual):
                 previous_epoch_dir = pathlib.Path(previous_chunk_path.as_posix().split(device_name)[0])
                 previous_epoch_start = datetime.datetime.strptime(
                     previous_epoch_dir.name, "%Y-%m-%dT%H-%M-%S"
-                )
+                ).replace(tzinfo=datetime.timezone.utc)
                 previous_chunk_end = previous_chunk.name + datetime.timedelta(hours=io_api.CHUNK_DURATION)
                 previous_epoch_end = min(previous_chunk_end, epoch_start)
                 previous_epoch_key = {
@@ -355,7 +357,9 @@ class EpochConfig(dj.Imported):
 
         # Load metadata and extract rig_config
         metadata = json.loads(metadata_filepath.read_text())
-        epoch_start = datetime.datetime.strptime(metadata_filepath.parent.name, "%Y-%m-%dT%H-%M-%S")
+        epoch_start = datetime.datetime.strptime(metadata_filepath.parent.name, "%Y-%m-%dT%H-%M-%S").replace(
+            tzinfo=datetime.timezone.utc
+        )
         rig_config = metadata.get("rig", {})
 
         if not rig_config:
@@ -465,7 +469,9 @@ class Chunk(dj.Manual):
         for _, chunk in all_chunks.iterrows():
             chunk_rep_file = pathlib.Path(chunk.path)
             epoch_dir = pathlib.Path(chunk_rep_file.as_posix().split(device_name)[0])
-            epoch_start = datetime.datetime.strptime(epoch_dir.name, "%Y-%m-%dT%H-%M-%S")
+            epoch_start = datetime.datetime.strptime(epoch_dir.name, "%Y-%m-%dT%H-%M-%S").replace(
+                tzinfo=datetime.timezone.utc
+            )
 
             epoch_key = {"experiment_name": experiment_name, "epoch_start": epoch_start}
             if not (Epoch & epoch_key):
@@ -483,6 +489,9 @@ class Chunk(dj.Manual):
             # If there's an epoch end, use that instead
             if EpochEnd & epoch_key:
                 epoch_end = (EpochEnd & epoch_key).fetch1("epoch_end")
+                # DataJoint returns naive datetimes from MySQL; make UTC-aware for comparison
+                if epoch_end.tzinfo is None:
+                    epoch_end = epoch_end.replace(tzinfo=datetime.timezone.utc)
                 chunk_end = min(chunk_end, epoch_end)
 
             # --- insert to Chunk ---


### PR DESCRIPTION
## Summary
- `io_api.load()` returns UTC-aware timestamps (`pd.to_datetime(utc=True)`), but `ingest_epochs`, `ingest_chunks`, and `EpochConfig.make` parse epoch directory names with `datetime.strptime()` which produces timezone-naive datetimes
- Comparing the two raises `TypeError: can't compare offset-naive and offset-aware datetimes`
- Adds `.replace(tzinfo=datetime.timezone.utc)` to all 4 `strptime` calls in `acquisition.py`, plus a defensive guard for `epoch_end` fetched from the DB via DataJoint (which returns naive datetimes from MySQL)

## How it was found
Hit during first end-to-end test of `tn/core_pipeline` with real foragingABC data on HPC. Crashed at `Epoch.ingest_epochs` line 242: `min(previous_chunk_end, epoch_start)`.

## Test plan
- [x] Verified all `strptime` calls in `acquisition.py` are covered
- [ ] Re-run `setup_pipeline.py` on HPC with this fix (in progress)