### PR TITLE
Fix timezone mismatch and MariaDB json compatibility

### DIFF
--- a/aeon/dj_pipeline/acquisition.py
+++ b/aeon/dj_pipeline/acquisition.py
@@ -397,6 +397,10 @@ class EpochConfig(dj.Imported):
         # Remove devices key before inserting - it was only needed for ingest_epoch_metadata_from_rig
         epoch_config.pop("devices", None)
 
+        # MariaDB aliases `json` to `longtext`, so DataJoint's auto json.dumps doesn't fire.
+        # Serialize manually before insert.
+        epoch_config["metadata"] = json.dumps(epoch_config["metadata"])
+
         # Insert EpochConfig entries (stores rig_config JSON for runtime reader resolution)
         self.insert1(key)
         self.Meta.insert1(epoch_config)

--- a/aeon/dj_pipeline/acquisition.py
+++ b/aeon/dj_pipeline/acquisition.py
@@ -210,6 +210,7 @@ class Epoch(dj.Manual):
         device_name = _ref_device_mapping.get(experiment_name, "CameraTop")
 
         all_chunks, raw_data_dirs = _get_all_chunks(experiment_name, device_name)
+        all_chunks.index = all_chunks.index.tz_localize(None)
 
         epoch_list = []
         for i, (_, chunk) in enumerate(all_chunks.iterrows()):
@@ -460,6 +461,7 @@ class Chunk(dj.Manual):
         device_name = _ref_device_mapping.get(experiment_name, "CameraTop")
 
         all_chunks, raw_data_dirs = _get_all_chunks(experiment_name, device_name)
+        all_chunks.index = all_chunks.index.tz_localize(None)
 
         chunk_starts, chunk_list, file_list, file_name_list = [], [], [], []
         for _, chunk in all_chunks.iterrows():

--- a/aeon/dj_pipeline/utils/load_metadata.py
+++ b/aeon/dj_pipeline/utils/load_metadata.py
@@ -467,6 +467,12 @@ def get_stream_reader_for_epoch(
     epoch_key = {"experiment_name": experiment_name, "epoch_start": epoch_start}
     rig_metadata = (acquisition.EpochConfig.Meta & epoch_key).fetch1("metadata")
 
+    # MariaDB 10.3 aliases `json` columns to `longtext`, so DataJoint's auto
+    # json.loads() doesn't fire. Deserialize manually if needed.
+    if isinstance(rig_metadata, str):
+        import json
+        rig_metadata = json.loads(rig_metadata)
+
     # Get Rig class from Experiment class and reconstruct directly
     experiment_class = get_experiment_pydantic(schema_name)
     rig_class = experiment_class.model_fields["rig"].annotation


### PR DESCRIPTION
## Summary

Two bugs found while testing `tn/core_pipeline` end-to-end with the foragingABC experiment on HPC (aeon-db, MariaDB 10.3.28):

- **Timezone mismatch** — `io_api.load()` returns UTC-aware timestamps, but `strptime` on epoch directory names returns naive timestamps. Comparing them raises `TypeError`. Fix: `tz_localize(None)` after `_get_all_chunks()` in both `ingest_epochs` and `ingest_chunks`.

- **MariaDB json column** — `EpochConfig.Meta.metadata` is defined as `json`, but MariaDB 10.3 aliases `json` → `longtext`. DataJoint reads the actual column type, so `attr.json` is `False` and auto `json.dumps()`/`json.loads()` never fires. Fix: manual serialization on insert (`acquisition.py`) and deserialization on fetch (`load_metadata.py`).

## Test plan

- [x] Tested on HPC with real foragingABC data (aeon-db, MariaDB 10.3.28)
- [x] All 8 setup steps pass
- [x] 27/28 validation checks pass (1 expected failure: SpinnakerCameraPosition for cameras without tracking)
- [x] 9/10 stream tables populate successfully from ceph