### PR TITLE
Refine unit matching design (spec + schema changes)

### DIFF
--- a/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
+++ b/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
@@ -16,13 +16,13 @@
 
 ### Purpose
 
-Long-running AEON experiments record neural activity across multiple consecutive ephys blocks (sessions), each independently spike-sorted. The same neuron appears as a different `unit` ID in each session's sorting results. The unit matching system solves this by assigning a persistent **global unit** identity to neurons across sessions, enabling longitudinal analysis of single-neuron activity over days or weeks.
+Long-running AEON experiments record neural activity across multiple consecutive ephys blocks, each independently spike-sorted. The same neuron appears as a different `unit` ID in each block's sorting results. The unit matching system solves this by assigning a persistent **global unit** identity to neurons across blocks, enabling longitudinal analysis of single-neuron activity over days or weeks.
 
-The system works by exploiting temporal overlap between consecutive ephys blocks: when two blocks share a time window, the same neurons produce spikes in both blocks' sorted data. By comparing spike times in the overlap region, the system identifies which units across sessions correspond to the same neuron.
+The system works by exploiting temporal overlap between consecutive ephys blocks: when two blocks share a time window, the same neurons produce spikes in both blocks' sorted data. By comparing spike times in the overlap region, the system identifies which units across blocks correspond to the same neuron.
 
 ### Prerequisites
 
-Unit matching sits at the end of the spike sorting pipeline. A session must have completed the full chain before it is eligible for matching:
+Unit matching sits at the end of the spike sorting pipeline. An ephys block must have completed the full chain before it is eligible for matching:
 
 ```
 SortingTask → PreProcessing → SpikeSorting → PostProcessing
@@ -30,27 +30,27 @@ SortingTask → PreProcessing → SpikeSorting → PostProcessing
 → UnitMatching (this system)
 ```
 
-Specifically, `UnitMatching.key_source` requires that `ApplyOfficialCuration` exists for the session, ensuring only curated (quality-controlled) results enter the matching pipeline.
+Specifically, `UnitMatching.key_source` requires that `ApplyOfficialCuration` exists for the block, ensuring only curated (quality-controlled) results enter the matching pipeline.
 
 ### Key Concepts
 
 A **global unit** is a persistent neuron identity scoped to a single probe insertion (i.e., one physical probe in one subject). Global unit IDs are integers starting at 1, unique within a `(experiment_name, subject, insertion_number)` scope.
 
-A **matched unit** links a session-specific `SortedSpikes.Unit` to its assigned global unit. Each session unit maps to exactly one global unit. A global unit may be matched to units from multiple sessions (that's the whole point).
+A **matched unit** links a block-specific `SortedSpikes.Unit` to its assigned global unit. Each block's unit maps to exactly one global unit. A global unit may be matched to units from multiple blocks (that's the whole point).
 
 **Temporal overlap** between consecutive ephys blocks is the mechanism that enables matching. The overlap region contains spikes from the same neurons captured by both blocks' independent sorting runs. The matching algorithm compares spike times in this overlap window to identify corresponding units.
 
-The **ownership convention** determines which session "owns" the spike data for a given (global_unit, chunk) pair when multiple sessions cover the same chunk. This prevents duplicate rows in `Spikes`.
+The **ownership convention** determines which block "owns" the spike data for a given (global_unit, chunk) pair when multiple blocks cover the same chunk. This prevents duplicate rows in `Spikes`.
 
 ### Critical Constraint: Temporal Ordering
 
-Sessions **must** be processed in temporal order (by `block_start`). Session N compares its units against previously-matched sessions (1..N-1). Processing out of order produces incorrect global unit assignments.
+Ephys blocks **must** be processed in temporal order (by `block_start`). Block N compares its units against previously-matched blocks (1..N-1). Processing out of order produces incorrect global unit assignments.
 
 This constraint is enforced at two levels:
 
-1. **`key_source` gate**: Only yields the session with the earliest unprocessed `block_start` per insertion. Under `populate(reserve_jobs=True)`, a worker that finishes the earliest session causes the next `key_source` evaluation to advance to the next block. Workers processing different insertions can run in parallel; within an insertion, processing is serialized.
+1. **`key_source` gate**: Only yields the block with the earliest unprocessed `block_start` per insertion. Under `populate(reserve_jobs=True)`, a worker that finishes the earliest block causes the next `key_source` evaluation to advance to the next block. Workers processing different insertions can run in parallel; within an insertion, processing is serialized.
 
-2. **`make()` guard**: Before processing, verifies that no earlier eligible session (by `block_start`) for the same insertion remains unprocessed. This is a defense-in-depth check that catches direct `make(key)` calls bypassing `key_source`, or hypothetical bugs in the key_source logic.
+2. **`make()` guard**: Before processing, verifies that no earlier eligible block (by `block_start`) for the same insertion remains unprocessed. This is a defense-in-depth check that catches direct `make(key)` calls bypassing `key_source`, or hypothetical bugs in the key_source logic.
 
 ```python
 # key_source: only the earliest unprocessed block per insertion
@@ -67,10 +67,10 @@ return candidates * next_per_insertion & "block_start = next_start"
 earlier_eligible = eligible & insertion_key & f'block_start < "{key["block_start"]}"'
 unprocessed_earlier = earlier_eligible - self
 if unprocessed_earlier:
-    raise ValueError("Temporal ordering violation: earlier sessions not yet processed.")
+    raise ValueError("Temporal ordering violation: earlier blocks not yet processed.")
 ```
 
-**Interaction with `reserve_jobs=True`**: When Worker A reserves the earliest session for insertion I1, Worker B's `key_source` also returns that same session (it's not yet in `self`). But the job reservation system prevents B from reserving the already-reserved key. With no other candidates for I1, Worker B idles or processes a different insertion. When A finishes, the next `populate()` cycle advances to the next block.
+**Interaction with `reserve_jobs=True`**: When Worker A reserves the earliest block for insertion I1, Worker B's `key_source` also returns that same block (it's not yet in `self`). But the job reservation system prevents B from reserving the already-reserved key. With no other candidates for I1, Worker B idles or processes a different insertion. When A finishes, the next `populate()` cycle advances to the next block.
 
 ---
 
@@ -85,7 +85,7 @@ UnitMatchingMethod (Lookup)
     matching_method_description: varchar(1000)
 
 UnitMatching (Computed)
-    -> SyncedSpikes                         # inherits full session key
+    -> SyncedSpikes                         # inherits full block key
     ---
     -> UnitMatchingMethod                   # non-PK: which method was used
     execution_time: datetime
@@ -112,7 +112,7 @@ GlobalUnit (Manual)
     -> ephys.ProbeInsertion                 # experiment_name, subject, insertion_number
     global_unit: int                     # unique ID within this insertion
     ---
-    -> ephys.ProbeType.Electrode      # peak electrode (denormalized, updated each session)
+    -> ephys.ProbeType.Electrode      # peak electrode (denormalized, updated each block)
     global_unit_comment='': varchar(1000)
 ```
 
@@ -133,13 +133,13 @@ erDiagram
 
 ### Design Notes
 
-- **`UnitMatchingMethod` as non-PK FK**: Only one matching result per session. The method is recorded for provenance but does not multiply the key space. This means one canonical set of global units per insertion — no parallel method comparison. This is a deliberate simplification; if method comparison becomes needed, it can be added later by promoting the FK back to PK.
+- **`UnitMatchingMethod` as non-PK FK**: Only one matching result per block. The method is recorded for provenance but does not multiply the key space. This means one canonical set of global units per insertion — no parallel method comparison. This is a deliberate simplification; if method comparison becomes needed, it can be added later by promoting the FK back to PK.
 
-- **`GlobalUnit` is Manual with denormalized electrode**: Populated programmatically by `UnitMatching.make()`, not by DataJoint's `populate()` machinery. This means it cannot be auto-cleared. Orphaned entries (those with no remaining `Unit` references) must be cleaned up explicitly during re-processing. The peak `electrode` is denormalized from `SortedSpikes.Unit` and stored directly on `GlobalUnit`. It is updated each time a new session is matched (latest session = best estimate of the unit's electrode position). This enables a clean unit roster query — `GlobalUnit & insertion_key` returns one row per unit with its electrode, no joins required.
+- **`GlobalUnit` is Manual with denormalized electrode**: Populated programmatically by `UnitMatching.make()`, not by DataJoint's `populate()` machinery. This means it cannot be auto-cleared. Orphaned entries (those with no remaining `Unit` references) must be cleaned up explicitly during re-processing. The peak `electrode` is denormalized from `SortedSpikes.Unit` and stored directly on `GlobalUnit`. It is updated each time a new block is matched (latest block = best estimate of the unit's electrode position). This enables a clean unit roster query — `GlobalUnit & insertion_key` returns one row per unit with its electrode, no joins required.
 
-- **`unique index` on `Spikes`**: The Part table PK includes the master's session key, so the same `(global_unit, chunk_start)` from different sessions would be valid at the PK level. The unique index on `(experiment_name, subject, insertion_number, global_unit, chunk_start)` provides a schema-level guarantee that only one session can own a given (insertion, unit, chunk) pair. The index is scoped per-insertion because `global_unit` IDs are only unique within an insertion — two insertions for the same subject can both have `global_unit=1`.
+- **`unique index` on `Spikes`**: The Part table PK includes the master's block key, so the same `(global_unit, chunk_start)` from different blocks would be valid at the PK level. The unique index on `(experiment_name, subject, insertion_number, global_unit, chunk_start)` provides a schema-level guarantee that only one block can own a given (insertion, unit, chunk) pair. The index is scoped per-insertion because `global_unit` IDs are only unique within an insertion — two insertions for the same subject can both have `global_unit=1`.
 
-- **`UnitMatching.Unit` references `SortedSpikes.Unit` via formal FK**: This enforces referential integrity (can't match a non-existent unit). Since `UnitMatching` sits downstream of `SortedSpikes` in the pipeline, and curation cleanup deletes `UnitMatching` before `SortedSpikes`, cascade ordering is correct.
+- **`UnitMatching.Unit` references `SortedSpikes.Unit` via formal FK**: This enforces referential integrity (cannot match a non-existent unit). Since `UnitMatching` sits downstream of `SortedSpikes` in the pipeline, and curation cleanup deletes `UnitMatching` before `SortedSpikes`, cascade ordering is correct.
 
 ---
 
@@ -147,31 +147,31 @@ erDiagram
 
 ### Matching Method: `spike_time_overlap`
 
-The current (and only) matching method uses SpikeInterface's `compare_two_sorters()` to identify corresponding units between sessions based on spike time coincidence in the overlap window.
+The current (and only) matching method uses SpikeInterface's `compare_two_sorters()` to identify corresponding units between ephys blocks based on spike time coincidence in the overlap window.
 
 #### Steps
 
-1. **Load this session's synced spike times** from `SyncedSpikes.Unit`. Concatenate across chunks per unit. Convert `datetime64[ns]` to epoch seconds for the overlap comparison and SpikeInterface compatibility.
+1. **Load this block's synced spike times** from `SyncedSpikes.Unit`. Concatenate across chunks per unit. Convert `datetime64[ns]` to epoch seconds for the overlap comparison and SpikeInterface compatibility.
 
-2. **Find overlapping previous sessions**: Query all previously-completed `UnitMatching` entries for the same `(experiment_name, subject, insertion_number)`. Filter to those whose `(block_start, block_end)` overlaps with this session's time range.
+2. **Find overlapping previous blocks**: Query all previously-completed `UnitMatching` entries for the same `(experiment_name, subject, insertion_number)`. Filter to those whose `(block_start, block_end)` overlaps with this block's time range.
 
-3. **For each overlapping previous session**:
-   a. Load the previous session's synced spike times (same format).
+3. **For each overlapping previous block**:
+   a. Load the previous block's synced spike times (same format).
    b. Compute the overlap window: `overlap_start = max(this.block_start, prev.block_start)`, `overlap_end = min(this.block_end, prev.block_end)`.
-   c. Restrict both sessions' spike times to the overlap window, converting to relative times (seconds from overlap start).
+   c. Restrict both blocks' spike times to the overlap window, converting to relative times (seconds from overlap start).
    d. Convert to sample indices at 30 kHz and build `NumpySorting` objects.
    e. Run `compare_two_sorters(delta_time=0.4)` (0.4 ms coincidence window).
-   f. Extract matched pairs. For each match, look up the previous session's unit's `global_unit` assignment (via `UnitMatching.Unit`). Assign this session's unit to the same global unit.
+   f. Extract matched pairs. For each match, look up the previous block's unit's `global_unit` assignment (via `UnitMatching.Unit`). Assign this block's unit to the same global unit.
 
 4. **Assign new global units** for unmatched units: find the current maximum `global_unit` ID for this insertion, increment sequentially.
 
 5. **Insert `GlobalUnit`** entries for newly created global units, with peak electrode from `SortedSpikes.Unit`.
 
-6. **Update electrode** on existing `GlobalUnit` entries for matched units (overwrite with this session's peak electrode — latest session = best estimate).
+6. **Update electrode** on existing `GlobalUnit` entries for matched units (overwrite with this block's peak electrode — latest block = best estimate).
 
 7. **Insert `UnitMatching`** master entry with execution metadata. (Master must exist before Part inserts.)
 
-8. **Insert `UnitMatching.Unit`** entries linking each session unit to its global unit.
+8. **Insert `UnitMatching.Unit`** entries linking each block's unit to its global unit.
 
 9. **Insert `UnitMatching.Spikes`** entries following the ownership convention (see next section).
 
@@ -188,25 +188,25 @@ The current (and only) matching method uses SpikeInterface's `compare_two_sorter
 
 ### Problem
 
-When two ephys blocks overlap in time, the same `EphysChunk` (1-hour raw data segment) is sorted independently by both blocks. For a global unit present in both blocks, `SyncedSpikes.Unit` contains spike times from both sessions for the overlapping chunks. Without a convention, `Spikes` would contain duplicate rows for the same `(global_unit, chunk)` from different sessions.
+When two ephys blocks overlap in time, the same `EphysChunk` (1-hour raw data segment) is sorted independently by both blocks. For a global unit present in both blocks, `SyncedSpikes.Unit` contains spike times from both blocks for the overlapping chunks. Without a convention, `Spikes` would contain duplicate rows for the same `(global_unit, chunk)` from different blocks.
 
 Duplicates cause incorrect downstream analysis: inflated spike counts, artificial short ISIs, and wrong firing rate estimates.
 
 ### Convention: Earlier Session Owns
 
-**Rule: for each `(global_unit, chunk)` pair, the first session (in processing order) to write a `Spikes` row wins. Later sessions skip that pair.**
+**Rule: for each `(global_unit, chunk)` pair, the first block (in processing order) to write a `Spikes` row wins. Later blocks skip that pair.**
 
-Since sessions are processed in temporal order, "first to process" = "earlier session" for chunks in the overlap region.
+Since blocks are processed in temporal order, "first to process" = "earlier block" for chunks in the overlap region.
 
 Implementation in `UnitMatching.make()`:
 
 ```python
-for uu_id in this_session_global_units:
-    for chunk_key in this_session_chunks:
-        # Check if ANY session already wrote this (uu, chunk)
-        if self.Spikes & {"global_unit": uu_id, "chunk_start": chunk_key["chunk_start"]}:
-            continue  # earlier session owns it
-        # Get synced spikes for this session's unit in this chunk
+for gu_id in this_block_global_units:
+    for chunk_key in this_block_chunks:
+        # Check if ANY block already wrote this (global_unit, chunk)
+        if self.Spikes & {"global_unit": gu_id, "chunk_start": chunk_key["chunk_start"]}:
+            continue  # earlier block owns it
+        # Get synced spikes for this block's unit in this chunk
         # ... insert if spikes exist
 ```
 
@@ -214,16 +214,16 @@ for uu_id in this_session_global_units:
 
 | Scenario | Behavior |
 |----------|----------|
-| Non-overlapping chunks | Each chunk covered by exactly one session. No ambiguity. |
-| Overlapping chunks, same global unit in both sessions | Earlier session writes the row. Later session skips. |
-| New global unit in later session (not matched to prior) | No prior data exists for this unit. Later session writes all its chunks, including overlap ones. |
-| Unit has no spikes in a chunk (silent period) | No row written. A later session that does have spikes for this unit in this chunk will write it. |
+| Non-overlapping chunks | Each chunk covered by exactly one block. No ambiguity. |
+| Overlapping chunks, same global unit in both blocks | Earlier block writes the row. Later block skips. |
+| New global unit in later block (not matched to prior) | No prior data exists for this unit. Later block writes all its chunks, including overlap ones. |
+| Unit has no spikes in a chunk (silent period) | No row written. A later block that does have spikes for this unit in this chunk will write it. |
 
 ### Invariant
 
-After all sessions are processed, each `(global_unit, chunk_start)` pair appears in **at most one** `UnitMatching.Spikes` row across all sessions. This invariant is enforced at two levels:
+After all blocks are processed, each `(global_unit, chunk_start)` pair appears in **at most one** `UnitMatching.Spikes` row across all blocks. This invariant is enforced at two levels:
 
-1. **Schema-level**: A `unique index (experiment_name, subject, insertion_number, global_unit, chunk_start)` on `Spikes` guarantees that the database rejects any duplicate per-insertion `(global_unit, chunk_start)` insertion, regardless of which session attempts it. The index is scoped per-insertion because `global_unit` IDs are only unique within an insertion. A later session trying to write an already-owned pair will raise an `IntegrityError`.
+1. **Schema-level**: A `unique index (experiment_name, subject, insertion_number, global_unit, chunk_start)` on `Spikes` guarantees that the database rejects any duplicate per-insertion `(global_unit, chunk_start)` insertion, regardless of which block attempts it. The index is scoped per-insertion because `global_unit` IDs are only unique within an insertion. A later block trying to write an already-owned pair will raise an `IntegrityError`.
 
 2. **Code-level**: The `make()` method checks for existing rows before inserting, skipping already-owned pairs. This prevents the `IntegrityError` from ever being raised during normal operation and provides clear logging of skipped chunks.
 
@@ -252,14 +252,14 @@ GlobalUnit (Manual)                    ← NEW (populated by UnitMatching.make()
 
 ### Curation Gate
 
-`UnitMatching.key_source` restricts to sessions that have `ApplyOfficialCuration`. This means:
-- Raw (uncurated) sessions are never matched
+`UnitMatching.key_source` restricts to blocks that have `ApplyOfficialCuration`. This means:
+- Raw (uncurated) blocks are never matched
 - The matching uses curated spike sorting results
 - Changing a curation requires re-running the matching (see next section)
 
 ### Worker Integration
 
-`UnitMatching` is a `Computed` table and can be registered with a DataJoint worker for automated processing. The `key_source` gate (see [Critical Constraint: Temporal Ordering](#critical-constraint-temporal-ordering)) ensures that `populate(reserve_jobs=True)` respects temporal ordering even under parallel execution — workers processing different insertions run in parallel, while sessions within an insertion are serialized automatically.
+`UnitMatching` is a `Computed` table and can be registered with a DataJoint worker for automated processing. The `key_source` gate (see [Critical Constraint: Temporal Ordering](#critical-constraint-temporal-ordering)) ensures that `populate(reserve_jobs=True)` respects temporal ordering even under parallel execution — workers processing different insertions run in parallel, while blocks within an insertion are serialized automatically.
 
 ---
 
@@ -267,14 +267,14 @@ GlobalUnit (Manual)                    ← NEW (populated by UnitMatching.make()
 
 ### Scenario: Re-curation of a Session
 
-When a session's curation is changed (via `restore_raw_sorting()` → new curation → `ApplyOfficialCuration`):
+When a block's curation is changed (via `restore_raw_sorting()` → new curation → `ApplyOfficialCuration`):
 
-1. `restore_raw_sorting()` deletes `UnitMatching` for the session → cascades to `Unit` and `Spikes` Part rows for that session.
-2. Orphaned `GlobalUnit` entries (those with no remaining `Unit` references from any session) are explicitly deleted.
+1. `restore_raw_sorting()` deletes `UnitMatching` for the block → cascades to `Unit` and `Spikes` Part rows for that block.
+2. Orphaned `GlobalUnit` entries (those with no remaining `Unit` references from any block) are explicitly deleted.
 3. `SortedSpikes` and downstream tables are deleted and re-populated with the new curation.
-4. `UnitMatching.populate()` re-runs for the session, re-matching and re-writing `Spikes`.
+4. `UnitMatching.populate()` re-runs for the block, re-matching and re-writing `Spikes`.
 
-**Important**: Later sessions' `UnitMatching` entries are NOT automatically invalidated. If the re-curation changes which units exist or how they match, downstream sessions may have stale global unit assignments. In this case, the user should re-run matching for affected downstream sessions as well.
+**Important**: Later blocks' `UnitMatching` entries are NOT automatically invalidated. If the re-curation changes which units exist or how they match, downstream blocks may have stale global unit assignments. In this case, the user should re-run matching for affected downstream blocks as well.
 
 ### Cascade Behavior
 
@@ -292,7 +292,7 @@ Delete SortedSpikes.Unit
 
 ```
 Step 1: Delete OfficialCuration (cascades to ApplyOfficialCuration)
-Step 2: Delete UnitMatching for this session (cascades to Unit + Spikes)
+Step 2: Delete UnitMatching for this block (cascades to Unit + Spikes)
 Step 3: Delete orphaned GlobalUnit entries
 Step 4: Delete SortedSpikes (cascades to Waveform, SortingQuality, SyncedSpikes)
 ```
@@ -324,7 +324,7 @@ Returns `(experiment_name, subject, insertion_number, global_unit, probe_type, e
 )
 ```
 
-Returns one row per chunk (guaranteed by unique index). Session key fields (block_start, block_end, etc.) exist in the PK but are not fetched.
+Returns one row per chunk (guaranteed by unique index). Block key fields (block_start, block_end, etc.) exist in the PK but are not fetched.
 
 ### Spike times filtered by chunk range (for alignment with other streams)
 
@@ -349,18 +349,18 @@ Returns one row per chunk (guaranteed by unique index). Session key fields (bloc
 )
 ```
 
-### Which sessions contributed to a global unit?
+### Which blocks contributed to a global unit?
 
 ```python
 UnitMatching.Unit & insertion_key & {"global_unit": 5}
 ```
 
-Returns one row per session where the unit was matched, with the session-specific `unit` ID and match confidence.
+Returns one row per block where the unit was matched, with the block-specific `unit` ID and match confidence.
 
-### Global unit assignments for a specific session
+### Global unit assignments for a specific block
 
 ```python
-UnitMatching.Unit & session_key
+UnitMatching.Unit & block_key
 ```
 
 ### Raw (non-deduplicated) spike times via join
@@ -369,7 +369,7 @@ UnitMatching.Unit & session_key
 SyncedSpikes.Unit * UnitMatching.Unit & insertion_key & {"global_unit": 5}
 ```
 
-Returns per-session per-chunk spike times with global unit labels. Overlap chunks appear with multiple rows (one per session). Use `UnitMatching.Spikes` for the deduplicated version.
+Returns per-block per-chunk spike times with global unit labels. Overlap chunks appear with multiple rows (one per block). Use `UnitMatching.Spikes` for the deduplicated version.
 
 ---
 
@@ -377,15 +377,15 @@ Returns per-session per-chunk spike times with global unit labels. Overlap chunk
 
 ### Why `UnitMatchingMethod` is a non-PK FK
 
-**Decision**: One matching result per session. The method is recorded but does not partition the data.
+**Decision**: One matching result per block. The method is recorded but does not partition the data.
 
-**Rationale**: Making it a PK would mean every downstream query must carry `matching_method`, and global units would be scoped per-method (allowing parallel sets). In practice, the team settles on one matching method and uses it consistently. The simpler design avoids combinatorial complexity. If method comparison becomes necessary, the FK can be promoted to PK.
+**Rationale**: Making it a PK would mean every downstream query must carry `matching_method`, and global units would be scoped per-method (allowing parallel sets). In practice, the team uses one matching method consistently. The simpler design avoids combinatorial complexity. If method comparison becomes necessary, the FK can be promoted to PK.
 
 ### Why `Unit` is a Part of `UnitMatching` (not `GlobalUnit`)
 
 **Decision**: `UnitMatching.Unit` instead of `GlobalUnit.Matched`.
 
-**Rationale**: Part table lifecycle should be governed by the master. `Unit` rows are created and destroyed with their session's `UnitMatching` entry. Placing them under `GlobalUnit` (which has a different lifecycle — it persists across sessions) creates cascade problems: deleting `SortedSpikes.Unit` is blocked by `GlobalUnit.Matched`'s FK, requiring `force=True` hacks. Under `UnitMatching`, the cascade is clean: delete `UnitMatching` → cascades to `Unit` and `Spikes`.
+**Rationale**: Part table lifecycle should be governed by the master. `Unit` rows are created and destroyed with their block's `UnitMatching` entry. Placing them under `GlobalUnit` (which has a different lifecycle — it persists across blocks) creates cascade problems: deleting `SortedSpikes.Unit` is blocked by `GlobalUnit.Matched`'s FK, requiring `force=True` hacks. Under `UnitMatching`, the cascade is clean: delete `UnitMatching` → cascades to `Unit` and `Spikes`.
 
 ### Why `Spikes` is a Part of `UnitMatching` (not standalone)
 
@@ -394,12 +394,12 @@ Returns per-session per-chunk spike times with global unit labels. Overlap chunk
 **Alternatives considered**:
 - **Standalone Computed keyed on `(GlobalUnit, EphysChunk)`**: Clean one-row-per-pair semantics, but the cartesian `key_source` (all units x all chunks) is prohibitively large. A restricted `key_source` is complex to express correctly.
 - **No table at all** (use `SyncedSpikes.Unit * UnitMatching.Unit` join): Simplest schema, but overlap chunks produce duplicate rows. Every downstream analysis must implement deduplication.
-- **Part of `UnitMatching`** with ownership convention: Avoids cartesian explosion (scoped to session's chunks). Ownership convention guarantees at most one row per (unit, chunk), enforced by a `unique index (experiment_name, subject, insertion_number, global_unit, chunk_start)` at the schema level. Lifecycle managed by cascade.
+- **Part of `UnitMatching`** with ownership convention: Avoids cartesian explosion (scoped to block's chunks). Ownership convention guarantees at most one row per (unit, chunk), enforced by a `unique index (experiment_name, subject, insertion_number, global_unit, chunk_start)` at the schema level. Lifecycle managed by cascade.
 
-The Part table approach was chosen because it provides pre-materialized, deduplicated spike times (the primary analysis output) while keeping the scope naturally bounded per session.
+The Part table approach was chosen because it provides pre-materialized, deduplicated spike times (the primary analysis output) while keeping the scope naturally bounded per block.
 
 ### Why `GlobalUnit` is Manual (not Computed)
 
 **Decision**: `GlobalUnit` is a Manual table populated programmatically by `UnitMatching.make()`.
 
-**Rationale**: Global units are created incrementally as sessions are processed. They persist across sessions — a global unit created by session 1 is referenced by sessions 2, 3, etc. A Computed table would need a well-defined `key_source` that doesn't exist (you can't predict which global units will be needed before running the matching). The Manual tier correctly reflects that these entries are managed by application logic, not by DataJoint's populate machinery.
+**Rationale**: Global units are created incrementally as blocks are processed. They persist across blocks — a global unit created by block 1 is referenced by blocks 2, 3, etc. A Computed table would need a well-defined `key_source` that doesn't exist (you can't predict which global units will be needed before running the matching). The Manual tier correctly reflects that these entries are managed by application logic, not by DataJoint's populate machinery.

--- a/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
+++ b/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
@@ -106,7 +106,7 @@ UnitMatching (Computed)
         ---
         spike_times: longblob               # float64 epoch seconds (UTC), HARP-synced
         spike_count: int
-        unique index (universal_unit, chunk_start)  # schema-enforced: one row per (unit, chunk)
+        unique index (experiment_name, subject, insertion_number, universal_unit, chunk_start)  # schema-enforced: one row per (insertion, unit, chunk)
 
 UniversalUnit (Manual)
     -> ephys.ProbeInsertion                 # experiment_name, subject, insertion_number
@@ -135,7 +135,7 @@ erDiagram
 
 - **`UniversalUnit` is Manual**: Populated programmatically by `UnitMatching.make()`, not by DataJoint's `populate()` machinery. This means it cannot be auto-cleared. Orphaned entries (those with no remaining `Matched` references) must be cleaned up explicitly during re-processing.
 
-- **`unique index` on `ChunkedSpikeTimes`**: The Part table PK includes the master's session key, so the same `(universal_unit, chunk_start)` from different sessions would be valid at the PK level. The unique index on `(universal_unit, chunk_start)` provides a schema-level guarantee that only one session can own a given (unit, chunk) pair, making the ownership convention a hard constraint rather than a soft convention.
+- **`unique index` on `ChunkedSpikeTimes`**: The Part table PK includes the master's session key, so the same `(universal_unit, chunk_start)` from different sessions would be valid at the PK level. The unique index on `(experiment_name, subject, insertion_number, universal_unit, chunk_start)` provides a schema-level guarantee that only one session can own a given (insertion, unit, chunk) pair. The index is scoped per-insertion because `universal_unit` IDs are only unique within an insertion — two insertions for the same subject can both have `universal_unit=1`.
 
 - **`UnitMatching.Matched` references `SortedSpikes.Unit` via formal FK**: This enforces referential integrity (can't match a non-existent unit). Since `UnitMatching` sits downstream of `SortedSpikes` in the pipeline, and curation cleanup deletes `UnitMatching` before `SortedSpikes`, cascade ordering is correct.
 
@@ -219,7 +219,7 @@ for uu_id in this_session_universal_units:
 
 After all sessions are processed, each `(universal_unit, chunk_start)` pair appears in **at most one** `UnitMatching.ChunkedSpikeTimes` row across all sessions. This invariant is enforced at two levels:
 
-1. **Schema-level**: A `unique index (universal_unit, chunk_start)` on `ChunkedSpikeTimes` guarantees that the database rejects any duplicate `(universal_unit, chunk_start)` insertion, regardless of which session attempts it. A later session trying to write an already-owned pair will raise an `IntegrityError`.
+1. **Schema-level**: A `unique index (experiment_name, subject, insertion_number, universal_unit, chunk_start)` on `ChunkedSpikeTimes` guarantees that the database rejects any duplicate per-insertion `(universal_unit, chunk_start)` insertion, regardless of which session attempts it. The index is scoped per-insertion because `universal_unit` IDs are only unique within an insertion. A later session trying to write an already-owned pair will raise an `IntegrityError`.
 
 2. **Code-level**: The `make()` method checks for existing rows before inserting, skipping already-owned pairs. This prevents the `IntegrityError` from ever being raised during normal operation and provides clear logging of skipped chunks.
 
@@ -358,7 +358,7 @@ UniversalUnit & {"experiment_name": "...", "subject": "...", "insertion_number":
 **Alternatives considered**:
 - **Standalone Computed keyed on `(UniversalUnit, EphysChunk)`**: Clean one-row-per-pair semantics, but the cartesian `key_source` (all units x all chunks) is prohibitively large. A restricted `key_source` is complex to express correctly.
 - **No table at all** (use `SyncedSpikes.Unit * UnitMatching.Matched` join): Simplest schema, but overlap chunks produce duplicate rows. Every downstream analysis must implement deduplication.
-- **Part of `UnitMatching`** with ownership convention: Avoids cartesian explosion (scoped to session's chunks). Ownership convention guarantees at most one row per (unit, chunk), enforced by a `unique index (universal_unit, chunk_start)` at the schema level. Lifecycle managed by cascade.
+- **Part of `UnitMatching`** with ownership convention: Avoids cartesian explosion (scoped to session's chunks). Ownership convention guarantees at most one row per (unit, chunk), enforced by a `unique index (experiment_name, subject, insertion_number, universal_unit, chunk_start)` at the schema level. Lifecycle managed by cascade.
 
 The Part table approach was chosen because it provides pre-materialized, deduplicated spike times (the primary analysis output) while keeping the scope naturally bounded per session.
 

--- a/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
+++ b/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
@@ -16,7 +16,7 @@
 
 ### Purpose
 
-Long-running AEON experiments record neural activity across multiple consecutive ephys blocks (sessions), each independently spike-sorted. The same neuron appears as a different `unit` ID in each session's sorting results. The unit matching system solves this by assigning a persistent **universal unit** identity to neurons across sessions, enabling longitudinal analysis of single-neuron activity over days or weeks.
+Long-running AEON experiments record neural activity across multiple consecutive ephys blocks (sessions), each independently spike-sorted. The same neuron appears as a different `unit` ID in each session's sorting results. The unit matching system solves this by assigning a persistent **global unit** identity to neurons across sessions, enabling longitudinal analysis of single-neuron activity over days or weeks.
 
 The system works by exploiting temporal overlap between consecutive ephys blocks: when two blocks share a time window, the same neurons produce spikes in both blocks' sorted data. By comparing spike times in the overlap region, the system identifies which units across sessions correspond to the same neuron.
 
@@ -34,17 +34,17 @@ Specifically, `UnitMatching.key_source` requires that `ApplyOfficialCuration` ex
 
 ### Key Concepts
 
-A **universal unit** is a persistent neuron identity scoped to a single probe insertion (i.e., one physical probe in one subject). Universal unit IDs are integers starting at 1, unique within a `(experiment_name, subject, insertion_number)` scope.
+A **global unit** is a persistent neuron identity scoped to a single probe insertion (i.e., one physical probe in one subject). Global unit IDs are integers starting at 1, unique within a `(experiment_name, subject, insertion_number)` scope.
 
-A **matched unit** links a session-specific `SortedSpikes.Unit` to its assigned universal unit. Each session unit maps to exactly one universal unit. A universal unit may be matched to units from multiple sessions (that's the whole point).
+A **matched unit** links a session-specific `SortedSpikes.Unit` to its assigned global unit. Each session unit maps to exactly one global unit. A global unit may be matched to units from multiple sessions (that's the whole point).
 
 **Temporal overlap** between consecutive ephys blocks is the mechanism that enables matching. The overlap region contains spikes from the same neurons captured by both blocks' independent sorting runs. The matching algorithm compares spike times in this overlap window to identify corresponding units.
 
-The **ownership convention** determines which session "owns" the spike data for a given (universal_unit, chunk) pair when multiple sessions cover the same chunk. This prevents duplicate rows in `Spikes`.
+The **ownership convention** determines which session "owns" the spike data for a given (global_unit, chunk) pair when multiple sessions cover the same chunk. This prevents duplicate rows in `Spikes`.
 
 ### Critical Constraint: Temporal Ordering
 
-Sessions **must** be processed in temporal order (by `block_start`). Session N compares its units against previously-matched sessions (1..N-1). Processing out of order produces incorrect universal unit assignments.
+Sessions **must** be processed in temporal order (by `block_start`). Session N compares its units against previously-matched sessions (1..N-1). Processing out of order produces incorrect global unit assignments.
 
 This constraint is enforced at two levels:
 
@@ -95,25 +95,25 @@ UnitMatching (Computed)
         -> master
         -> SortedSpikes.Unit                # adds `unit` to PK
         ---
-        -> UniversalUnit                    # universal_unit as dependent FK
-        -> ephys.ElectrodeConfig.Electrode  # peak electrode (denormalized from SortedSpikes.Unit)
+        -> GlobalUnit                    # global_unit as dependent FK
         match_confidence=null: float
         match_comment='': varchar(1000)
 
     UnitMatching.Spikes (Part)
         -> master
-        -> UniversalUnit                    # adds universal_unit to PK
+        -> GlobalUnit                    # adds global_unit to PK
         -> ephys.EphysChunk                 # adds chunk_start to PK
         ---
         spike_times: longblob               # datetime64[ns] (UTC), HARP-synced — same format as SyncedSpikes.Unit
         spike_count: int
-        unique index (experiment_name, subject, insertion_number, universal_unit, chunk_start)  # schema-enforced: one row per (insertion, unit, chunk)
+        unique index (experiment_name, subject, insertion_number, global_unit, chunk_start)  # schema-enforced: one row per (insertion, unit, chunk)
 
-UniversalUnit (Manual)
+GlobalUnit (Manual)
     -> ephys.ProbeInsertion                 # experiment_name, subject, insertion_number
-    universal_unit: int                     # unique ID within this insertion
+    global_unit: int                     # unique ID within this insertion
     ---
-    universal_unit_comment='': varchar(1000)
+    -> ephys.ProbeType.Electrode      # peak electrode (denormalized, updated each session)
+    global_unit_comment='': varchar(1000)
 ```
 
 ### Entity Relationship Diagram
@@ -124,21 +124,22 @@ erDiagram
     UnitMatching ||--o{ "UnitMatching.Unit" : "part"
     UnitMatching ||--o{ "UnitMatching.Spikes" : "part"
     "SortedSpikes.Unit" ||--o| "UnitMatching.Unit" : "FK (unit)"
-    UniversalUnit ||--o{ "UnitMatching.Unit" : "FK (universal_unit)"
-    UniversalUnit ||--o{ "UnitMatching.Spikes" : "FK (universal_unit)"
+    GlobalUnit ||--o{ "UnitMatching.Unit" : "FK (global_unit)"
+    GlobalUnit ||--o{ "UnitMatching.Spikes" : "FK (global_unit)"
     "ephys.EphysChunk" ||--o{ "UnitMatching.Spikes" : "FK (chunk_start)"
-    "ephys.ProbeInsertion" ||--|| UniversalUnit : "scopes"
+    "ephys.ProbeType.Electrode" ||--o{ GlobalUnit : "FK (electrode)"
+    "ephys.ProbeInsertion" ||--|| GlobalUnit : "scopes"
 ```
 
 ### Design Notes
 
-- **`UnitMatchingMethod` as non-PK FK**: Only one matching result per session. The method is recorded for provenance but does not multiply the key space. This means one canonical set of universal units per insertion — no parallel method comparison. This is a deliberate simplification; if method comparison becomes needed, it can be added later by promoting the FK back to PK.
+- **`UnitMatchingMethod` as non-PK FK**: Only one matching result per session. The method is recorded for provenance but does not multiply the key space. This means one canonical set of global units per insertion — no parallel method comparison. This is a deliberate simplification; if method comparison becomes needed, it can be added later by promoting the FK back to PK.
 
-- **`UniversalUnit` is Manual**: Populated programmatically by `UnitMatching.make()`, not by DataJoint's `populate()` machinery. This means it cannot be auto-cleared. Orphaned entries (those with no remaining `Unit` references) must be cleaned up explicitly during re-processing.
+- **`GlobalUnit` is Manual with denormalized electrode**: Populated programmatically by `UnitMatching.make()`, not by DataJoint's `populate()` machinery. This means it cannot be auto-cleared. Orphaned entries (those with no remaining `Unit` references) must be cleaned up explicitly during re-processing. The peak `electrode` is denormalized from `SortedSpikes.Unit` and stored directly on `GlobalUnit`. It is updated each time a new session is matched (latest session = best estimate of the unit's electrode position). This enables a clean unit roster query — `GlobalUnit & insertion_key` returns one row per unit with its electrode, no joins required.
 
-- **`unique index` on `Spikes`**: The Part table PK includes the master's session key, so the same `(universal_unit, chunk_start)` from different sessions would be valid at the PK level. The unique index on `(experiment_name, subject, insertion_number, universal_unit, chunk_start)` provides a schema-level guarantee that only one session can own a given (insertion, unit, chunk) pair. The index is scoped per-insertion because `universal_unit` IDs are only unique within an insertion — two insertions for the same subject can both have `universal_unit=1`.
+- **`unique index` on `Spikes`**: The Part table PK includes the master's session key, so the same `(global_unit, chunk_start)` from different sessions would be valid at the PK level. The unique index on `(experiment_name, subject, insertion_number, global_unit, chunk_start)` provides a schema-level guarantee that only one session can own a given (insertion, unit, chunk) pair. The index is scoped per-insertion because `global_unit` IDs are only unique within an insertion — two insertions for the same subject can both have `global_unit=1`.
 
-- **`UnitMatching.Unit` references `SortedSpikes.Unit` via formal FK**: This enforces referential integrity (can't match a non-existent unit). Since `UnitMatching` sits downstream of `SortedSpikes` in the pipeline, and curation cleanup deletes `UnitMatching` before `SortedSpikes`, cascade ordering is correct. The peak `electrode` is denormalized from `SortedSpikes.Unit` for query convenience — users can get unit identity, universal unit assignment, and electrode location without joining back through the sorting chain.
+- **`UnitMatching.Unit` references `SortedSpikes.Unit` via formal FK**: This enforces referential integrity (can't match a non-existent unit). Since `UnitMatching` sits downstream of `SortedSpikes` in the pipeline, and curation cleanup deletes `UnitMatching` before `SortedSpikes`, cascade ordering is correct.
 
 ---
 
@@ -160,17 +161,19 @@ The current (and only) matching method uses SpikeInterface's `compare_two_sorter
    c. Restrict both sessions' spike times to the overlap window, converting to relative times (seconds from overlap start).
    d. Convert to sample indices at 30 kHz and build `NumpySorting` objects.
    e. Run `compare_two_sorters(delta_time=0.4)` (0.4 ms coincidence window).
-   f. Extract matched pairs. For each match, look up the previous session's unit's `universal_unit` assignment (via `UnitMatching.Unit`). Assign this session's unit to the same universal unit.
+   f. Extract matched pairs. For each match, look up the previous session's unit's `global_unit` assignment (via `UnitMatching.Unit`). Assign this session's unit to the same global unit.
 
-4. **Assign new universal units** for unmatched units: find the current maximum `universal_unit` ID for this insertion, increment sequentially.
+4. **Assign new global units** for unmatched units: find the current maximum `global_unit` ID for this insertion, increment sequentially.
 
-5. **Insert `UniversalUnit`** entries for newly created universal units.
+5. **Insert `GlobalUnit`** entries for newly created global units, with peak electrode from `SortedSpikes.Unit`.
 
-6. **Insert `UnitMatching.Unit`** entries linking each session unit to its universal unit.
+6. **Update electrode** on existing `GlobalUnit` entries for matched units (overwrite with this session's peak electrode — latest session = best estimate).
 
-7. **Insert `UnitMatching.Spikes`** entries following the ownership convention (see next section).
+7. **Insert `UnitMatching.Unit`** entries linking each session unit to its global unit.
 
-8. **Insert `UnitMatching`** master entry with execution metadata.
+8. **Insert `UnitMatching.Spikes`** entries following the ownership convention (see next section).
+
+9. **Insert `UnitMatching`** master entry with execution metadata.
 
 #### Parameters
 
@@ -185,23 +188,23 @@ The current (and only) matching method uses SpikeInterface's `compare_two_sorter
 
 ### Problem
 
-When two ephys blocks overlap in time, the same `EphysChunk` (1-hour raw data segment) is sorted independently by both blocks. For a universal unit present in both blocks, `SyncedSpikes.Unit` contains spike times from both sessions for the overlapping chunks. Without a convention, `Spikes` would contain duplicate rows for the same `(universal_unit, chunk)` from different sessions.
+When two ephys blocks overlap in time, the same `EphysChunk` (1-hour raw data segment) is sorted independently by both blocks. For a global unit present in both blocks, `SyncedSpikes.Unit` contains spike times from both sessions for the overlapping chunks. Without a convention, `Spikes` would contain duplicate rows for the same `(global_unit, chunk)` from different sessions.
 
 Duplicates cause incorrect downstream analysis: inflated spike counts, artificial short ISIs, and wrong firing rate estimates.
 
 ### Convention: Earlier Session Owns
 
-**Rule: for each `(universal_unit, chunk)` pair, the first session (in processing order) to write a `Spikes` row wins. Later sessions skip that pair.**
+**Rule: for each `(global_unit, chunk)` pair, the first session (in processing order) to write a `Spikes` row wins. Later sessions skip that pair.**
 
 Since sessions are processed in temporal order, "first to process" = "earlier session" for chunks in the overlap region.
 
 Implementation in `UnitMatching.make()`:
 
 ```python
-for uu_id in this_session_universal_units:
+for uu_id in this_session_global_units:
     for chunk_key in this_session_chunks:
         # Check if ANY session already wrote this (uu, chunk)
-        if self.Spikes & {"universal_unit": uu_id, "chunk_start": chunk_key["chunk_start"]}:
+        if self.Spikes & {"global_unit": uu_id, "chunk_start": chunk_key["chunk_start"]}:
             continue  # earlier session owns it
         # Get synced spikes for this session's unit in this chunk
         # ... insert if spikes exist
@@ -212,15 +215,15 @@ for uu_id in this_session_universal_units:
 | Scenario | Behavior |
 |----------|----------|
 | Non-overlapping chunks | Each chunk covered by exactly one session. No ambiguity. |
-| Overlapping chunks, same universal unit in both sessions | Earlier session writes the row. Later session skips. |
-| New universal unit in later session (not matched to prior) | No prior data exists for this unit. Later session writes all its chunks, including overlap ones. |
+| Overlapping chunks, same global unit in both sessions | Earlier session writes the row. Later session skips. |
+| New global unit in later session (not matched to prior) | No prior data exists for this unit. Later session writes all its chunks, including overlap ones. |
 | Unit has no spikes in a chunk (silent period) | No row written. A later session that does have spikes for this unit in this chunk will write it. |
 
 ### Invariant
 
-After all sessions are processed, each `(universal_unit, chunk_start)` pair appears in **at most one** `UnitMatching.Spikes` row across all sessions. This invariant is enforced at two levels:
+After all sessions are processed, each `(global_unit, chunk_start)` pair appears in **at most one** `UnitMatching.Spikes` row across all sessions. This invariant is enforced at two levels:
 
-1. **Schema-level**: A `unique index (experiment_name, subject, insertion_number, universal_unit, chunk_start)` on `Spikes` guarantees that the database rejects any duplicate per-insertion `(universal_unit, chunk_start)` insertion, regardless of which session attempts it. The index is scoped per-insertion because `universal_unit` IDs are only unique within an insertion. A later session trying to write an already-owned pair will raise an `IntegrityError`.
+1. **Schema-level**: A `unique index (experiment_name, subject, insertion_number, global_unit, chunk_start)` on `Spikes` guarantees that the database rejects any duplicate per-insertion `(global_unit, chunk_start)` insertion, regardless of which session attempts it. The index is scoped per-insertion because `global_unit` IDs are only unique within an insertion. A later session trying to write an already-owned pair will raise an `IntegrityError`.
 
 2. **Code-level**: The `make()` method checks for existing rows before inserting, skipping already-owned pairs. This prevents the `IntegrityError` from ever being raised during normal operation and provides clear logging of skipped chunks.
 
@@ -244,7 +247,7 @@ SortingTask (Manual)
               ├─ .Unit (Part)             ← NEW
               └─ .Spikes (Part)← NEW
 
-UniversalUnit (Manual)                    ← NEW (populated by UnitMatching.make())
+GlobalUnit (Manual)                    ← NEW (populated by UnitMatching.make())
 ```
 
 ### Curation Gate
@@ -267,11 +270,11 @@ UniversalUnit (Manual)                    ← NEW (populated by UnitMatching.mak
 When a session's curation is changed (via `restore_raw_sorting()` → new curation → `ApplyOfficialCuration`):
 
 1. `restore_raw_sorting()` deletes `UnitMatching` for the session → cascades to `Unit` and `Spikes` Part rows for that session.
-2. Orphaned `UniversalUnit` entries (those with no remaining `Unit` references from any session) are explicitly deleted.
+2. Orphaned `GlobalUnit` entries (those with no remaining `Unit` references from any session) are explicitly deleted.
 3. `SortedSpikes` and downstream tables are deleted and re-populated with the new curation.
 4. `UnitMatching.populate()` re-runs for the session, re-matching and re-writing `Spikes`.
 
-**Important**: Later sessions' `UnitMatching` entries are NOT automatically invalidated. If the re-curation changes which units exist or how they match, downstream sessions may have stale universal unit assignments. In this case, the user should re-run matching for affected downstream sessions as well.
+**Important**: Later sessions' `UnitMatching` entries are NOT automatically invalidated. If the re-curation changes which units exist or how they match, downstream sessions may have stale global unit assignments. In this case, the user should re-run matching for affected downstream sessions as well.
 
 ### Cascade Behavior
 
@@ -290,51 +293,83 @@ Delete SortedSpikes.Unit
 ```
 Step 1: Delete OfficialCuration (cascades to ApplyOfficialCuration)
 Step 2: Delete UnitMatching for this session (cascades to Unit + Spikes)
-Step 3: Delete orphaned UniversalUnit entries
+Step 3: Delete orphaned GlobalUnit entries
 Step 4: Delete SortedSpikes (cascades to Waveform, SortingQuality, SyncedSpikes)
 ```
 
-Note: Step 2 no longer requires `force=True` on Part tables (unlike the previous design where `UniversalUnit.Matched` was a Part of `UniversalUnit` but referenced `SortedSpikes.Unit`). With `Unit` as a Part of `UnitMatching`, deleting `UnitMatching` cleanly cascades.
+Note: Step 2 no longer requires `force=True` on Part tables (unlike the previous design where `GlobalUnit.Matched` was a Part of `GlobalUnit` but referenced `SortedSpikes.Unit`). With `Unit` as a Part of `UnitMatching`, deleting `UnitMatching` cleanly cascades.
 
 ---
 
 ## Query Patterns
 
-### Get all spikes for a universal unit across all time
+The primary query interface is designed around a natural workflow: start from an insertion, discover its units (with electrode), then access spike times filterable by chunk for alignment with other data streams.
+
+### Unit roster: all global units for an insertion (with electrode)
 
 ```python
-(UnitMatching.Spikes & {"universal_unit": 5}).fetch(
+insertion_key = {"experiment_name": "exp02", "subject": "BAA-1104548", "insertion_number": 1}
+
+# One row per global unit, with electrode — the primary entry point
+GlobalUnit & insertion_key
+```
+
+Returns `(experiment_name, subject, insertion_number, global_unit, probe_type, electrode)` — one row per unit. No joins needed.
+
+### Spike times for a unit across all time
+
+```python
+(UnitMatching.Spikes & insertion_key & {"global_unit": 5}).fetch(
     "chunk_start", "spike_times", "spike_count", order_by="chunk_start"
 )
 ```
 
-Note: the result includes session key fields (block_start, block_end, etc.) inherited from the master. These can be ignored — the ownership convention guarantees one row per (universal_unit, chunk_start).
+Returns one row per chunk (guaranteed by unique index). Session key fields (block_start, block_end, etc.) exist in the PK but are not fetched.
 
-### Get all sessions where a universal unit was observed
+### Spike times filtered by chunk range (for alignment with other streams)
 
 ```python
-UnitMatching.Unit & {"universal_unit": 5}
+# Time window — align with behavioral or other neural data by chunk
+(UnitMatching.Spikes & insertion_key & {"global_unit": 5}
+ & f'chunk_start BETWEEN "{start}" AND "{end}"'
+).fetch("chunk_start", "spike_times", order_by="chunk_start")
+
+# Single chunk
+(UnitMatching.Spikes & insertion_key
+ & {"global_unit": 5, "chunk_start": chunk_ts}
+).fetch1("spike_times")
 ```
 
-### Get universal unit assignments for a specific session
+### All units + all spikes for an insertion
+
+```python
+(UnitMatching.Spikes & insertion_key).fetch(
+    "global_unit", "chunk_start", "spike_times", "spike_count",
+    order_by="global_unit, chunk_start"
+)
+```
+
+### Which sessions contributed to a global unit?
+
+```python
+UnitMatching.Unit & insertion_key & {"global_unit": 5}
+```
+
+Returns one row per session where the unit was matched, with the session-specific `unit` ID and match confidence.
+
+### Global unit assignments for a specific session
 
 ```python
 UnitMatching.Unit & session_key
 ```
 
-### Get synced spike times via join (alternative to Spikes)
+### Raw (non-deduplicated) spike times via join
 
 ```python
-SyncedSpikes.Unit * UnitMatching.Unit & {"universal_unit": 5}
+SyncedSpikes.Unit * UnitMatching.Unit & insertion_key & {"global_unit": 5}
 ```
 
-This returns per-session per-chunk spike times with universal unit labels. Overlap chunks will appear with multiple rows (one per session). Use `Spikes` for the deduplicated version.
-
-### List all universal units for an insertion
-
-```python
-UniversalUnit & {"experiment_name": "...", "subject": "...", "insertion_number": 1}
-```
+Returns per-session per-chunk spike times with global unit labels. Overlap chunks appear with multiple rows (one per session). Use `UnitMatching.Spikes` for the deduplicated version.
 
 ---
 
@@ -344,27 +379,27 @@ UniversalUnit & {"experiment_name": "...", "subject": "...", "insertion_number":
 
 **Decision**: One matching result per session. The method is recorded but does not partition the data.
 
-**Rationale**: Making it a PK would mean every downstream query must carry `matching_method`, and universal units would be scoped per-method (allowing parallel sets). In practice, the team settles on one matching method and uses it consistently. The simpler design avoids combinatorial complexity. If method comparison becomes necessary, the FK can be promoted to PK.
+**Rationale**: Making it a PK would mean every downstream query must carry `matching_method`, and global units would be scoped per-method (allowing parallel sets). In practice, the team settles on one matching method and uses it consistently. The simpler design avoids combinatorial complexity. If method comparison becomes necessary, the FK can be promoted to PK.
 
-### Why `Unit` is a Part of `UnitMatching` (not `UniversalUnit`)
+### Why `Unit` is a Part of `UnitMatching` (not `GlobalUnit`)
 
-**Decision**: `UnitMatching.Unit` instead of `UniversalUnit.Matched`.
+**Decision**: `UnitMatching.Unit` instead of `GlobalUnit.Matched`.
 
-**Rationale**: Part table lifecycle should be governed by the master. `Unit` rows are created and destroyed with their session's `UnitMatching` entry. Placing them under `UniversalUnit` (which has a different lifecycle — it persists across sessions) creates cascade problems: deleting `SortedSpikes.Unit` is blocked by `UniversalUnit.Matched`'s FK, requiring `force=True` hacks. Under `UnitMatching`, the cascade is clean: delete `UnitMatching` → cascades to `Unit` and `Spikes`.
+**Rationale**: Part table lifecycle should be governed by the master. `Unit` rows are created and destroyed with their session's `UnitMatching` entry. Placing them under `GlobalUnit` (which has a different lifecycle — it persists across sessions) creates cascade problems: deleting `SortedSpikes.Unit` is blocked by `GlobalUnit.Matched`'s FK, requiring `force=True` hacks. Under `UnitMatching`, the cascade is clean: delete `UnitMatching` → cascades to `Unit` and `Spikes`.
 
 ### Why `Spikes` is a Part of `UnitMatching` (not standalone)
 
 **Decision**: Part table with ownership convention, not a standalone Computed table.
 
 **Alternatives considered**:
-- **Standalone Computed keyed on `(UniversalUnit, EphysChunk)`**: Clean one-row-per-pair semantics, but the cartesian `key_source` (all units x all chunks) is prohibitively large. A restricted `key_source` is complex to express correctly.
+- **Standalone Computed keyed on `(GlobalUnit, EphysChunk)`**: Clean one-row-per-pair semantics, but the cartesian `key_source` (all units x all chunks) is prohibitively large. A restricted `key_source` is complex to express correctly.
 - **No table at all** (use `SyncedSpikes.Unit * UnitMatching.Unit` join): Simplest schema, but overlap chunks produce duplicate rows. Every downstream analysis must implement deduplication.
-- **Part of `UnitMatching`** with ownership convention: Avoids cartesian explosion (scoped to session's chunks). Ownership convention guarantees at most one row per (unit, chunk), enforced by a `unique index (experiment_name, subject, insertion_number, universal_unit, chunk_start)` at the schema level. Lifecycle managed by cascade.
+- **Part of `UnitMatching`** with ownership convention: Avoids cartesian explosion (scoped to session's chunks). Ownership convention guarantees at most one row per (unit, chunk), enforced by a `unique index (experiment_name, subject, insertion_number, global_unit, chunk_start)` at the schema level. Lifecycle managed by cascade.
 
 The Part table approach was chosen because it provides pre-materialized, deduplicated spike times (the primary analysis output) while keeping the scope naturally bounded per session.
 
-### Why `UniversalUnit` is Manual (not Computed)
+### Why `GlobalUnit` is Manual (not Computed)
 
-**Decision**: `UniversalUnit` is a Manual table populated programmatically by `UnitMatching.make()`.
+**Decision**: `GlobalUnit` is a Manual table populated programmatically by `UnitMatching.make()`.
 
-**Rationale**: Universal units are created incrementally as sessions are processed. They persist across sessions — a universal unit created by session 1 is referenced by sessions 2, 3, etc. A Computed table would need a well-defined `key_source` that doesn't exist (you can't predict which universal units will be needed before running the matching). The Manual tier correctly reflects that these entries are managed by application logic, not by DataJoint's populate machinery.
+**Rationale**: Global units are created incrementally as sessions are processed. They persist across sessions — a global unit created by session 1 is referenced by sessions 2, 3, etc. A Computed table would need a well-defined `key_source` that doesn't exist (you can't predict which global units will be needed before running the matching). The Manual tier correctly reflects that these entries are managed by application logic, not by DataJoint's populate machinery.

--- a/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
+++ b/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
@@ -34,7 +34,7 @@ Specifically, `UnitMatching.key_source` requires that `ApplyOfficialCuration` ex
 
 ### Key Concepts
 
-A **global unit** is a persistent neuron identity scoped to a single probe insertion (i.e., one physical probe in one subject). Global unit IDs are integers starting at 1, unique within a `(experiment_name, subject, insertion_number)` scope.
+A **global unit** is a persistent neuron identity scoped to a single probe insertion (i.e., one physical probe in one experiment). Global unit IDs are integers starting at 1, unique within a `(experiment_name, insertion_number)` scope.
 
 A **matched unit** links a block-specific `SortedSpikes.Unit` to its assigned global unit. Each block's unit maps to exactly one global unit. A global unit may be matched to units from multiple blocks (that's the whole point).
 
@@ -57,7 +57,7 @@ This constraint is enforced at two levels:
 eligible = SyncedSpikes & spike_sorting_curation.ApplyOfficialCuration
 candidates = eligible - self
 next_per_insertion = dj.U(
-    "experiment_name", "subject", "insertion_number"
+    "experiment_name", "insertion_number"
 ).aggr(candidates, next_start="MIN(block_start)")
 return candidates * next_per_insertion & "block_start = next_start"
 ```
@@ -106,10 +106,10 @@ UnitMatching (Computed)
         ---
         spike_times: longblob               # datetime64[ns] (UTC), HARP-synced — same format as SyncedSpikes.Unit
         spike_count: int
-        unique index (experiment_name, subject, insertion_number, global_unit, chunk_start)  # schema-enforced: one row per (insertion, unit, chunk)
+        unique index (experiment_name, insertion_number, global_unit, chunk_start)  # schema-enforced: one row per (insertion, unit, chunk)
 
 GlobalUnit (Manual)
-    -> ephys.ProbeInsertion                 # experiment_name, subject, insertion_number
+    -> ephys.ProbeInsertion                 # experiment_name, insertion_number
     global_unit: int                     # unique ID within this insertion
     ---
     -> ephys.ProbeType.Electrode      # peak electrode (denormalized, updated each block)
@@ -137,7 +137,7 @@ erDiagram
 
 - **`GlobalUnit` is Manual with denormalized electrode**: Populated programmatically by `UnitMatching.make()`, not by DataJoint's `populate()` machinery. This means it cannot be auto-cleared. Orphaned entries (those with no remaining `Unit` references) must be cleaned up explicitly during re-processing. The peak `electrode` is denormalized from `SortedSpikes.Unit` and stored directly on `GlobalUnit`. It is updated each time a new block is matched (latest block = best estimate of the unit's electrode position). This enables a clean unit roster query — `GlobalUnit & insertion_key` returns one row per unit with its electrode, no joins required.
 
-- **`unique index` on `Spikes`**: The Part table PK includes the master's block key, so the same `(global_unit, chunk_start)` from different blocks would be valid at the PK level. The unique index on `(experiment_name, subject, insertion_number, global_unit, chunk_start)` provides a schema-level guarantee that only one block can own a given (insertion, unit, chunk) pair. The index is scoped per-insertion because `global_unit` IDs are only unique within an insertion — two insertions for the same subject can both have `global_unit=1`.
+- **`unique index` on `Spikes`**: The Part table PK includes the master's block key, so the same `(global_unit, chunk_start)` from different blocks would be valid at the PK level. The unique index on `(experiment_name, insertion_number, global_unit, chunk_start)` provides a schema-level guarantee that only one block can own a given (insertion, unit, chunk) pair. The index is scoped per-insertion because `global_unit` IDs are only unique within an insertion — two insertions in the same experiment can both have `global_unit=1`.
 
 - **`UnitMatching.Unit` references `SortedSpikes.Unit` via formal FK**: This enforces referential integrity (cannot match a non-existent unit). Since `UnitMatching` sits downstream of `SortedSpikes` in the pipeline, and curation cleanup deletes `UnitMatching` before `SortedSpikes`, cascade ordering is correct.
 
@@ -153,7 +153,7 @@ The current (and only) matching method uses SpikeInterface's `compare_two_sorter
 
 1. **Load this block's synced spike times** from `SyncedSpikes.Unit`. Concatenate across chunks per unit. Convert `datetime64[ns]` to epoch seconds for the overlap comparison and SpikeInterface compatibility.
 
-2. **Find overlapping previous blocks**: Query all previously-completed `UnitMatching` entries for the same `(experiment_name, subject, insertion_number)`. Filter to those whose `(block_start, block_end)` overlaps with this block's time range.
+2. **Find overlapping previous blocks**: Query all previously-completed `UnitMatching` entries for the same `(experiment_name, insertion_number)`. Filter to those whose `(block_start, block_end)` overlaps with this block's time range.
 
 3. **For each overlapping previous block**:
    a. Load the previous block's synced spike times (same format).
@@ -192,7 +192,7 @@ When two ephys blocks overlap in time, the same `EphysChunk` (1-hour raw data se
 
 Duplicates cause incorrect downstream analysis: inflated spike counts, artificial short ISIs, and wrong firing rate estimates.
 
-### Convention: Earlier Session Owns
+### Convention: Earlier Block Owns
 
 **Rule: for each `(global_unit, chunk)` pair, the first block (in processing order) to write a `Spikes` row wins. Later blocks skip that pair.**
 
@@ -223,7 +223,7 @@ for gu_id in this_block_global_units:
 
 After all blocks are processed, each `(global_unit, chunk_start)` pair appears in **at most one** `UnitMatching.Spikes` row across all blocks. This invariant is enforced at two levels:
 
-1. **Schema-level**: A `unique index (experiment_name, subject, insertion_number, global_unit, chunk_start)` on `Spikes` guarantees that the database rejects any duplicate per-insertion `(global_unit, chunk_start)` insertion, regardless of which block attempts it. The index is scoped per-insertion because `global_unit` IDs are only unique within an insertion. A later block trying to write an already-owned pair will raise an `IntegrityError`.
+1. **Schema-level**: A `unique index (experiment_name, insertion_number, global_unit, chunk_start)` on `Spikes` guarantees that the database rejects any duplicate per-insertion `(global_unit, chunk_start)` insertion, regardless of which block attempts it. The index is scoped per-insertion because `global_unit` IDs are only unique within an insertion. A later block trying to write an already-owned pair will raise an `IntegrityError`.
 
 2. **Code-level**: The `make()` method checks for existing rows before inserting, skipping already-owned pairs. This prevents the `IntegrityError` from ever being raised during normal operation and provides clear logging of skipped chunks.
 
@@ -265,7 +265,7 @@ GlobalUnit (Manual)                    ← NEW (populated by UnitMatching.make()
 
 ## Re-processing and Deletion
 
-### Scenario: Re-curation of a Session
+### Scenario: Re-curation of an EphysBlock
 
 When a block's curation is changed (via `restore_raw_sorting()` → new curation → `ApplyOfficialCuration`):
 
@@ -308,13 +308,13 @@ The primary query interface is designed around a natural workflow: start from an
 ### Unit roster: all global units for an insertion (with electrode)
 
 ```python
-insertion_key = {"experiment_name": "exp02", "subject": "BAA-1104548", "insertion_number": 1}
+insertion_key = {"experiment_name": "exp02", "insertion_number": 1}
 
 # One row per global unit, with electrode — the primary entry point
 GlobalUnit & insertion_key
 ```
 
-Returns `(experiment_name, subject, insertion_number, global_unit, probe_type, electrode)` — one row per unit. No joins needed.
+Returns `(experiment_name, insertion_number, global_unit, probe_type, electrode)` — one row per unit. No joins needed.
 
 ### Spike times for a unit across all time
 
@@ -394,7 +394,7 @@ Returns per-block per-chunk spike times with global unit labels. Overlap chunks 
 **Alternatives considered**:
 - **Standalone Computed keyed on `(GlobalUnit, EphysChunk)`**: Clean one-row-per-pair semantics, but the cartesian `key_source` (all units x all chunks) is prohibitively large. A restricted `key_source` is complex to express correctly.
 - **No table at all** (use `SyncedSpikes.Unit * UnitMatching.Unit` join): Simplest schema, but overlap chunks produce duplicate rows. Every downstream analysis must implement deduplication.
-- **Part of `UnitMatching`** with ownership convention: Avoids cartesian explosion (scoped to block's chunks). Ownership convention guarantees at most one row per (unit, chunk), enforced by a `unique index (experiment_name, subject, insertion_number, global_unit, chunk_start)` at the schema level. Lifecycle managed by cascade.
+- **Part of `UnitMatching`** with ownership convention: Avoids cartesian explosion (scoped to block's chunks). Ownership convention guarantees at most one row per (unit, chunk), enforced by a `unique index (experiment_name, insertion_number, global_unit, chunk_start)` at the schema level. Lifecycle managed by cascade.
 
 The Part table approach was chosen because it provides pre-materialized, deduplicated spike times (the primary analysis output) while keeping the scope naturally bounded per block.
 

--- a/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
+++ b/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
@@ -668,3 +668,72 @@ The Part table approach was chosen because it provides pre-materialized, dedupli
 **Decision**: `GlobalUnit` is a Manual table populated programmatically by `UnitMatching.make()`.
 
 **Rationale**: Global units are created incrementally as blocks are processed. They persist across blocks — a global unit created by block 1 is referenced by blocks 2, 3, etc. A Computed table would need a well-defined `key_source` that doesn't exist (you can't predict which global units will be needed before running the matching). The Manual tier correctly reflects that these entries are managed by application logic, not by DataJoint's populate machinery.
+
+---
+
+## Alternative Design: Pair-Based Unit Matching
+
+> **Status**: Both designs are implemented. The team will evaluate and choose one.
+
+### Motivation
+
+The sequential `UnitMatching` design auto-selects the next block via `key_source` and enforces strict temporal ordering. The pair-based alternative gives users explicit control over which two blocks to compare, while maintaining the same matching algorithm and GlobalUnit semantics.
+
+### Table Definitions
+
+```
+UnitMatchingPair (Manual)
+    -> SyncedSpikes.proj(earlier_block_start='block_start', earlier_block_end='block_end')
+    -> SyncedSpikes.proj(latter_block_start='block_start', latter_block_end='block_end')
+    -> UnitMatchingParamSet
+
+PairMatching (Computed)
+    -> UnitMatchingPair
+    ---
+    execution_time: datetime
+    execution_duration: float               # hours
+
+    PairMatching.Unit (Part)
+        -> master
+        -> GlobalUnit
+        ---
+        -> [nullable] SortedSpikes.Unit.proj(earlier_block_start='block_start', earlier_block_end='block_end', earlier_unit='unit')
+        -> [nullable] SortedSpikes.Unit.proj(latter_block_start='block_start', latter_block_end='block_end', latter_unit='unit')
+        match_confidence=null: float
+        match_comment='': varchar(1000)
+
+    PairMatching.Spikes (Part)
+        -> master
+        -> GlobalUnit
+        -> ephys.EphysChunk
+        ---
+        spike_times: longblob
+        spike_count: int
+        unique index (experiment_name, subject, insertion_number, global_unit, chunk_start)
+```
+
+### How It Works
+
+The key insight: **this design is functionally equivalent to the sequential design.** In practice, one of the two blocks in a pair has already been matched (its units have GlobalUnit assignments from a previous pair). That block becomes the "anchor." The other block is "new" — its units are compared against the anchor and assigned global units. This is identical to "match one new block to the existing chain."
+
+**Canonical ordering**: `earlier_block_start < latter_block_start` prevents duplicate pairs `(A,B)` / `(B,A)`. The naming is positional, not semantic — either block can be the anchor.
+
+**Anchor determination** (`PairMatching.make()`):
+- If one block has previous `PairMatching.Unit` entries → it's the anchor
+- If both do → earlier block is anchor by convention
+- If neither (seed pair) → earlier block is anchor; all units get fresh global unit IDs
+
+**Constraint**: At least one block must be already matched, unless this is the seed pair (no previous `PairMatching` for this insertion + paramset).
+
+**Unit Part table semantics**: Each `PairMatching.Unit` row is keyed by `(pair_key, global_unit)` and records the unit IDs from both blocks via nullable projected FKs to `SortedSpikes.Unit`. For matched pairs, both `earlier_unit` and `latter_unit` are populated — you can read "unit X in the earlier block matched unit Y in the latter block → GlobalUnit G." For unmatched units (only present in one block), one side is null. The projection renames `block_start`/`block_end`/`unit` to match the master's `earlier_block_start`/`latter_block_start` naming. The `[nullable]` FK provides referential integrity on insert (can't reference a non-existent unit) and `ON DELETE SET NULL` behavior (deleting a `SortedSpikes.Unit` nulls the reference rather than deleting the `PairMatching.Unit` row).
+
+### Comparison with Sequential Design
+
+| Aspect | Sequential (`UnitMatching`) | Pair-Based (`UnitMatchingPair` + `PairMatching`) |
+|--------|----------------------------|--------------------------------------------------|
+| Block selection | Auto (`key_source`, temporal order) | Manual (user picks pairs) |
+| Ordering enforcement | Schema + `key_source` + `make()` guard | `make()` constraint (one must be matched) |
+| Non-adjacent matching | Not supported | Supported (user picks any two blocks) |
+| Method per comparison | Same paramset for all blocks | Different paramset per pair |
+| GlobalUnit / Spikes | Identical semantics | Identical semantics |
+| `SortedSpikes.Unit` FK | Formal FK in Part table | Nullable projected FK (ON DELETE SET NULL) |

--- a/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
+++ b/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
@@ -43,36 +43,48 @@ A **matched unit** links a block-specific `SortedSpikes.Unit` to its assigned gl
 
 The **ownership convention** determines which block "owns" the spike data for a given (global_unit, chunk) pair when multiple blocks cover the same chunk. This prevents duplicate rows in `Spikes`.
 
-### Critical Constraint: Temporal Ordering
+### Critical Constraint: Seed-Based Bidirectional Propagation
 
-Ephys blocks **must** be processed in temporal order (by `block_start`). Block N compares its units against previously-matched blocks (1..N-1). Processing out of order produces incorrect global unit assignments.
+Ephys blocks are processed starting from a user-specified **seed block** (the block with the best signal quality), then propagating outward in both directions. Each `UnitMatchingParamSet` entry specifies a `seed_block_start` — the block from which matching begins.
 
 This constraint is enforced at two levels:
 
-1. **`key_source` gate**: Only yields the block with the earliest unprocessed `block_start` per (insertion, paramset). Under `populate(reserve_jobs=True)`, a worker that finishes the earliest block causes the next `key_source` evaluation to advance to the next block. Workers processing different insertions or different paramsets can run in parallel; within an (insertion, paramset), processing is serialized.
+1. **`key_source` gate**: Yields at most 3 blocks per (insertion, paramset) — the seed (if unprocessed), the forward frontier (nearest unprocessed block after the processed region), and the backward frontier (nearest unprocessed block before the processed region). Workers processing different insertions or paramsets can run in parallel; within an (insertion, paramset), processing is serialized to at most 3 candidates.
 
-2. **`make()` guard**: Before processing, verifies that no earlier eligible block (by `block_start`) for the same insertion remains unprocessed. This is a defense-in-depth check that catches direct `make(key)` calls bypassing `key_source`, or hypothetical bugs in the key_source logic.
+2. **`make()` guard**: Before processing, verifies that either (a) this is the first block and it matches `seed_block_start`, or (b) this block overlaps with at least one previously-matched block. This is a defense-in-depth check that catches direct `make(key)` calls bypassing `key_source`.
 
 ```python
-# key_source: only the earliest unprocessed block per (insertion, paramset)
+# key_source: seed block if unprocessed, else forward/backward frontiers
 eligible = SyncedSpikes & spike_sorting_curation.ApplyOfficialCuration
 all_candidates = eligible * UnitMatchingParamSet
 candidates = all_candidates - self
-next_per_group = dj.U(
-    "experiment_name", "subject", "insertion_number", "matching_paramset_id"
-).aggr(candidates, next_start="MIN(block_start)")
-return candidates * next_per_group & "block_start = next_start"
+
+# Case 1: seed block itself is unprocessed
+seed_candidates = candidates & "block_start = seed_block_start"
+
+# Case 2: seed already processed -> find frontiers
+processed = all_candidates & self
+processed_bounds = dj.U(...).aggr(processed, proc_min="MIN(block_start)", proc_max="MAX(block_start)")
+fwd_candidates = candidates * fwd & "block_start = fwd_start"  # MIN unprocessed > proc_max
+bwd_candidates = candidates * bwd & "block_start = bwd_start"  # MAX unprocessed < proc_min
+
+return seed_candidates + fwd_candidates + bwd_candidates
 ```
 
 ```python
-# make() guard: verify all predecessors are done
-earlier_eligible = eligible & insertion_key & f'block_start < "{key["block_start"]}"'
-unprocessed_earlier = earlier_eligible - self
-if unprocessed_earlier:
-    raise ValueError("Temporal ordering violation: earlier blocks not yet processed.")
+# make() guard: seed-first + overlap check
+previously_matched = (self & insertion_key & paramset_key).fetch(as_dict=True)
+if not previously_matched:
+    # First block must be the seed
+    if key["block_start"] != seed_block_start:
+        raise ValueError("First block must be the seed.")
+else:
+    # Subsequent blocks must overlap with at least one processed block
+    if not any(s["block_start"] < block_end and s["block_end"] > block_start for s in previously_matched):
+        raise ValueError("Block does not overlap with any previously matched block.")
 ```
 
-**Interaction with `reserve_jobs=True`**: When Worker A reserves the earliest block for insertion I1, Worker B's `key_source` also returns that same block (it's not yet in `self`). But the job reservation system prevents B from reserving the already-reserved key. With no other candidates for I1, Worker B idles or processes a different insertion. When A finishes, the next `populate()` cycle advances to the next block.
+**Interaction with `reserve_jobs=True`**: When the seed is consumed, the next `populate()` cycle yields up to 2 frontier blocks (forward and backward). Workers processing different insertions or paramsets run in parallel. Within an (insertion, paramset), the seed must complete before frontiers are yielded, and each frontier must complete before the next frontier in that direction is yielded.
 
 ---
 
@@ -261,6 +273,7 @@ UnitMatchingParamSet (Lookup)
     matching_paramset_id: smallint
     ---
     -> UnitMatchingMethod
+    seed_block_start: datetime(6)           # block_start of the seed block (first to process)
     matching_paramset_description='': varchar(1000)
     params: longblob                        # dictionary of all applicable parameters
 
@@ -669,71 +682,18 @@ The Part table approach was chosen because it provides pre-materialized, dedupli
 
 **Rationale**: Global units are created incrementally as blocks are processed. They persist across blocks — a global unit created by block 1 is referenced by blocks 2, 3, etc. A Computed table would need a well-defined `key_source` that doesn't exist (you can't predict which global units will be needed before running the matching). The Manual tier correctly reflects that these entries are managed by application logic, not by DataJoint's populate machinery.
 
----
+### Why `seed_block_start` on `UnitMatchingParamSet`
 
-## Alternative Design: Pair-Based Unit Matching
+**Decision**: `seed_block_start` is a required dependent attribute on `UnitMatchingParamSet`, not a separate configuration table or a runtime parameter.
 
-> **Status**: Both designs are implemented. The team will evaluate and choose one.
+**Rationale**: Scientists need control over where matching starts — the block with the best signal quality (e.g., highest unit count, cleanest waveforms). Placing the seed on the paramset means:
 
-### Motivation
+1. **Different seeds → different paramset entries**: Even if all other parameters are identical, two paramsets with different seeds produce different matching chains (different propagation order → potentially different global unit assignments). This is correct: the seed is a meaningful parameter that affects the result.
 
-The sequential `UnitMatching` design auto-selects the next block via `key_source` and enforces strict temporal ordering. The pair-based alternative gives users explicit control over which two blocks to compare, while maintaining the same matching algorithm and GlobalUnit semantics.
+2. **Reproducibility**: The seed is recorded as part of the paramset, so the matching result is fully reproducible from the paramset alone.
 
-### Table Definitions
+3. **Bidirectional propagation**: From the seed, `key_source` propagates outward in both directions — forward (toward later blocks) and backward (toward earlier blocks). This eliminates the old restriction that matching must start from the earliest block, which was suboptimal when early blocks have poor signal quality.
 
-```
-UnitMatchingPair (Manual)
-    -> SyncedSpikes.proj(earlier_block_start='block_start', earlier_block_end='block_end')
-    -> SyncedSpikes.proj(latter_block_start='block_start', latter_block_end='block_end')
-    -> UnitMatchingParamSet
+4. **No separate Manual table**: A separate "seed configuration" table would add complexity without benefit. The seed is a matching parameter, not an independent entity.
 
-PairMatching (Computed)
-    -> UnitMatchingPair
-    ---
-    execution_time: datetime
-    execution_duration: float               # hours
-
-    PairMatching.Unit (Part)
-        -> master
-        -> GlobalUnit
-        ---
-        -> [nullable] SortedSpikes.Unit.proj(earlier_block_start='block_start', earlier_block_end='block_end', earlier_unit='unit')
-        -> [nullable] SortedSpikes.Unit.proj(latter_block_start='block_start', latter_block_end='block_end', latter_unit='unit')
-        match_confidence=null: float
-        match_comment='': varchar(1000)
-
-    PairMatching.Spikes (Part)
-        -> master
-        -> GlobalUnit
-        -> ephys.EphysChunk
-        ---
-        spike_times: longblob
-        spike_count: int
-        unique index (experiment_name, subject, insertion_number, global_unit, chunk_start)
-```
-
-### How It Works
-
-The key insight: **this design is functionally equivalent to the sequential design.** In practice, one of the two blocks in a pair has already been matched (its units have GlobalUnit assignments from a previous pair). That block becomes the "anchor." The other block is "new" — its units are compared against the anchor and assigned global units. This is identical to "match one new block to the existing chain."
-
-**Canonical ordering**: `earlier_block_start < latter_block_start` prevents duplicate pairs `(A,B)` / `(B,A)`. The naming is positional, not semantic — either block can be the anchor.
-
-**Anchor determination** (`PairMatching.make()`):
-- If one block has previous `PairMatching.Unit` entries → it's the anchor
-- If both do → earlier block is anchor by convention
-- If neither (seed pair) → earlier block is anchor; all units get fresh global unit IDs
-
-**Constraint**: At least one block must be already matched, unless this is the seed pair (no previous `PairMatching` for this insertion + paramset).
-
-**Unit Part table semantics**: Each `PairMatching.Unit` row is keyed by `(pair_key, global_unit)` and records the unit IDs from both blocks via nullable projected FKs to `SortedSpikes.Unit`. For matched pairs, both `earlier_unit` and `latter_unit` are populated — you can read "unit X in the earlier block matched unit Y in the latter block → GlobalUnit G." For unmatched units (only present in one block), one side is null. The projection renames `block_start`/`block_end`/`unit` to match the master's `earlier_block_start`/`latter_block_start` naming. The `[nullable]` FK provides referential integrity on insert (can't reference a non-existent unit) and `ON DELETE SET NULL` behavior (deleting a `SortedSpikes.Unit` nulls the reference rather than deleting the `PairMatching.Unit` row).
-
-### Comparison with Sequential Design
-
-| Aspect | Sequential (`UnitMatching`) | Pair-Based (`UnitMatchingPair` + `PairMatching`) |
-|--------|----------------------------|--------------------------------------------------|
-| Block selection | Auto (`key_source`, temporal order) | Manual (user picks pairs) |
-| Ordering enforcement | Schema + `key_source` + `make()` guard | `make()` constraint (one must be matched) |
-| Non-adjacent matching | Not supported | Supported (user picks any two blocks) |
-| Method per comparison | Same paramset for all blocks | Different paramset per pair |
-| GlobalUnit / Spikes | Identical semantics | Identical semantics |
-| `SortedSpikes.Unit` FK | Formal FK in Part table | Nullable projected FK (ON DELETE SET NULL) |
+**Alternative rejected: Pair-based matching** (`UnitMatchingPair` + `PairMatching`). This design gave users explicit control over which pairs of blocks to compare, but was functionally equivalent to seed-based sequential matching with extra complexity. The seed-based approach provides the same user control (choosing the starting point) with simpler schema and automatic propagation.

--- a/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
+++ b/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
@@ -44,7 +44,33 @@ The **ownership convention** determines which session "owns" the spike data for 
 
 ### Critical Constraint: Temporal Ordering
 
-Sessions **must** be processed in temporal order (by `block_start`). Session N compares its units against previously-matched sessions (1..N-1). Processing out of order produces incorrect universal unit assignments. This constraint is documented but enforced only by convention — there is no schema-level enforcement.
+Sessions **must** be processed in temporal order (by `block_start`). Session N compares its units against previously-matched sessions (1..N-1). Processing out of order produces incorrect universal unit assignments.
+
+This constraint is enforced at two levels:
+
+1. **`key_source` gate**: Only yields the session with the earliest unprocessed `block_start` per insertion. Under `populate(reserve_jobs=True)`, a worker that finishes the earliest session causes the next `key_source` evaluation to advance to the next block. Workers processing different insertions can run in parallel; within an insertion, processing is serialized.
+
+2. **`make()` guard**: Before processing, verifies that no earlier eligible session (by `block_start`) for the same insertion remains unprocessed. This is a defense-in-depth check that catches direct `make(key)` calls bypassing `key_source`, or hypothetical bugs in the key_source logic.
+
+```python
+# key_source: only the earliest unprocessed block per insertion
+eligible = SyncedSpikes & spike_sorting_curation.ApplyOfficialCuration
+candidates = eligible - self
+next_per_insertion = dj.U(
+    "experiment_name", "subject", "insertion_number"
+).aggr(candidates, next_start="MIN(block_start)")
+return candidates * next_per_insertion & "block_start = next_start"
+```
+
+```python
+# make() guard: verify all predecessors are done
+earlier_eligible = eligible & insertion_key & f'block_start < "{key["block_start"]}"'
+unprocessed_earlier = earlier_eligible - self
+if unprocessed_earlier:
+    raise ValueError("Temporal ordering violation: earlier sessions not yet processed.")
+```
+
+**Interaction with `reserve_jobs=True`**: When Worker A reserves the earliest session for insertion I1, Worker B's `key_source` also returns that same session (it's not yet in `self`). But the job reservation system prevents B from reserving the already-reserved key. With no other candidates for I1, Worker B idles or processes a different insertion. When A finishes, the next `populate()` cycle advances to the next block.
 
 ---
 
@@ -229,9 +255,7 @@ UniversalUnit (Manual)                    ← NEW (populated by UnitMatching.mak
 
 ### Worker Integration
 
-`UnitMatching` is a `Computed` table and can be registered with a DataJoint worker for automated processing. However, the temporal ordering constraint means the worker must process sessions sequentially by `block_start`. If the worker picks up sessions out of order, results will be incorrect.
-
-**Recommendation**: Either (a) register with a dedicated worker that processes one session at a time in order, or (b) keep matching as a manually-triggered step until the ordering constraint is better enforced.
+`UnitMatching` is a `Computed` table and can be registered with a DataJoint worker for automated processing. The `key_source` gate (see [Critical Constraint: Temporal Ordering](#critical-constraint-temporal-ordering)) ensures that `populate(reserve_jobs=True)` respects temporal ordering even under parallel execution — workers processing different insertions run in parallel, while sessions within an insertion are serialized automatically.
 
 ---
 

--- a/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
+++ b/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
@@ -104,7 +104,7 @@ UnitMatching (Computed)
         -> UniversalUnit                    # adds universal_unit to PK
         -> ephys.EphysChunk                 # adds chunk_start to PK
         ---
-        spike_times: longblob               # float64 epoch seconds (UTC), HARP-synced
+        spike_times: longblob               # datetime64[ns] (UTC), HARP-synced — same format as SyncedSpikes.Unit
         spike_count: int
         unique index (experiment_name, subject, insertion_number, universal_unit, chunk_start)  # schema-enforced: one row per (insertion, unit, chunk)
 
@@ -149,7 +149,7 @@ The current (and only) matching method uses SpikeInterface's `compare_two_sorter
 
 #### Steps
 
-1. **Load this session's synced spike times** from `SyncedSpikes.Unit`. Concatenate across chunks per unit. Convert `datetime64[ns]` to float64 epoch seconds.
+1. **Load this session's synced spike times** from `SyncedSpikes.Unit`. Concatenate across chunks per unit. Convert `datetime64[ns]` to epoch seconds for the overlap comparison and SpikeInterface compatibility.
 
 2. **Find overlapping previous sessions**: Query all previously-completed `UnitMatching` entries for the same `(experiment_name, subject, insertion_number)`. Filter to those whose `(block_start, block_end)` overlaps with this session's time range.
 
@@ -176,7 +176,7 @@ The current (and only) matching method uses SpikeInterface's `compare_two_sorter
 | Parameter | Value | Description |
 |-----------|-------|-------------|
 | `delta_time` | 0.4 ms | Spike time coincidence window for `compare_two_sorters` |
-| Sampling frequency | 30,000 Hz | Used to convert epoch seconds to sample indices for SpikeInterface |
+| Sampling frequency | 30,000 Hz | Used internally to convert timestamps to sample indices for SpikeInterface comparison |
 
 ---
 

--- a/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
+++ b/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
@@ -49,18 +49,19 @@ Ephys blocks **must** be processed in temporal order (by `block_start`). Block N
 
 This constraint is enforced at two levels:
 
-1. **`key_source` gate**: Only yields the block with the earliest unprocessed `block_start` per insertion. Under `populate(reserve_jobs=True)`, a worker that finishes the earliest block causes the next `key_source` evaluation to advance to the next block. Workers processing different insertions can run in parallel; within an insertion, processing is serialized.
+1. **`key_source` gate**: Only yields the block with the earliest unprocessed `block_start` per (insertion, paramset). Under `populate(reserve_jobs=True)`, a worker that finishes the earliest block causes the next `key_source` evaluation to advance to the next block. Workers processing different insertions or different paramsets can run in parallel; within an (insertion, paramset), processing is serialized.
 
 2. **`make()` guard**: Before processing, verifies that no earlier eligible block (by `block_start`) for the same insertion remains unprocessed. This is a defense-in-depth check that catches direct `make(key)` calls bypassing `key_source`, or hypothetical bugs in the key_source logic.
 
 ```python
-# key_source: only the earliest unprocessed block per insertion
+# key_source: only the earliest unprocessed block per (insertion, paramset)
 eligible = SyncedSpikes & spike_sorting_curation.ApplyOfficialCuration
-candidates = eligible - self
-next_per_insertion = dj.U(
-    "experiment_name", "subject", "insertion_number"
+all_candidates = eligible * UnitMatchingParamSet
+candidates = all_candidates - self
+next_per_group = dj.U(
+    "experiment_name", "subject", "insertion_number", "matching_paramset_id"
 ).aggr(candidates, next_start="MIN(block_start)")
-return candidates * next_per_insertion & "block_start = next_start"
+return candidates * next_per_group & "block_start = next_start"
 ```
 
 ```python
@@ -240,7 +241,7 @@ ProbeInsertion: (experiment_name, subject, insertion_number)
     → EphysBlockInfo
     → SortingTask: + (probe_type, electrode_config_name, electrode_group, sorting_method, paramset_id)
       → PreProcessing → SpikeSorting → PostProcessing → SortedSpikes → SyncedSpikes
-        → UnitMatching
+        → UnitMatching: + (matching_paramset_id)
           → GlobalUnit: (experiment_name, subject, insertion_number, global_unit)
 ```
 
@@ -256,10 +257,17 @@ UnitMatchingMethod (Lookup)
     ---
     matching_method_description: varchar(1000)
 
+UnitMatchingParamSet (Lookup)
+    matching_paramset_id: smallint
+    ---
+    -> UnitMatchingMethod
+    matching_paramset_description='': varchar(1000)
+    params: longblob                        # dictionary of all applicable parameters
+
 UnitMatching (Computed)
     -> SyncedSpikes                         # inherits full block key
+    -> UnitMatchingParamSet                 # PK: which paramset was used
     ---
-    -> UnitMatchingMethod                   # non-PK: which method was used
     execution_time: datetime
     execution_duration: float               # hours
 
@@ -284,6 +292,7 @@ GlobalUnit (Manual)
     -> ephys.ProbeInsertion                 # experiment_name, subject, insertion_number
     global_unit: int                        # unique ID within this insertion
     ---
+    -> UnitMatchingParamSet                 # FK: which paramset produced this unit
     -> ephys.ProbeType.Electrode            # peak electrode (denormalized, updated each block)
     global_unit_comment='': varchar(1000)
 ```
@@ -293,13 +302,15 @@ GlobalUnit (Manual)
 ```mermaid
 erDiagram
     SyncedSpikes ||--o| UnitMatching : "populates"
-    UnitMatchingMethod ||--o| UnitMatching : "FK (matching_method)"
+    UnitMatchingParamSet ||--o{ UnitMatching : "PK (matching_paramset_id)"
+    UnitMatchingMethod ||--o{ UnitMatchingParamSet : "FK (matching_method)"
     UnitMatching ||--o{ "UnitMatching.Unit" : "part"
     UnitMatching ||--o{ "UnitMatching.Spikes" : "part"
     "SortedSpikes.Unit" ||--o| "UnitMatching.Unit" : "FK (unit)"
     GlobalUnit ||--o{ "UnitMatching.Unit" : "FK (global_unit)"
     GlobalUnit ||--o{ "UnitMatching.Spikes" : "FK (global_unit)"
     "ephys.EphysChunk" ||--o{ "UnitMatching.Spikes" : "FK (chunk_start)"
+    UnitMatchingParamSet ||--o{ GlobalUnit : "FK (matching_paramset_id)"
     "ephys.ProbeType.Electrode" ||--o{ GlobalUnit : "FK (electrode)"
     "ephys.ProbeInsertion" ||--|| GlobalUnit : "scopes"
     "ephys.EphysEpoch" ||--o{ "ephys.EphysChunk" : "FK (epoch_start)"
@@ -309,7 +320,7 @@ erDiagram
 
 ### Design Notes
 
-- **`UnitMatchingMethod` as non-PK FK**: Only one matching result per block. The method is recorded for provenance but does not multiply the key space. This means one canonical set of global units per insertion — no parallel method comparison. This is a deliberate simplification; if method comparison becomes needed, it can be added later by promoting the FK back to PK.
+- **`UnitMatchingParamSet` as PK in `UnitMatching`, FK in `GlobalUnit`**: Each block can be matched with multiple parameter sets (different methods or tuning). `UnitMatchingParamSet` is in the PK of `UnitMatching`, so each (block, paramset) is a separate matching result. However, `GlobalUnit` has `UnitMatchingParamSet` as a non-PK FK — a neuron's identity is scoped to the insertion `(experiment_name, subject, insertion_number)`, not to the method that discovered it. The FK records provenance (which paramset produced this global unit).
 
 - **`GlobalUnit` is Manual with denormalized electrode**: Populated programmatically by `UnitMatching.make()`, not by DataJoint's `populate()` machinery. This means it cannot be auto-cleared. Orphaned entries (those with no remaining `Unit` references) must be cleaned up explicitly during re-processing. The peak `electrode` is denormalized from `SortedSpikes.Unit` and stored directly on `GlobalUnit`. It is updated each time a new block is matched (latest block = best estimate of the unit's electrode position). This enables a clean unit roster query — `GlobalUnit & insertion_key` returns one row per unit with its electrode, no joins required.
 
@@ -428,11 +439,12 @@ ProbeInsertion (Manual)                        ← CHANGED: subject in PK, probe
                   → Waveform (Imported)
                   → SortingQuality (Imported)
                   → SyncedSpikes (Imported)
-                    → UnitMatching (Computed)
+                    → UnitMatching (Computed)          ← PK includes UnitMatchingParamSet
                       ├─ .Unit (Part)
                       └─ .Spikes (Part)
 
-GlobalUnit (Manual, populated by UnitMatching.make())
+UnitMatchingMethod (Lookup) → UnitMatchingParamSet (Lookup)
+GlobalUnit (Manual, populated by UnitMatching.make())  ← FK to UnitMatchingParamSet
 ```
 
 ### Ingestion Flow
@@ -462,7 +474,7 @@ Steps 3-5 can run continuously as data arrives. Step 4 only needs the epoch dire
 
 ### Worker Integration
 
-`UnitMatching` is a `Computed` table and can be registered with a DataJoint worker for automated processing. The `key_source` gate (see [Critical Constraint: Temporal Ordering](#critical-constraint-temporal-ordering)) ensures that `populate(reserve_jobs=True)` respects temporal ordering even under parallel execution — workers processing different insertions run in parallel, while blocks within an insertion are serialized automatically.
+`UnitMatching` is a `Computed` table and can be registered with a DataJoint worker for automated processing. The `key_source` gate (see [Critical Constraint: Temporal Ordering](#critical-constraint-temporal-ordering)) ensures that `populate(reserve_jobs=True)` respects temporal ordering even under parallel execution — workers processing different insertions or paramsets run in parallel, while blocks within an (insertion, paramset) are serialized automatically.
 
 ---
 
@@ -628,11 +640,11 @@ The operational cost is small: subject-probe association must be provided (via f
 - **Dependency enforcement**: EphysEpoch must be populated (subject-probe mapping established) before chunks can be created for that epoch. This is the correct ordering.
 - **Real-time compatible**: The FK references `epoch_start`, not `epoch_end`. As soon as an epoch begins and EphysEpoch runs (Metadata.yml exists immediately), the mapping is established. Chunks are ingested as they arrive — no waiting for the epoch to end.
 
-### Why `UnitMatchingMethod` is a non-PK FK
+### Why `UnitMatchingParamSet` is PK in `UnitMatching` but FK in `GlobalUnit`
 
-**Decision**: One matching result per block. The method is recorded but does not partition the data.
+**Decision**: `UnitMatchingParamSet` is part of the `UnitMatching` PK (enabling parallel matching with different parameters), but is a non-PK FK on `GlobalUnit` (a neuron's identity is scoped to the insertion, not the matching method).
 
-**Rationale**: Making it a PK would mean every downstream query must carry `matching_method`, and global units would be scoped per-method (allowing parallel sets). In practice, the team uses one matching method consistently. The simpler design avoids combinatorial complexity. If method comparison becomes necessary, the FK can be promoted to PK.
+**Rationale**: Unit matching is parameterizable — different methods (spike time overlap, template matching) and different tuning (delta_time, sampling frequency) should be explorable in parallel. Making `UnitMatchingParamSet` part of the `UnitMatching` PK allows each (block, paramset) combination to produce independent matching results. However, a global unit represents a physical neuron in a specific subject's brain via a specific probe insertion. Its identity should not depend on how it was discovered. The FK on `GlobalUnit` records which paramset produced the unit for provenance, without fragmenting the global unit namespace.
 
 ### Why `Unit` is a Part of `UnitMatching` (not `GlobalUnit`)
 

--- a/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
+++ b/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
@@ -396,7 +396,6 @@ Duplicates cause incorrect downstream analysis: inflated spike counts, artificia
 
 **Rule: for each `(global_unit, chunk)` pair, the first block (in processing order) to write a `Spikes` row wins. Later blocks skip that pair.**
 
-Since blocks are processed in temporal order, "first to process" = "earlier block" for chunks in the overlap region.
 
 Implementation in `UnitMatching.make()`:
 

--- a/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
+++ b/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
@@ -136,13 +136,14 @@ EphysEpoch (Imported)
 
 1. **Discover probes** from epoch directory files (probe serial + probe_type are available from files).
 2. **Auto-create `Probe` entries** (serial + type) — idempotent, since probe_type is now discoverable from files.
-3. **Read subject-probe mapping** from one of two sources:
+3. **Read subject-probe mapping** (**not yet implemented** — placeholder raises `NotImplementedError`). The intended design is:
    - **Per-epoch file** (e.g., `probe_assignments.json` in epoch directory): Contains `{probe_label: {probe: serial, subject: name, ...}}` mapping.
    - **Carry-forward**: If no file exists, reuse the mapping from the most recent `EphysEpoch` that had one. The first epoch with ephys data MUST have the file (no previous to carry forward from).
+   - The exact file format and carry-forward logic will be determined once the experimental data conventions are finalized.
 4. **Create `ProbeInsertion` entries** (with subject) — idempotent. If a probe-swap is detected (same probe, different subject), a new ProbeInsertion is created.
 5. **Insert `EphysEpoch.Insertion`** Part rows recording which ProbeInsertions are active in this epoch with their file labels.
 
-**Carry-forward semantics** for probe-swap detection:
+**Carry-forward semantics** (planned, not yet implemented) for probe-swap detection:
 
 ```
 Epoch 1: probe_assignments.json found

--- a/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
+++ b/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
@@ -169,11 +169,11 @@ The current (and only) matching method uses SpikeInterface's `compare_two_sorter
 
 6. **Update electrode** on existing `GlobalUnit` entries for matched units (overwrite with this session's peak electrode — latest session = best estimate).
 
-7. **Insert `UnitMatching.Unit`** entries linking each session unit to its global unit.
+7. **Insert `UnitMatching`** master entry with execution metadata. (Master must exist before Part inserts.)
 
-8. **Insert `UnitMatching.Spikes`** entries following the ownership convention (see next section).
+8. **Insert `UnitMatching.Unit`** entries linking each session unit to its global unit.
 
-9. **Insert `UnitMatching`** master entry with execution metadata.
+9. **Insert `UnitMatching.Spikes`** entries following the ownership convention (see next section).
 
 #### Parameters
 

--- a/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
+++ b/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
@@ -2,13 +2,14 @@
 
 ## Table of Contents
 1. [Overview](#overview)
-2. [Database Schema](#database-schema)
-3. [Algorithm](#algorithm)
-4. [Ownership Convention for Overlapping Chunks](#ownership-convention-for-overlapping-chunks)
-5. [Integration with Existing Pipeline](#integration-with-existing-pipeline)
-6. [Re-processing and Deletion](#re-processing-and-deletion)
-7. [Query Patterns](#query-patterns)
-8. [Design Decisions and Rationale](#design-decisions-and-rationale)
+2. [Upstream Schema Changes](#upstream-schema-changes)
+3. [Database Schema](#database-schema)
+4. [Algorithm](#algorithm)
+5. [Ownership Convention for Overlapping Chunks](#ownership-convention-for-overlapping-chunks)
+6. [Integration with Existing Pipeline](#integration-with-existing-pipeline)
+7. [Re-processing and Deletion](#re-processing-and-deletion)
+8. [Query Patterns](#query-patterns)
+9. [Design Decisions and Rationale](#design-decisions-and-rationale)
 
 ---
 
@@ -34,7 +35,7 @@ Specifically, `UnitMatching.key_source` requires that `ApplyOfficialCuration` ex
 
 ### Key Concepts
 
-A **global unit** is a persistent neuron identity scoped to a single probe insertion (i.e., one physical probe in one experiment). Global unit IDs are integers starting at 1, unique within a `(experiment_name, insertion_number)` scope.
+A **global unit** is a persistent neuron identity scoped to a single probe insertion (i.e., one physical probe in one subject in one experiment). Global unit IDs are integers starting at 1, unique within a `(experiment_name, subject, insertion_number)` scope.
 
 A **matched unit** links a block-specific `SortedSpikes.Unit` to its assigned global unit. Each block's unit maps to exactly one global unit. A global unit may be matched to units from multiple blocks (that's the whole point).
 
@@ -57,7 +58,7 @@ This constraint is enforced at two levels:
 eligible = SyncedSpikes & spike_sorting_curation.ApplyOfficialCuration
 candidates = eligible - self
 next_per_insertion = dj.U(
-    "experiment_name", "insertion_number"
+    "experiment_name", "subject", "insertion_number"
 ).aggr(candidates, next_start="MIN(block_start)")
 return candidates * next_per_insertion & "block_start = next_start"
 ```
@@ -71,6 +72,176 @@ if unprocessed_earlier:
 ```
 
 **Interaction with `reserve_jobs=True`**: When Worker A reserves the earliest block for insertion I1, Worker B's `key_source` also returns that same block (it's not yet in `self`). But the job reservation system prevents B from reserving the already-reserved key. With no other candidates for I1, Worker B idles or processes a different insertion. When A finishes, the next `populate()` cycle advances to the next block.
+
+---
+
+## Upstream Schema Changes
+
+This section documents design changes to the `ephys` module tables that support the unit matching system and the broader ephys pipeline. These changes are proposed as part of the same design effort and should be implemented together.
+
+### ProbeInsertion: Subject Restored to PK
+
+**Change**: `subject` is restored to the `ProbeInsertion` primary key.
+
+**Before** (upstream v2):
+```
+ProbeInsertion (Manual)
+    -> acquisition.Experiment              # experiment_name
+    insertion_number: int
+    ---
+    -> Probe
+    probe_label: varchar(32)
+    implantation_date=null: datetime(6)
+```
+
+**After** (proposed):
+```
+ProbeInsertion (Manual)
+    -> acquisition.Experiment              # experiment_name
+    -> acquisition.Experiment.Subject      # subject
+    insertion_number: int                  # unique per (experiment, subject)
+    ---
+    -> Probe
+    implantation_date=null: datetime(6)
+```
+
+**Rationale**: A ProbeInsertion models a *surgical event* — a specific probe implanted into a specific subject's brain. The subject is a natural part of this identity, not an afterthought:
+
+- **Probe swaps are correctly modeled**: The same physical probe moved from Subject1 to Subject2 creates two distinct ProbeInsertion rows, each with its own GlobalUnit lineage. These are different neuron populations in different brains — they must not share a global unit namespace.
+- **Subject is structurally required**: With subject in the PK, every downstream row (EphysChunk, EphysBlock, GlobalUnit, Spikes) carries subject identity. No extra joins needed. With subject as a separate FK (the v2 approach via `EphysSubject`), an unfilled Manual table silently breaks every subject-based query.
+- **The information is always available**: Probe implantation is a planned surgical procedure. The experimenter always knows which subject carries which probe before recording begins.
+- **`probe_label` moves off ProbeInsertion**: The file label (e.g., "ProbeA") is an epoch-level detail determined by hardware port assignment, not a property of the surgical event. It moves to `EphysEpoch.Insertion` (see below).
+
+**Eliminated table**: `EphysSubject` is no longer needed and is removed.
+
+### EphysEpoch: Per-Epoch Probe Registry
+
+**Change**: `EphysEpoch` is redesigned from a probe auto-creator to a per-epoch probe registry. It discovers probes in each epoch's files, reads subject-probe mapping (from file or carry-forward), and records which ProbeInsertions are active in each epoch.
+
+```
+EphysEpoch (Imported)
+    -> acquisition.Epoch                   # experiment_name, epoch_start
+    ---
+    has_ephys: bool                        # whether ephys data was found in this epoch
+    n_probes: int                          # number of probes discovered (0 if no ephys)
+
+    EphysEpoch.Insertion (Part)
+        -> master
+        -> ProbeInsertion                  # which insertion is active in this epoch
+        ---
+        probe_label: varchar(32)           # file label discovered from this epoch's files (e.g., "ProbeA")
+```
+
+**EphysEpoch.make() responsibilities**:
+
+1. **Discover probes** from epoch directory files (probe serial + probe_type are available from files).
+2. **Auto-create `Probe` entries** (serial + type) — idempotent, since probe_type is now discoverable from files.
+3. **Read subject-probe mapping** from one of two sources:
+   - **Per-epoch file** (e.g., `probe_assignments.json` in epoch directory): Contains `{probe_label: {probe: serial, subject: name, ...}}` mapping.
+   - **Carry-forward**: If no file exists, reuse the mapping from the most recent `EphysEpoch` that had one. The first epoch with ephys data MUST have the file (no previous to carry forward from).
+4. **Create `ProbeInsertion` entries** (with subject) — idempotent. If a probe-swap is detected (same probe, different subject), a new ProbeInsertion is created.
+5. **Insert `EphysEpoch.Insertion`** Part rows recording which ProbeInsertions are active in this epoch with their file labels.
+
+**Carry-forward semantics** for probe-swap detection:
+
+```
+Epoch 1: probe_assignments.json found
+  → ProbeA: Subject1, serial 12345
+  → Inserts ProbeInsertion(exp, Subject1, 1, probe=12345)
+  → EphysEpoch.Insertion: {(exp, Subject1, 1): probe_label="ProbeA"}
+
+Epoch 2: no file
+  → Carries forward from Epoch 1
+  → EphysEpoch.Insertion: same as Epoch 1
+
+Epoch 3: probe_assignments.json found (PROBE SWAP)
+  → ProbeA: Subject2, serial 12345  ← different subject!
+  → Inserts NEW ProbeInsertion(exp, Subject2, 1, probe=12345)
+  → EphysEpoch.Insertion: {(exp, Subject2, 1): probe_label="ProbeA"}
+```
+
+**Manual alternative**: Users may also insert `ProbeInsertion` rows directly (e.g., at surgery time). If `EphysEpoch.make()` finds an existing ProbeInsertion matching the discovered probe serial, it validates and links to it rather than creating a new one.
+
+### EphysChunk: Epoch FK Added
+
+**Change**: `EphysChunk` gains a FK to `EphysEpoch`, explicitly recording which epoch each chunk came from.
+
+**Before**:
+```
+EphysChunk (Manual)
+    -> ProbeInsertion
+    chunk_start: datetime(6)
+    ---
+    chunk_end: datetime(6)
+    -> ElectrodeConfig
+```
+
+**After**:
+```
+EphysChunk (Manual)
+    -> ProbeInsertion                      # (experiment_name, subject, insertion_number)
+    chunk_start: datetime(6)
+    ---
+    -> EphysEpoch                          # adds epoch_start — "this chunk came from this epoch"
+    chunk_end: datetime(6)
+    -> ElectrodeConfig
+```
+
+**Rationale**:
+
+- **Traceability**: Given any chunk, trace back to its epoch → EphysEpoch.Insertion → the exact subject-probe mapping active at that time.
+- **Probe-swap correctness**: Two chunks from the same physical probe but different epochs can point to different ProbeInsertions (different subjects) — the epoch FK disambiguates.
+- **Structural dependency**: EphysEpoch must process an epoch before ingest_chunks can create chunks for it. This enforces the correct ordering: subject-probe mapping must be established before data ingestion.
+
+### ingest_chunks: Epoch-Aware with Subject Guard
+
+**Change**: `ingest_chunks()` is restructured to process files epoch-aware, using `EphysEpoch.Insertion` to resolve which ProbeInsertion each file belongs to.
+
+**Revised flow**:
+
+1. **Discover files** via rglob across the raw data directory (unchanged — still real-time, chunk-by-chunk).
+2. **For each file**, determine its epoch from the directory path (epoch directory is encoded in the file path).
+3. **Look up `EphysEpoch.Insertion`** for that epoch + probe_label to get the correct ProbeInsertion (with subject).
+4. **If no `EphysEpoch.Insertion` found** → warn and skip:
+   ```
+   "Skipping {file}: no subject-probe mapping for ProbeA in epoch {epoch_start}.
+    Register via probe_assignments.json or manual ProbeInsertion insert,
+    then run EphysEpoch.populate()."
+   ```
+5. **If found** → insert EphysChunk with the epoch_start FK and the resolved ProbeInsertion key.
+
+**Real-time compatibility**: This flow does NOT wait for epochs to end. As soon as an epoch starts and `EphysEpoch.make()` runs (which only needs the epoch directory and `Metadata.yml` to exist, not any chunk files), the subject-probe mapping is established. Subsequent chunk files are ingested as they arrive.
+
+### InsertionTargetArea: Subject in PK
+
+`InsertionTargetArea` inherits the subject PK change from ProbeInsertion — no other structural changes needed.
+
+### Summary of Upstream Changes
+
+| Table | Change | Impact |
+|-------|--------|--------|
+| `ProbeInsertion` | `subject` restored to PK; `probe_label` removed | Subject in every downstream PK |
+| `EphysSubject` | **Eliminated** | No longer needed |
+| `EphysEpoch` | Redesigned: per-epoch probe registry with `.Insertion` Part | Reads subject-probe mapping, carry-forward semantics |
+| `EphysChunk` | FK to `EphysEpoch` added | Epoch traceability, probe-swap correctness |
+| `ingest_chunks()` | Epoch-aware file routing with subject guard | Skips files without subject-probe mapping |
+| `EphysBlock` | Inherits subject from ProbeInsertion PK | No structural change needed |
+| `EphysBlockInfo` | Inherits subject from ProbeInsertion PK | No structural change needed |
+
+### PK Cascade
+
+With subject restored, the full PK chain is:
+
+```
+ProbeInsertion: (experiment_name, subject, insertion_number)
+  → EphysChunk: (experiment_name, subject, insertion_number, chunk_start)
+  → EphysBlock: (experiment_name, subject, insertion_number, block_start, block_end)
+    → EphysBlockInfo
+    → SortingTask: + (probe_type, electrode_config_name, electrode_group, sorting_method, paramset_id)
+      → PreProcessing → SpikeSorting → PostProcessing → SortedSpikes → SyncedSpikes
+        → UnitMatching
+          → GlobalUnit: (experiment_name, subject, insertion_number, global_unit)
+```
 
 ---
 
@@ -95,24 +266,24 @@ UnitMatching (Computed)
         -> master
         -> SortedSpikes.Unit                # adds `unit` to PK
         ---
-        -> GlobalUnit                    # global_unit as dependent FK
+        -> GlobalUnit                       # global_unit as dependent FK
         match_confidence=null: float
         match_comment='': varchar(1000)
 
     UnitMatching.Spikes (Part)
         -> master
-        -> GlobalUnit                    # adds global_unit to PK
+        -> GlobalUnit                       # adds global_unit to PK
         -> ephys.EphysChunk                 # adds chunk_start to PK
         ---
         spike_times: longblob               # datetime64[ns] (UTC), HARP-synced — same format as SyncedSpikes.Unit
         spike_count: int
-        unique index (experiment_name, insertion_number, global_unit, chunk_start)  # schema-enforced: one row per (insertion, unit, chunk)
+        unique index (experiment_name, subject, insertion_number, global_unit, chunk_start)
 
 GlobalUnit (Manual)
-    -> ephys.ProbeInsertion                 # experiment_name, insertion_number
-    global_unit: int                     # unique ID within this insertion
+    -> ephys.ProbeInsertion                 # experiment_name, subject, insertion_number
+    global_unit: int                        # unique ID within this insertion
     ---
-    -> ephys.ProbeType.Electrode      # peak electrode (denormalized, updated each block)
+    -> ephys.ProbeType.Electrode            # peak electrode (denormalized, updated each block)
     global_unit_comment='': varchar(1000)
 ```
 
@@ -121,6 +292,7 @@ GlobalUnit (Manual)
 ```mermaid
 erDiagram
     SyncedSpikes ||--o| UnitMatching : "populates"
+    UnitMatchingMethod ||--o| UnitMatching : "FK (matching_method)"
     UnitMatching ||--o{ "UnitMatching.Unit" : "part"
     UnitMatching ||--o{ "UnitMatching.Spikes" : "part"
     "SortedSpikes.Unit" ||--o| "UnitMatching.Unit" : "FK (unit)"
@@ -129,6 +301,9 @@ erDiagram
     "ephys.EphysChunk" ||--o{ "UnitMatching.Spikes" : "FK (chunk_start)"
     "ephys.ProbeType.Electrode" ||--o{ GlobalUnit : "FK (electrode)"
     "ephys.ProbeInsertion" ||--|| GlobalUnit : "scopes"
+    "ephys.EphysEpoch" ||--o{ "ephys.EphysChunk" : "FK (epoch_start)"
+    "ephys.EphysEpoch" ||--o{ "EphysEpoch.Insertion" : "part"
+    "ephys.ProbeInsertion" ||--o{ "EphysEpoch.Insertion" : "FK"
 ```
 
 ### Design Notes
@@ -137,7 +312,7 @@ erDiagram
 
 - **`GlobalUnit` is Manual with denormalized electrode**: Populated programmatically by `UnitMatching.make()`, not by DataJoint's `populate()` machinery. This means it cannot be auto-cleared. Orphaned entries (those with no remaining `Unit` references) must be cleaned up explicitly during re-processing. The peak `electrode` is denormalized from `SortedSpikes.Unit` and stored directly on `GlobalUnit`. It is updated each time a new block is matched (latest block = best estimate of the unit's electrode position). This enables a clean unit roster query — `GlobalUnit & insertion_key` returns one row per unit with its electrode, no joins required.
 
-- **`unique index` on `Spikes`**: The Part table PK includes the master's block key, so the same `(global_unit, chunk_start)` from different blocks would be valid at the PK level. The unique index on `(experiment_name, insertion_number, global_unit, chunk_start)` provides a schema-level guarantee that only one block can own a given (insertion, unit, chunk) pair. The index is scoped per-insertion because `global_unit` IDs are only unique within an insertion — two insertions in the same experiment can both have `global_unit=1`.
+- **`unique index` on `Spikes`**: The Part table PK includes the master's block key, so the same `(global_unit, chunk_start)` from different blocks would be valid at the PK level. The unique index on `(experiment_name, subject, insertion_number, global_unit, chunk_start)` provides a schema-level guarantee that only one block can own a given (insertion, unit, chunk) pair. The index is scoped per-insertion because `global_unit` IDs are only unique within an insertion — two insertions in the same experiment can both have `global_unit=1`.
 
 - **`UnitMatching.Unit` references `SortedSpikes.Unit` via formal FK**: This enforces referential integrity (cannot match a non-existent unit). Since `UnitMatching` sits downstream of `SortedSpikes` in the pipeline, and curation cleanup deletes `UnitMatching` before `SortedSpikes`, cascade ordering is correct.
 
@@ -153,7 +328,7 @@ The current (and only) matching method uses SpikeInterface's `compare_two_sorter
 
 1. **Load this block's synced spike times** from `SyncedSpikes.Unit`. Concatenate across chunks per unit. Convert `datetime64[ns]` to epoch seconds for the overlap comparison and SpikeInterface compatibility.
 
-2. **Find overlapping previous blocks**: Query all previously-completed `UnitMatching` entries for the same `(experiment_name, insertion_number)`. Filter to those whose `(block_start, block_end)` overlaps with this block's time range.
+2. **Find overlapping previous blocks**: Query all previously-completed `UnitMatching` entries for the same `(experiment_name, subject, insertion_number)`. Filter to those whose `(block_start, block_end)` overlaps with this block's time range.
 
 3. **For each overlapping previous block**:
    a. Load the previous block's synced spike times (same format).
@@ -223,7 +398,7 @@ for gu_id in this_block_global_units:
 
 After all blocks are processed, each `(global_unit, chunk_start)` pair appears in **at most one** `UnitMatching.Spikes` row across all blocks. This invariant is enforced at two levels:
 
-1. **Schema-level**: A `unique index (experiment_name, insertion_number, global_unit, chunk_start)` on `Spikes` guarantees that the database rejects any duplicate per-insertion `(global_unit, chunk_start)` insertion, regardless of which block attempts it. The index is scoped per-insertion because `global_unit` IDs are only unique within an insertion. A later block trying to write an already-owned pair will raise an `IntegrityError`.
+1. **Schema-level**: A `unique index (experiment_name, subject, insertion_number, global_unit, chunk_start)` on `Spikes` guarantees that the database rejects any duplicate per-insertion `(global_unit, chunk_start)` insertion, regardless of which block attempts it. The index is scoped per-insertion because `global_unit` IDs are only unique within an insertion. A later block trying to write an already-owned pair will raise an `IntegrityError`.
 
 2. **Code-level**: The `make()` method checks for existing rows before inserting, skipping already-owned pairs. This prevents the `IntegrityError` from ever being raised during normal operation and provides clear logging of skipped chunks.
 
@@ -231,24 +406,51 @@ After all blocks are processed, each `(global_unit, chunk_start)` pair appears i
 
 ## Integration with Existing Pipeline
 
-### Pipeline Position
+### Full Pipeline Position
 
 ```
-SortingTask (Manual)
-  → PreProcessing (Computed)
-    → SpikeSorting (Computed)
-      → PostProcessing (Computed)
-        → SIExport (Computed)
-        → SortedSpikes (Imported)
-          → Waveform (Imported)
-          → SortingQuality (Imported)
-          → SyncedSpikes (Imported)
-            → UnitMatching (Computed)     ← NEW
-              ├─ .Unit (Part)             ← NEW
-              └─ .Spikes (Part)← NEW
+Epoch (Manual)
+  → EphysEpoch (Imported)                     ← REDESIGNED
+    ├─ .Insertion (Part)                       ← NEW: per-epoch active ProbeInsertions
+    └─ Probe (Lookup, auto-created)
 
-GlobalUnit (Manual)                    ← NEW (populated by UnitMatching.make())
+ProbeInsertion (Manual)                        ← CHANGED: subject in PK, probe_label removed
+  → EphysChunk (Manual, via ingest_chunks)     ← CHANGED: FK to EphysEpoch
+    → EphysBlock (Manual)
+      → EphysBlockInfo (Imported)
+        → SortingTask (Manual)
+          → PreProcessing (Computed)
+            → SpikeSorting (Computed)
+              → PostProcessing (Computed)
+                → SIExport (Computed)
+                → SortedSpikes (Imported)
+                  → Waveform (Imported)
+                  → SortingQuality (Imported)
+                  → SyncedSpikes (Imported)
+                    → UnitMatching (Computed)
+                      ├─ .Unit (Part)
+                      └─ .Spikes (Part)
+
+GlobalUnit (Manual, populated by UnitMatching.make())
 ```
+
+### Ingestion Flow
+
+```
+Manual (one-time, at surgery time):
+  1. Probe entries           ← OR auto-created by EphysEpoch from files
+  2. ProbeInsertion          ← OR auto-created by EphysEpoch from probe_assignments file
+
+Automated pipeline (real-time):
+  3. Epoch.ingest_epochs()         → discover epoch directories
+  4. EphysEpoch.populate()         → discover probes, read subject-probe mapping, carry forward
+  5. EphysChunk.ingest_chunks()    → process binary files (guarded: skips if no subject-probe mapping)
+  6. EphysBlock (manual)           → user defines block boundaries
+  7. EphysBlockInfo.populate()     → compute block metadata
+  8. SortingTask → ... → UnitMatching.populate()  → spike sorting + unit matching
+```
+
+Steps 3-5 can run continuously as data arrives. Step 4 only needs the epoch directory to exist (not any chunk files). Step 5 processes chunk files as they appear, consulting step 4's output for the correct ProbeInsertion.
 
 ### Curation Gate
 
@@ -308,13 +510,21 @@ The primary query interface is designed around a natural workflow: start from an
 ### Unit roster: all global units for an insertion (with electrode)
 
 ```python
-insertion_key = {"experiment_name": "exp02", "insertion_number": 1}
+insertion_key = {"experiment_name": "exp02", "subject": "BAA-1104545", "insertion_number": 1}
 
 # One row per global unit, with electrode — the primary entry point
 GlobalUnit & insertion_key
 ```
 
-Returns `(experiment_name, insertion_number, global_unit, probe_type, electrode)` — one row per unit. No joins needed.
+Returns `(experiment_name, subject, insertion_number, global_unit, probe_type, electrode)` — one row per unit. No joins needed. Subject is directly in the result.
+
+### All global units for a subject across insertions
+
+```python
+GlobalUnit & {"subject": "BAA-1104545"}
+```
+
+No join through a separate EphysSubject table — subject is in the PK.
 
 ### Spike times for a unit across all time
 
@@ -371,9 +581,51 @@ SyncedSpikes.Unit * UnitMatching.Unit & insertion_key & {"global_unit": 5}
 
 Returns per-block per-chunk spike times with global unit labels. Overlap chunks appear with multiple rows (one per block). Use `UnitMatching.Spikes` for the deduplicated version.
 
+### Trace a chunk back to its epoch and subject-probe mapping
+
+```python
+# Given a chunk, find the epoch it came from and the active probe assignment
+chunk_key = {"experiment_name": "exp02", "subject": "BAA-1104545",
+             "insertion_number": 1, "chunk_start": chunk_ts}
+epoch_start = (ephys.EphysChunk & chunk_key).fetch1("epoch_start")
+ephys.EphysEpoch.Insertion & {"epoch_start": epoch_start} & chunk_key
+```
+
 ---
 
 ## Design Decisions and Rationale
+
+### Why Subject Belongs in ProbeInsertion PK
+
+**Decision**: `subject` is a primary key field of `ProbeInsertion`, cascading to all downstream tables.
+
+**Rationale**: A ProbeInsertion is a surgical event: a specific probe implanted into a specific subject's brain. The alternative (subject as a separate FK in `EphysSubject`) was motivated by an ingestion constraint — raw files don't encode which subject carries which probe. However:
+
+1. **The experimenter always knows** which subject has which probe. This information is available at surgery time, well before ingestion.
+2. **Probe swaps break the no-subject model**: If the same physical probe is moved from Subject1 to Subject2, the no-subject design creates a single ProbeInsertion shared by both subjects — mixing neurons from different brains into one GlobalUnit lineage. With subject in PK, two distinct insertions are created automatically.
+3. **EphysSubject (Manual) is fragile**: Being Manual with no enforcement, it can be left empty, silently breaking every subject-based query downstream.
+4. **Every consumer needs subject**: Neural analysis correlates spikes with behavior. Subject identity is needed at every analysis boundary. Having it in the PK eliminates a join from every query.
+
+The operational cost is small: subject-probe association must be provided (via file or manual entry) before ingestion. This is a reasonable requirement given that probe surgery is a planned procedure.
+
+### Why `probe_label` Moves to EphysEpoch.Insertion
+
+**Decision**: `probe_label` (e.g., "ProbeA") is stored per-epoch on `EphysEpoch.Insertion`, not on `ProbeInsertion`.
+
+**Rationale**: The probe_label is a file-system naming convention determined by hardware port assignment (which port the probe is plugged into). It is:
+- **Not a property of the surgical event**: The same insertion could appear as "ProbeA" in one epoch and theoretically a different label if hardware is reconfigured.
+- **An epoch-level detail**: It's used by `ingest_chunks()` to match files to ProbeInsertions, and this matching happens per-epoch.
+- **Discoverable from files**: The label is parsed from filenames (e.g., `NeuropixelsV2Beta_ProbeA_AmplifierData_0.bin`).
+
+### Why EphysChunk Has an Epoch FK
+
+**Decision**: `EphysChunk` references `EphysEpoch` via `epoch_start` as a non-PK FK.
+
+**Rationale**:
+- **Traceability**: Given any chunk, you can trace back to its epoch and from there to the subject-probe mapping that was active.
+- **Probe-swap correctness**: The epoch FK disambiguates which ProbeInsertion a chunk belongs to when a probe is swapped between subjects across epochs.
+- **Dependency enforcement**: EphysEpoch must be populated (subject-probe mapping established) before chunks can be created for that epoch. This is the correct ordering.
+- **Real-time compatible**: The FK references `epoch_start`, not `epoch_end`. As soon as an epoch begins and EphysEpoch runs (Metadata.yml exists immediately), the mapping is established. Chunks are ingested as they arrive — no waiting for the epoch to end.
 
 ### Why `UnitMatchingMethod` is a non-PK FK
 
@@ -394,7 +646,7 @@ Returns per-block per-chunk spike times with global unit labels. Overlap chunks 
 **Alternatives considered**:
 - **Standalone Computed keyed on `(GlobalUnit, EphysChunk)`**: Clean one-row-per-pair semantics, but the cartesian `key_source` (all units x all chunks) is prohibitively large. A restricted `key_source` is complex to express correctly.
 - **No table at all** (use `SyncedSpikes.Unit * UnitMatching.Unit` join): Simplest schema, but overlap chunks produce duplicate rows. Every downstream analysis must implement deduplication.
-- **Part of `UnitMatching`** with ownership convention: Avoids cartesian explosion (scoped to block's chunks). Ownership convention guarantees at most one row per (unit, chunk), enforced by a `unique index (experiment_name, insertion_number, global_unit, chunk_start)` at the schema level. Lifecycle managed by cascade.
+- **Part of `UnitMatching`** with ownership convention: Avoids cartesian explosion (scoped to block's chunks). Ownership convention guarantees at most one row per (unit, chunk), enforced by a `unique index (experiment_name, subject, insertion_number, global_unit, chunk_start)` at the schema level. Lifecycle managed by cascade.
 
 The Part table approach was chosen because it provides pre-materialized, deduplicated spike times (the primary analysis output) while keeping the scope naturally bounded per block.
 

--- a/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
+++ b/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
@@ -40,7 +40,7 @@ A **matched unit** links a session-specific `SortedSpikes.Unit` to its assigned 
 
 **Temporal overlap** between consecutive ephys blocks is the mechanism that enables matching. The overlap region contains spikes from the same neurons captured by both blocks' independent sorting runs. The matching algorithm compares spike times in this overlap window to identify corresponding units.
 
-The **ownership convention** determines which session "owns" the spike data for a given (universal_unit, chunk) pair when multiple sessions cover the same chunk. This prevents duplicate rows in `ChunkedSpikeTimes`.
+The **ownership convention** determines which session "owns" the spike data for a given (universal_unit, chunk) pair when multiple sessions cover the same chunk. This prevents duplicate rows in `Spikes`.
 
 ### Critical Constraint: Temporal Ordering
 
@@ -91,15 +91,16 @@ UnitMatching (Computed)
     execution_time: datetime
     execution_duration: float               # hours
 
-    UnitMatching.Matched (Part)
+    UnitMatching.Unit (Part)
         -> master
         -> SortedSpikes.Unit                # adds `unit` to PK
         ---
         -> UniversalUnit                    # universal_unit as dependent FK
+        -> ephys.ElectrodeConfig.Electrode  # peak electrode (denormalized from SortedSpikes.Unit)
         match_confidence=null: float
         match_comment='': varchar(1000)
 
-    UnitMatching.ChunkedSpikeTimes (Part)
+    UnitMatching.Spikes (Part)
         -> master
         -> UniversalUnit                    # adds universal_unit to PK
         -> ephys.EphysChunk                 # adds chunk_start to PK
@@ -120,12 +121,12 @@ UniversalUnit (Manual)
 ```mermaid
 erDiagram
     SyncedSpikes ||--o| UnitMatching : "populates"
-    UnitMatching ||--o{ "UnitMatching.Matched" : "part"
-    UnitMatching ||--o{ "UnitMatching.ChunkedSpikeTimes" : "part"
-    "SortedSpikes.Unit" ||--o| "UnitMatching.Matched" : "FK (unit)"
-    UniversalUnit ||--o{ "UnitMatching.Matched" : "FK (universal_unit)"
-    UniversalUnit ||--o{ "UnitMatching.ChunkedSpikeTimes" : "FK (universal_unit)"
-    "ephys.EphysChunk" ||--o{ "UnitMatching.ChunkedSpikeTimes" : "FK (chunk_start)"
+    UnitMatching ||--o{ "UnitMatching.Unit" : "part"
+    UnitMatching ||--o{ "UnitMatching.Spikes" : "part"
+    "SortedSpikes.Unit" ||--o| "UnitMatching.Unit" : "FK (unit)"
+    UniversalUnit ||--o{ "UnitMatching.Unit" : "FK (universal_unit)"
+    UniversalUnit ||--o{ "UnitMatching.Spikes" : "FK (universal_unit)"
+    "ephys.EphysChunk" ||--o{ "UnitMatching.Spikes" : "FK (chunk_start)"
     "ephys.ProbeInsertion" ||--|| UniversalUnit : "scopes"
 ```
 
@@ -133,11 +134,11 @@ erDiagram
 
 - **`UnitMatchingMethod` as non-PK FK**: Only one matching result per session. The method is recorded for provenance but does not multiply the key space. This means one canonical set of universal units per insertion — no parallel method comparison. This is a deliberate simplification; if method comparison becomes needed, it can be added later by promoting the FK back to PK.
 
-- **`UniversalUnit` is Manual**: Populated programmatically by `UnitMatching.make()`, not by DataJoint's `populate()` machinery. This means it cannot be auto-cleared. Orphaned entries (those with no remaining `Matched` references) must be cleaned up explicitly during re-processing.
+- **`UniversalUnit` is Manual**: Populated programmatically by `UnitMatching.make()`, not by DataJoint's `populate()` machinery. This means it cannot be auto-cleared. Orphaned entries (those with no remaining `Unit` references) must be cleaned up explicitly during re-processing.
 
-- **`unique index` on `ChunkedSpikeTimes`**: The Part table PK includes the master's session key, so the same `(universal_unit, chunk_start)` from different sessions would be valid at the PK level. The unique index on `(experiment_name, subject, insertion_number, universal_unit, chunk_start)` provides a schema-level guarantee that only one session can own a given (insertion, unit, chunk) pair. The index is scoped per-insertion because `universal_unit` IDs are only unique within an insertion — two insertions for the same subject can both have `universal_unit=1`.
+- **`unique index` on `Spikes`**: The Part table PK includes the master's session key, so the same `(universal_unit, chunk_start)` from different sessions would be valid at the PK level. The unique index on `(experiment_name, subject, insertion_number, universal_unit, chunk_start)` provides a schema-level guarantee that only one session can own a given (insertion, unit, chunk) pair. The index is scoped per-insertion because `universal_unit` IDs are only unique within an insertion — two insertions for the same subject can both have `universal_unit=1`.
 
-- **`UnitMatching.Matched` references `SortedSpikes.Unit` via formal FK**: This enforces referential integrity (can't match a non-existent unit). Since `UnitMatching` sits downstream of `SortedSpikes` in the pipeline, and curation cleanup deletes `UnitMatching` before `SortedSpikes`, cascade ordering is correct.
+- **`UnitMatching.Unit` references `SortedSpikes.Unit` via formal FK**: This enforces referential integrity (can't match a non-existent unit). Since `UnitMatching` sits downstream of `SortedSpikes` in the pipeline, and curation cleanup deletes `UnitMatching` before `SortedSpikes`, cascade ordering is correct. The peak `electrode` is denormalized from `SortedSpikes.Unit` for query convenience — users can get unit identity, universal unit assignment, and electrode location without joining back through the sorting chain.
 
 ---
 
@@ -159,15 +160,15 @@ The current (and only) matching method uses SpikeInterface's `compare_two_sorter
    c. Restrict both sessions' spike times to the overlap window, converting to relative times (seconds from overlap start).
    d. Convert to sample indices at 30 kHz and build `NumpySorting` objects.
    e. Run `compare_two_sorters(delta_time=0.4)` (0.4 ms coincidence window).
-   f. Extract matched pairs. For each match, look up the previous session's unit's `universal_unit` assignment (via `UnitMatching.Matched`). Assign this session's unit to the same universal unit.
+   f. Extract matched pairs. For each match, look up the previous session's unit's `universal_unit` assignment (via `UnitMatching.Unit`). Assign this session's unit to the same universal unit.
 
 4. **Assign new universal units** for unmatched units: find the current maximum `universal_unit` ID for this insertion, increment sequentially.
 
 5. **Insert `UniversalUnit`** entries for newly created universal units.
 
-6. **Insert `UnitMatching.Matched`** entries linking each session unit to its universal unit.
+6. **Insert `UnitMatching.Unit`** entries linking each session unit to its universal unit.
 
-7. **Insert `UnitMatching.ChunkedSpikeTimes`** entries following the ownership convention (see next section).
+7. **Insert `UnitMatching.Spikes`** entries following the ownership convention (see next section).
 
 8. **Insert `UnitMatching`** master entry with execution metadata.
 
@@ -184,13 +185,13 @@ The current (and only) matching method uses SpikeInterface's `compare_two_sorter
 
 ### Problem
 
-When two ephys blocks overlap in time, the same `EphysChunk` (1-hour raw data segment) is sorted independently by both blocks. For a universal unit present in both blocks, `SyncedSpikes.Unit` contains spike times from both sessions for the overlapping chunks. Without a convention, `ChunkedSpikeTimes` would contain duplicate rows for the same `(universal_unit, chunk)` from different sessions.
+When two ephys blocks overlap in time, the same `EphysChunk` (1-hour raw data segment) is sorted independently by both blocks. For a universal unit present in both blocks, `SyncedSpikes.Unit` contains spike times from both sessions for the overlapping chunks. Without a convention, `Spikes` would contain duplicate rows for the same `(universal_unit, chunk)` from different sessions.
 
 Duplicates cause incorrect downstream analysis: inflated spike counts, artificial short ISIs, and wrong firing rate estimates.
 
 ### Convention: Earlier Session Owns
 
-**Rule: for each `(universal_unit, chunk)` pair, the first session (in processing order) to write a `ChunkedSpikeTimes` row wins. Later sessions skip that pair.**
+**Rule: for each `(universal_unit, chunk)` pair, the first session (in processing order) to write a `Spikes` row wins. Later sessions skip that pair.**
 
 Since sessions are processed in temporal order, "first to process" = "earlier session" for chunks in the overlap region.
 
@@ -200,7 +201,7 @@ Implementation in `UnitMatching.make()`:
 for uu_id in this_session_universal_units:
     for chunk_key in this_session_chunks:
         # Check if ANY session already wrote this (uu, chunk)
-        if self.ChunkedSpikeTimes & {"universal_unit": uu_id, "chunk_start": chunk_key["chunk_start"]}:
+        if self.Spikes & {"universal_unit": uu_id, "chunk_start": chunk_key["chunk_start"]}:
             continue  # earlier session owns it
         # Get synced spikes for this session's unit in this chunk
         # ... insert if spikes exist
@@ -217,9 +218,9 @@ for uu_id in this_session_universal_units:
 
 ### Invariant
 
-After all sessions are processed, each `(universal_unit, chunk_start)` pair appears in **at most one** `UnitMatching.ChunkedSpikeTimes` row across all sessions. This invariant is enforced at two levels:
+After all sessions are processed, each `(universal_unit, chunk_start)` pair appears in **at most one** `UnitMatching.Spikes` row across all sessions. This invariant is enforced at two levels:
 
-1. **Schema-level**: A `unique index (experiment_name, subject, insertion_number, universal_unit, chunk_start)` on `ChunkedSpikeTimes` guarantees that the database rejects any duplicate per-insertion `(universal_unit, chunk_start)` insertion, regardless of which session attempts it. The index is scoped per-insertion because `universal_unit` IDs are only unique within an insertion. A later session trying to write an already-owned pair will raise an `IntegrityError`.
+1. **Schema-level**: A `unique index (experiment_name, subject, insertion_number, universal_unit, chunk_start)` on `Spikes` guarantees that the database rejects any duplicate per-insertion `(universal_unit, chunk_start)` insertion, regardless of which session attempts it. The index is scoped per-insertion because `universal_unit` IDs are only unique within an insertion. A later session trying to write an already-owned pair will raise an `IntegrityError`.
 
 2. **Code-level**: The `make()` method checks for existing rows before inserting, skipping already-owned pairs. This prevents the `IntegrityError` from ever being raised during normal operation and provides clear logging of skipped chunks.
 
@@ -240,8 +241,8 @@ SortingTask (Manual)
           → SortingQuality (Imported)
           → SyncedSpikes (Imported)
             → UnitMatching (Computed)     ← NEW
-              ├─ .Matched (Part)          ← NEW
-              └─ .ChunkedSpikeTimes (Part)← NEW
+              ├─ .Unit (Part)             ← NEW
+              └─ .Spikes (Part)← NEW
 
 UniversalUnit (Manual)                    ← NEW (populated by UnitMatching.make())
 ```
@@ -265,10 +266,10 @@ UniversalUnit (Manual)                    ← NEW (populated by UnitMatching.mak
 
 When a session's curation is changed (via `restore_raw_sorting()` → new curation → `ApplyOfficialCuration`):
 
-1. `restore_raw_sorting()` deletes `UnitMatching` for the session → cascades to `Matched` and `ChunkedSpikeTimes` Part rows for that session.
-2. Orphaned `UniversalUnit` entries (those with no remaining `Matched` references from any session) are explicitly deleted.
+1. `restore_raw_sorting()` deletes `UnitMatching` for the session → cascades to `Unit` and `Spikes` Part rows for that session.
+2. Orphaned `UniversalUnit` entries (those with no remaining `Unit` references from any session) are explicitly deleted.
 3. `SortedSpikes` and downstream tables are deleted and re-populated with the new curation.
-4. `UnitMatching.populate()` re-runs for the session, re-matching and re-writing `ChunkedSpikeTimes`.
+4. `UnitMatching.populate()` re-runs for the session, re-matching and re-writing `Spikes`.
 
 **Important**: Later sessions' `UnitMatching` entries are NOT automatically invalidated. If the re-curation changes which units exist or how they match, downstream sessions may have stale universal unit assignments. In this case, the user should re-run matching for affected downstream sessions as well.
 
@@ -276,11 +277,11 @@ When a session's curation is changed (via `restore_raw_sorting()` → new curati
 
 ```
 Delete UnitMatching entry
-  → Cascades to UnitMatching.Matched (Part)
-  → Cascades to UnitMatching.ChunkedSpikeTimes (Part)
+  → Cascades to UnitMatching.Unit (Part)
+  → Cascades to UnitMatching.Spikes (Part)
 
 Delete SortedSpikes.Unit
-  → Blocked if UnitMatching.Matched references it
+  → Blocked if UnitMatching.Unit references it
   → Solution: delete UnitMatching first (handled by restore_raw_sorting)
 ```
 
@@ -288,12 +289,12 @@ Delete SortedSpikes.Unit
 
 ```
 Step 1: Delete OfficialCuration (cascades to ApplyOfficialCuration)
-Step 2: Delete UnitMatching for this session (cascades to Matched + ChunkedSpikeTimes)
+Step 2: Delete UnitMatching for this session (cascades to Unit + Spikes)
 Step 3: Delete orphaned UniversalUnit entries
 Step 4: Delete SortedSpikes (cascades to Waveform, SortingQuality, SyncedSpikes)
 ```
 
-Note: Step 2 no longer requires `force=True` on Part tables (unlike the previous design where `UniversalUnit.Matched` was a Part of `UniversalUnit` but referenced `SortedSpikes.Unit`). With `Matched` as a Part of `UnitMatching`, deleting `UnitMatching` cleanly cascades.
+Note: Step 2 no longer requires `force=True` on Part tables (unlike the previous design where `UniversalUnit.Matched` was a Part of `UniversalUnit` but referenced `SortedSpikes.Unit`). With `Unit` as a Part of `UnitMatching`, deleting `UnitMatching` cleanly cascades.
 
 ---
 
@@ -302,7 +303,7 @@ Note: Step 2 no longer requires `force=True` on Part tables (unlike the previous
 ### Get all spikes for a universal unit across all time
 
 ```python
-(UnitMatching.ChunkedSpikeTimes & {"universal_unit": 5}).fetch(
+(UnitMatching.Spikes & {"universal_unit": 5}).fetch(
     "chunk_start", "spike_times", "spike_count", order_by="chunk_start"
 )
 ```
@@ -312,22 +313,22 @@ Note: the result includes session key fields (block_start, block_end, etc.) inhe
 ### Get all sessions where a universal unit was observed
 
 ```python
-UnitMatching.Matched & {"universal_unit": 5}
+UnitMatching.Unit & {"universal_unit": 5}
 ```
 
 ### Get universal unit assignments for a specific session
 
 ```python
-UnitMatching.Matched & session_key
+UnitMatching.Unit & session_key
 ```
 
-### Get synced spike times via join (alternative to ChunkedSpikeTimes)
+### Get synced spike times via join (alternative to Spikes)
 
 ```python
-SyncedSpikes.Unit * UnitMatching.Matched & {"universal_unit": 5}
+SyncedSpikes.Unit * UnitMatching.Unit & {"universal_unit": 5}
 ```
 
-This returns per-session per-chunk spike times with universal unit labels. Overlap chunks will appear with multiple rows (one per session). Use `ChunkedSpikeTimes` for the deduplicated version.
+This returns per-session per-chunk spike times with universal unit labels. Overlap chunks will appear with multiple rows (one per session). Use `Spikes` for the deduplicated version.
 
 ### List all universal units for an insertion
 
@@ -345,19 +346,19 @@ UniversalUnit & {"experiment_name": "...", "subject": "...", "insertion_number":
 
 **Rationale**: Making it a PK would mean every downstream query must carry `matching_method`, and universal units would be scoped per-method (allowing parallel sets). In practice, the team settles on one matching method and uses it consistently. The simpler design avoids combinatorial complexity. If method comparison becomes necessary, the FK can be promoted to PK.
 
-### Why `Matched` is a Part of `UnitMatching` (not `UniversalUnit`)
+### Why `Unit` is a Part of `UnitMatching` (not `UniversalUnit`)
 
-**Decision**: `UnitMatching.Matched` instead of `UniversalUnit.Matched`.
+**Decision**: `UnitMatching.Unit` instead of `UniversalUnit.Matched`.
 
-**Rationale**: Part table lifecycle should be governed by the master. `Matched` rows are created and destroyed with their session's `UnitMatching` entry. Placing them under `UniversalUnit` (which has a different lifecycle — it persists across sessions) creates cascade problems: deleting `SortedSpikes.Unit` is blocked by `UniversalUnit.Matched`'s FK, requiring `force=True` hacks. Under `UnitMatching`, the cascade is clean: delete `UnitMatching` → cascades to `Matched` and `ChunkedSpikeTimes`.
+**Rationale**: Part table lifecycle should be governed by the master. `Unit` rows are created and destroyed with their session's `UnitMatching` entry. Placing them under `UniversalUnit` (which has a different lifecycle — it persists across sessions) creates cascade problems: deleting `SortedSpikes.Unit` is blocked by `UniversalUnit.Matched`'s FK, requiring `force=True` hacks. Under `UnitMatching`, the cascade is clean: delete `UnitMatching` → cascades to `Unit` and `Spikes`.
 
-### Why `ChunkedSpikeTimes` is a Part of `UnitMatching` (not standalone)
+### Why `Spikes` is a Part of `UnitMatching` (not standalone)
 
 **Decision**: Part table with ownership convention, not a standalone Computed table.
 
 **Alternatives considered**:
 - **Standalone Computed keyed on `(UniversalUnit, EphysChunk)`**: Clean one-row-per-pair semantics, but the cartesian `key_source` (all units x all chunks) is prohibitively large. A restricted `key_source` is complex to express correctly.
-- **No table at all** (use `SyncedSpikes.Unit * UnitMatching.Matched` join): Simplest schema, but overlap chunks produce duplicate rows. Every downstream analysis must implement deduplication.
+- **No table at all** (use `SyncedSpikes.Unit * UnitMatching.Unit` join): Simplest schema, but overlap chunks produce duplicate rows. Every downstream analysis must implement deduplication.
 - **Part of `UnitMatching`** with ownership convention: Avoids cartesian explosion (scoped to session's chunks). Ownership convention guarantees at most one row per (unit, chunk), enforced by a `unique index (experiment_name, subject, insertion_number, universal_unit, chunk_start)` at the schema level. Lifecycle managed by cascade.
 
 The Part table approach was chosen because it provides pre-materialized, deduplicated spike times (the primary analysis output) while keeping the scope naturally bounded per session.

--- a/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
+++ b/aeon/dj_pipeline/docs/specs/SPEC_unit_matching.md
@@ -1,0 +1,345 @@
+# Unit Matching Specifications
+
+## Table of Contents
+1. [Overview](#overview)
+2. [Database Schema](#database-schema)
+3. [Algorithm](#algorithm)
+4. [Ownership Convention for Overlapping Chunks](#ownership-convention-for-overlapping-chunks)
+5. [Integration with Existing Pipeline](#integration-with-existing-pipeline)
+6. [Re-processing and Deletion](#re-processing-and-deletion)
+7. [Query Patterns](#query-patterns)
+8. [Design Decisions and Rationale](#design-decisions-and-rationale)
+
+---
+
+## Overview
+
+### Purpose
+
+Long-running AEON experiments record neural activity across multiple consecutive ephys blocks (sessions), each independently spike-sorted. The same neuron appears as a different `unit` ID in each session's sorting results. The unit matching system solves this by assigning a persistent **universal unit** identity to neurons across sessions, enabling longitudinal analysis of single-neuron activity over days or weeks.
+
+The system works by exploiting temporal overlap between consecutive ephys blocks: when two blocks share a time window, the same neurons produce spikes in both blocks' sorted data. By comparing spike times in the overlap region, the system identifies which units across sessions correspond to the same neuron.
+
+### Prerequisites
+
+Unit matching sits at the end of the spike sorting pipeline. A session must have completed the full chain before it is eligible for matching:
+
+```
+SortingTask → PreProcessing → SpikeSorting → PostProcessing
+→ SortedSpikes → SyncedSpikes → [OfficialCuration + ApplyOfficialCuration]
+→ UnitMatching (this system)
+```
+
+Specifically, `UnitMatching.key_source` requires that `ApplyOfficialCuration` exists for the session, ensuring only curated (quality-controlled) results enter the matching pipeline.
+
+### Key Concepts
+
+A **universal unit** is a persistent neuron identity scoped to a single probe insertion (i.e., one physical probe in one subject). Universal unit IDs are integers starting at 1, unique within a `(experiment_name, subject, insertion_number)` scope.
+
+A **matched unit** links a session-specific `SortedSpikes.Unit` to its assigned universal unit. Each session unit maps to exactly one universal unit. A universal unit may be matched to units from multiple sessions (that's the whole point).
+
+**Temporal overlap** between consecutive ephys blocks is the mechanism that enables matching. The overlap region contains spikes from the same neurons captured by both blocks' independent sorting runs. The matching algorithm compares spike times in this overlap window to identify corresponding units.
+
+The **ownership convention** determines which session "owns" the spike data for a given (universal_unit, chunk) pair when multiple sessions cover the same chunk. This prevents duplicate rows in `ChunkedSpikeTimes`.
+
+### Critical Constraint: Temporal Ordering
+
+Sessions **must** be processed in temporal order (by `block_start`). Session N compares its units against previously-matched sessions (1..N-1). Processing out of order produces incorrect universal unit assignments. This constraint is documented but enforced only by convention — there is no schema-level enforcement.
+
+---
+
+## Database Schema
+
+### Table Definitions
+
+```
+UnitMatchingMethod (Lookup)
+    matching_method: varchar(32)
+    ---
+    matching_method_description: varchar(1000)
+
+UnitMatching (Computed)
+    -> SyncedSpikes                         # inherits full session key
+    ---
+    -> UnitMatchingMethod                   # non-PK: which method was used
+    execution_time: datetime
+    execution_duration: float               # hours
+
+    UnitMatching.Matched (Part)
+        -> master
+        -> SortedSpikes.Unit                # adds `unit` to PK
+        ---
+        -> UniversalUnit                    # universal_unit as dependent FK
+        match_confidence=null: float
+        match_comment='': varchar(1000)
+
+    UnitMatching.ChunkedSpikeTimes (Part)
+        -> master
+        -> UniversalUnit                    # adds universal_unit to PK
+        -> ephys.EphysChunk                 # adds chunk_start to PK
+        ---
+        spike_times: longblob               # float64 epoch seconds (UTC), HARP-synced
+        spike_count: int
+        unique index (universal_unit, chunk_start)  # schema-enforced: one row per (unit, chunk)
+
+UniversalUnit (Manual)
+    -> ephys.ProbeInsertion                 # experiment_name, subject, insertion_number
+    universal_unit: int                     # unique ID within this insertion
+    ---
+    universal_unit_comment='': varchar(1000)
+```
+
+### Entity Relationship Diagram
+
+```mermaid
+erDiagram
+    SyncedSpikes ||--o| UnitMatching : "populates"
+    UnitMatching ||--o{ "UnitMatching.Matched" : "part"
+    UnitMatching ||--o{ "UnitMatching.ChunkedSpikeTimes" : "part"
+    "SortedSpikes.Unit" ||--o| "UnitMatching.Matched" : "FK (unit)"
+    UniversalUnit ||--o{ "UnitMatching.Matched" : "FK (universal_unit)"
+    UniversalUnit ||--o{ "UnitMatching.ChunkedSpikeTimes" : "FK (universal_unit)"
+    "ephys.EphysChunk" ||--o{ "UnitMatching.ChunkedSpikeTimes" : "FK (chunk_start)"
+    "ephys.ProbeInsertion" ||--|| UniversalUnit : "scopes"
+```
+
+### Design Notes
+
+- **`UnitMatchingMethod` as non-PK FK**: Only one matching result per session. The method is recorded for provenance but does not multiply the key space. This means one canonical set of universal units per insertion — no parallel method comparison. This is a deliberate simplification; if method comparison becomes needed, it can be added later by promoting the FK back to PK.
+
+- **`UniversalUnit` is Manual**: Populated programmatically by `UnitMatching.make()`, not by DataJoint's `populate()` machinery. This means it cannot be auto-cleared. Orphaned entries (those with no remaining `Matched` references) must be cleaned up explicitly during re-processing.
+
+- **`unique index` on `ChunkedSpikeTimes`**: The Part table PK includes the master's session key, so the same `(universal_unit, chunk_start)` from different sessions would be valid at the PK level. The unique index on `(universal_unit, chunk_start)` provides a schema-level guarantee that only one session can own a given (unit, chunk) pair, making the ownership convention a hard constraint rather than a soft convention.
+
+- **`UnitMatching.Matched` references `SortedSpikes.Unit` via formal FK**: This enforces referential integrity (can't match a non-existent unit). Since `UnitMatching` sits downstream of `SortedSpikes` in the pipeline, and curation cleanup deletes `UnitMatching` before `SortedSpikes`, cascade ordering is correct.
+
+---
+
+## Algorithm
+
+### Matching Method: `spike_time_overlap`
+
+The current (and only) matching method uses SpikeInterface's `compare_two_sorters()` to identify corresponding units between sessions based on spike time coincidence in the overlap window.
+
+#### Steps
+
+1. **Load this session's synced spike times** from `SyncedSpikes.Unit`. Concatenate across chunks per unit. Convert `datetime64[ns]` to float64 epoch seconds.
+
+2. **Find overlapping previous sessions**: Query all previously-completed `UnitMatching` entries for the same `(experiment_name, subject, insertion_number)`. Filter to those whose `(block_start, block_end)` overlaps with this session's time range.
+
+3. **For each overlapping previous session**:
+   a. Load the previous session's synced spike times (same format).
+   b. Compute the overlap window: `overlap_start = max(this.block_start, prev.block_start)`, `overlap_end = min(this.block_end, prev.block_end)`.
+   c. Restrict both sessions' spike times to the overlap window, converting to relative times (seconds from overlap start).
+   d. Convert to sample indices at 30 kHz and build `NumpySorting` objects.
+   e. Run `compare_two_sorters(delta_time=0.4)` (0.4 ms coincidence window).
+   f. Extract matched pairs. For each match, look up the previous session's unit's `universal_unit` assignment (via `UnitMatching.Matched`). Assign this session's unit to the same universal unit.
+
+4. **Assign new universal units** for unmatched units: find the current maximum `universal_unit` ID for this insertion, increment sequentially.
+
+5. **Insert `UniversalUnit`** entries for newly created universal units.
+
+6. **Insert `UnitMatching.Matched`** entries linking each session unit to its universal unit.
+
+7. **Insert `UnitMatching.ChunkedSpikeTimes`** entries following the ownership convention (see next section).
+
+8. **Insert `UnitMatching`** master entry with execution metadata.
+
+#### Parameters
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| `delta_time` | 0.4 ms | Spike time coincidence window for `compare_two_sorters` |
+| Sampling frequency | 30,000 Hz | Used to convert epoch seconds to sample indices for SpikeInterface |
+
+---
+
+## Ownership Convention for Overlapping Chunks
+
+### Problem
+
+When two ephys blocks overlap in time, the same `EphysChunk` (1-hour raw data segment) is sorted independently by both blocks. For a universal unit present in both blocks, `SyncedSpikes.Unit` contains spike times from both sessions for the overlapping chunks. Without a convention, `ChunkedSpikeTimes` would contain duplicate rows for the same `(universal_unit, chunk)` from different sessions.
+
+Duplicates cause incorrect downstream analysis: inflated spike counts, artificial short ISIs, and wrong firing rate estimates.
+
+### Convention: Earlier Session Owns
+
+**Rule: for each `(universal_unit, chunk)` pair, the first session (in processing order) to write a `ChunkedSpikeTimes` row wins. Later sessions skip that pair.**
+
+Since sessions are processed in temporal order, "first to process" = "earlier session" for chunks in the overlap region.
+
+Implementation in `UnitMatching.make()`:
+
+```python
+for uu_id in this_session_universal_units:
+    for chunk_key in this_session_chunks:
+        # Check if ANY session already wrote this (uu, chunk)
+        if self.ChunkedSpikeTimes & {"universal_unit": uu_id, "chunk_start": chunk_key["chunk_start"]}:
+            continue  # earlier session owns it
+        # Get synced spikes for this session's unit in this chunk
+        # ... insert if spikes exist
+```
+
+### Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| Non-overlapping chunks | Each chunk covered by exactly one session. No ambiguity. |
+| Overlapping chunks, same universal unit in both sessions | Earlier session writes the row. Later session skips. |
+| New universal unit in later session (not matched to prior) | No prior data exists for this unit. Later session writes all its chunks, including overlap ones. |
+| Unit has no spikes in a chunk (silent period) | No row written. A later session that does have spikes for this unit in this chunk will write it. |
+
+### Invariant
+
+After all sessions are processed, each `(universal_unit, chunk_start)` pair appears in **at most one** `UnitMatching.ChunkedSpikeTimes` row across all sessions. This invariant is enforced at two levels:
+
+1. **Schema-level**: A `unique index (universal_unit, chunk_start)` on `ChunkedSpikeTimes` guarantees that the database rejects any duplicate `(universal_unit, chunk_start)` insertion, regardless of which session attempts it. A later session trying to write an already-owned pair will raise an `IntegrityError`.
+
+2. **Code-level**: The `make()` method checks for existing rows before inserting, skipping already-owned pairs. This prevents the `IntegrityError` from ever being raised during normal operation and provides clear logging of skipped chunks.
+
+---
+
+## Integration with Existing Pipeline
+
+### Pipeline Position
+
+```
+SortingTask (Manual)
+  → PreProcessing (Computed)
+    → SpikeSorting (Computed)
+      → PostProcessing (Computed)
+        → SIExport (Computed)
+        → SortedSpikes (Imported)
+          → Waveform (Imported)
+          → SortingQuality (Imported)
+          → SyncedSpikes (Imported)
+            → UnitMatching (Computed)     ← NEW
+              ├─ .Matched (Part)          ← NEW
+              └─ .ChunkedSpikeTimes (Part)← NEW
+
+UniversalUnit (Manual)                    ← NEW (populated by UnitMatching.make())
+```
+
+### Curation Gate
+
+`UnitMatching.key_source` restricts to sessions that have `ApplyOfficialCuration`. This means:
+- Raw (uncurated) sessions are never matched
+- The matching uses curated spike sorting results
+- Changing a curation requires re-running the matching (see next section)
+
+### Worker Integration
+
+`UnitMatching` is a `Computed` table and can be registered with a DataJoint worker for automated processing. However, the temporal ordering constraint means the worker must process sessions sequentially by `block_start`. If the worker picks up sessions out of order, results will be incorrect.
+
+**Recommendation**: Either (a) register with a dedicated worker that processes one session at a time in order, or (b) keep matching as a manually-triggered step until the ordering constraint is better enforced.
+
+---
+
+## Re-processing and Deletion
+
+### Scenario: Re-curation of a Session
+
+When a session's curation is changed (via `restore_raw_sorting()` → new curation → `ApplyOfficialCuration`):
+
+1. `restore_raw_sorting()` deletes `UnitMatching` for the session → cascades to `Matched` and `ChunkedSpikeTimes` Part rows for that session.
+2. Orphaned `UniversalUnit` entries (those with no remaining `Matched` references from any session) are explicitly deleted.
+3. `SortedSpikes` and downstream tables are deleted and re-populated with the new curation.
+4. `UnitMatching.populate()` re-runs for the session, re-matching and re-writing `ChunkedSpikeTimes`.
+
+**Important**: Later sessions' `UnitMatching` entries are NOT automatically invalidated. If the re-curation changes which units exist or how they match, downstream sessions may have stale universal unit assignments. In this case, the user should re-run matching for affected downstream sessions as well.
+
+### Cascade Behavior
+
+```
+Delete UnitMatching entry
+  → Cascades to UnitMatching.Matched (Part)
+  → Cascades to UnitMatching.ChunkedSpikeTimes (Part)
+
+Delete SortedSpikes.Unit
+  → Blocked if UnitMatching.Matched references it
+  → Solution: delete UnitMatching first (handled by restore_raw_sorting)
+```
+
+### Cleanup Steps in `restore_raw_sorting()`
+
+```
+Step 1: Delete OfficialCuration (cascades to ApplyOfficialCuration)
+Step 2: Delete UnitMatching for this session (cascades to Matched + ChunkedSpikeTimes)
+Step 3: Delete orphaned UniversalUnit entries
+Step 4: Delete SortedSpikes (cascades to Waveform, SortingQuality, SyncedSpikes)
+```
+
+Note: Step 2 no longer requires `force=True` on Part tables (unlike the previous design where `UniversalUnit.Matched` was a Part of `UniversalUnit` but referenced `SortedSpikes.Unit`). With `Matched` as a Part of `UnitMatching`, deleting `UnitMatching` cleanly cascades.
+
+---
+
+## Query Patterns
+
+### Get all spikes for a universal unit across all time
+
+```python
+(UnitMatching.ChunkedSpikeTimes & {"universal_unit": 5}).fetch(
+    "chunk_start", "spike_times", "spike_count", order_by="chunk_start"
+)
+```
+
+Note: the result includes session key fields (block_start, block_end, etc.) inherited from the master. These can be ignored — the ownership convention guarantees one row per (universal_unit, chunk_start).
+
+### Get all sessions where a universal unit was observed
+
+```python
+UnitMatching.Matched & {"universal_unit": 5}
+```
+
+### Get universal unit assignments for a specific session
+
+```python
+UnitMatching.Matched & session_key
+```
+
+### Get synced spike times via join (alternative to ChunkedSpikeTimes)
+
+```python
+SyncedSpikes.Unit * UnitMatching.Matched & {"universal_unit": 5}
+```
+
+This returns per-session per-chunk spike times with universal unit labels. Overlap chunks will appear with multiple rows (one per session). Use `ChunkedSpikeTimes` for the deduplicated version.
+
+### List all universal units for an insertion
+
+```python
+UniversalUnit & {"experiment_name": "...", "subject": "...", "insertion_number": 1}
+```
+
+---
+
+## Design Decisions and Rationale
+
+### Why `UnitMatchingMethod` is a non-PK FK
+
+**Decision**: One matching result per session. The method is recorded but does not partition the data.
+
+**Rationale**: Making it a PK would mean every downstream query must carry `matching_method`, and universal units would be scoped per-method (allowing parallel sets). In practice, the team settles on one matching method and uses it consistently. The simpler design avoids combinatorial complexity. If method comparison becomes necessary, the FK can be promoted to PK.
+
+### Why `Matched` is a Part of `UnitMatching` (not `UniversalUnit`)
+
+**Decision**: `UnitMatching.Matched` instead of `UniversalUnit.Matched`.
+
+**Rationale**: Part table lifecycle should be governed by the master. `Matched` rows are created and destroyed with their session's `UnitMatching` entry. Placing them under `UniversalUnit` (which has a different lifecycle — it persists across sessions) creates cascade problems: deleting `SortedSpikes.Unit` is blocked by `UniversalUnit.Matched`'s FK, requiring `force=True` hacks. Under `UnitMatching`, the cascade is clean: delete `UnitMatching` → cascades to `Matched` and `ChunkedSpikeTimes`.
+
+### Why `ChunkedSpikeTimes` is a Part of `UnitMatching` (not standalone)
+
+**Decision**: Part table with ownership convention, not a standalone Computed table.
+
+**Alternatives considered**:
+- **Standalone Computed keyed on `(UniversalUnit, EphysChunk)`**: Clean one-row-per-pair semantics, but the cartesian `key_source` (all units x all chunks) is prohibitively large. A restricted `key_source` is complex to express correctly.
+- **No table at all** (use `SyncedSpikes.Unit * UnitMatching.Matched` join): Simplest schema, but overlap chunks produce duplicate rows. Every downstream analysis must implement deduplication.
+- **Part of `UnitMatching`** with ownership convention: Avoids cartesian explosion (scoped to session's chunks). Ownership convention guarantees at most one row per (unit, chunk), enforced by a `unique index (universal_unit, chunk_start)` at the schema level. Lifecycle managed by cascade.
+
+The Part table approach was chosen because it provides pre-materialized, deduplicated spike times (the primary analysis output) while keeping the scope naturally bounded per session.
+
+### Why `UniversalUnit` is Manual (not Computed)
+
+**Decision**: `UniversalUnit` is a Manual table populated programmatically by `UnitMatching.make()`.
+
+**Rationale**: Universal units are created incrementally as sessions are processed. They persist across sessions — a universal unit created by session 1 is referenced by sessions 2, 3, etc. A Computed table would need a well-defined `key_source` that doesn't exist (you can't predict which universal units will be needed before running the matching). The Manual tier correctly reflects that these entries are managed by application logic, not by DataJoint's populate machinery.

--- a/aeon/dj_pipeline/ephys.py
+++ b/aeon/dj_pipeline/ephys.py
@@ -1,17 +1,20 @@
-import datajoint as dj
-import json
 import re
-import numpy as np
-from pathlib import Path
-import joblib
-import tempfile
+import datajoint as dj
 from typing import Dict, Any
 from datetime import datetime
-
-from swc.aeon.io import api as io_api
-from aeon.schema.ephys import social_ephys
+from pathlib import Path
 
 from aeon.dj_pipeline import acquisition, get_schema_name
+from aeon.dj_pipeline.utils.ephys_utils import (
+    DEVICE_PROBE_TYPE_MAP,
+    create_probe_type as _create_probe_type,
+    discover_epoch_probes,
+    find_or_create_probe_insertion,
+    get_probe_id,
+    parse_epoch_metadata,
+    process_ephys_file,
+    read_probe_assignments,
+)
 
 schema = dj.schema(get_schema_name("ephys"))
 logger = dj.logger
@@ -109,12 +112,6 @@ class EphysEpoch(dj.Imported):
         probe_label: varchar(32)  # file label discovered from this epoch's files (e.g., "ProbeA")
         """
 
-    # Mapping from device directory name to probe_type
-    _device_probe_type_map = {
-        "NeuropixelsV2Beta": "neuropixels2.0_beta",
-        "NeuropixelsV2": "neuropixels2.0",
-    }
-
     def make(self, key: Dict[str, Any]) -> None:
         """Discover ephys data in an epoch and register active probe insertions.
 
@@ -150,62 +147,27 @@ class EphysEpoch(dj.Imported):
 
         epoch_path = data_dir / epoch_dir
 
-        # Look for ephys device subdirectory
-        device_name = None
-        device_dir = None
-        for subdir_name in ("NeuropixelsV2Beta", "NeuropixelsV2"):
-            candidate = epoch_path / subdir_name
-            if candidate.exists() and candidate.is_dir():
-                device_name = subdir_name
-                device_dir = candidate
-                break
-
-        if device_name is None:
-            self.insert1({**key, "has_ephys": False, "n_probes": 0})
-            return
-
-        # Discover probes from binary files
-        amplifier_files = sorted(device_dir.glob(f"{device_name}_Probe*_AmplifierData_*.bin"))
-        if not amplifier_files:
-            self.insert1({**key, "has_ephys": False, "n_probes": 0})
-            return
-
-        # Extract unique probe labels from filenames
-        # e.g., "NeuropixelsV2Beta_ProbeA_AmplifierData_0.bin" -> "ProbeA"
-        probe_labels = set()
-        for f in amplifier_files:
-            match = re.search(rf"{device_name}_(Probe[A-Z])_AmplifierData", f.name)
-            if match:
-                probe_labels.add(match.group(1))
-
+        # Discover probes
+        device_name, device_dir, probe_labels = discover_epoch_probes(epoch_path)
         if not probe_labels:
-            logger.warning(f"Found amplifier files but couldn't parse probe labels in {device_dir}")
             self.insert1({**key, "has_ephys": False, "n_probes": 0})
             return
 
-        probe_labels = sorted(probe_labels)
-
-        # Parse Metadata.yml for probe identity (serial numbers)
-        metadata_path = epoch_path / "Metadata.yml"
-        metadata = None
-        if metadata_path.exists():
-            try:
-                with open(metadata_path) as f:
-                    metadata = json.load(f)  # JSON despite .yml extension
-            except (json.JSONDecodeError, IOError) as e:
-                logger.warning(f"Failed to parse Metadata.yml at {metadata_path}: {e}")
+        # Parse metadata for probe identity (serial numbers)
+        metadata = parse_epoch_metadata(epoch_path)
 
         # Build probe info: {label: probe_id}
-        probe_info = {}
-        for label in probe_labels:
-            probe_info[label] = self._get_probe_id(metadata, device_name, label)
+        probe_info = {
+            label: get_probe_id(metadata, device_name, label)
+            for label in probe_labels
+        }
 
         # Auto-create Probe entries (probe_type derived from device directory name)
-        probe_type = self._device_probe_type_map.get(device_name)
+        probe_type = DEVICE_PROBE_TYPE_MAP.get(device_name)
         if probe_type is None:
             raise ValueError(
                 f"Unknown device '{device_name}'. Cannot determine probe_type. "
-                f"Known devices: {list(self._device_probe_type_map.keys())}"
+                f"Known devices: {list(DEVICE_PROBE_TYPE_MAP.keys())}"
             )
         for label in probe_labels:
             probe_id = probe_info[label]
@@ -222,7 +184,9 @@ class EphysEpoch(dj.Imported):
                 logger.info(f"Auto-created Probe entry: {probe_id} (type={probe_type})")
 
         # Read subject-probe mapping
-        probe_assignments = self._read_probe_assignments(key, epoch_path, probe_labels)
+        probe_assignments = read_probe_assignments(
+            key, epoch_path, probe_labels, self.Insertion,
+        )
 
         # Create/validate ProbeInsertion entries and build Insertion Part rows
         insertion_entries = []
@@ -230,9 +194,8 @@ class EphysEpoch(dj.Imported):
             probe_id = probe_info[label]
             subject = probe_assignments[label]["subject"]
 
-            # Find or create ProbeInsertion
-            pi_key = self._find_or_create_probe_insertion(
-                key["experiment_name"], subject, probe_id
+            pi_key = find_or_create_probe_insertion(
+                key["experiment_name"], subject, probe_id, ProbeInsertion, Probe,
             )
             insertion_entries.append({
                 **key,
@@ -243,125 +206,6 @@ class EphysEpoch(dj.Imported):
         # Insert master + Part rows
         self.insert1({**key, "has_ephys": True, "n_probes": len(probe_labels)})
         self.Insertion.insert(insertion_entries)
-
-    def _read_probe_assignments(
-        self, key: Dict[str, Any], epoch_path: Path, probe_labels: list[str]
-    ) -> dict:
-        """Read subject-probe mapping from file or carry forward from previous epoch.
-
-        Priority:
-        1. probe_assignments.json in epoch directory
-        2. Carry-forward from most recent EphysEpoch with .Insertion entries
-        3. Pre-existing ProbeInsertion matched by probe serial (error if not found)
-
-        Args:
-            key: Epoch key (experiment_name, epoch_start)
-            epoch_path: Path to epoch directory
-            probe_labels: Sorted list of probe labels discovered in this epoch
-
-        Returns:
-            Dict mapping probe_label -> {"subject": str, ...}
-        """
-        raise NotImplementedError(
-            "Probe-subject assignment resolution is not yet implemented. "
-            "The exact file format and carry-forward logic will be determined "
-            "once the experimental data conventions are finalized."
-        )
-
-    @staticmethod
-    def _find_or_create_probe_insertion(
-        experiment_name: str, subject: str, probe_id: str
-    ) -> dict:
-        """Find existing or create new ProbeInsertion for this (experiment, subject, probe).
-
-        Returns the ProbeInsertion key: {experiment_name, subject, insertion_number}.
-
-        Args:
-            experiment_name: Experiment name
-            subject: Subject name
-            probe_id: Probe identifier (serial number)
-
-        Returns:
-            Dict with ProbeInsertion PK fields
-        """
-        # Check if a ProbeInsertion already exists for this probe + subject + experiment
-        existing = (
-            ProbeInsertion
-            & {"experiment_name": experiment_name, "subject": subject, "probe": probe_id}
-        ).fetch(as_dict=True)
-        if existing:
-            row = existing[0]
-            return {
-                "experiment_name": row["experiment_name"],
-                "subject": row["subject"],
-                "insertion_number": row["insertion_number"],
-            }
-
-        # Create new ProbeInsertion with auto-assigned insertion_number
-        existing_nums = (
-            ProbeInsertion
-            & {"experiment_name": experiment_name, "subject": subject}
-        ).fetch("insertion_number")
-        new_num = int(existing_nums.max()) + 1 if len(existing_nums) > 0 else 1
-
-        ProbeInsertion.insert1({
-            "experiment_name": experiment_name,
-            "subject": subject,
-            "insertion_number": new_num,
-            "probe": probe_id,
-        })
-        logger.info(
-            f"Created ProbeInsertion: experiment={experiment_name}, "
-            f"subject={subject}, insertion_number={new_num}, probe={probe_id}"
-        )
-        return {
-            "experiment_name": experiment_name,
-            "subject": subject,
-            "insertion_number": new_num,
-        }
-
-    @staticmethod
-    def _get_probe_id(
-        metadata: dict | None, device_name: str, probe_label: str
-    ) -> str:
-        """Extract probe identifier from metadata.
-
-        For V2Beta hardware (no serial numbers): probe ID = "{device_name}_{label}"
-        For V2 hardware: probe ID = serial number from GainCalibrationFileName
-
-        Args:
-            metadata: Parsed Metadata.yml dict, or None
-            device_name: Hardware device name (e.g., "NeuropixelsV2Beta", "NeuropixelsV2")
-            probe_label: Probe label from filename (e.g., "ProbeA", "ProbeB")
-
-        Returns:
-            Probe identifier string
-        """
-        default_id = f"{device_name}_{probe_label}"
-
-        if metadata is None:
-            return default_id
-
-        # V2 hardware: try to extract serial number
-        if device_name == "NeuropixelsV2":
-            v2e_config = metadata.get("NeuropixelsV2e")
-            if v2e_config:
-                config_key_map = {
-                    "ProbeA": "ProbeConfigurationA",
-                    "ProbeB": "ProbeConfigurationB",
-                }
-                config_key = config_key_map.get(probe_label)
-                if config_key and config_key in v2e_config:
-                    gain_cal = v2e_config[config_key].get("GainCalibrationFileName")
-                    if gain_cal:
-                        try:
-                            serial = Path(gain_cal).parent.name
-                            if serial and serial.isdigit():
-                                return serial
-                        except Exception:
-                            pass
-
-        return default_id
 
 
 @schema
@@ -421,8 +265,6 @@ class EphysChunk(dj.Manual):
         epoch_dir_to_start = {}
         for ep in epochs:
             if ep["epoch_dir"]:
-                # epoch_dir is relative path like "2024-01-15T10-00-00"
-                # Extract the top-level directory name
                 top_dir = Path(ep["epoch_dir"]).parts[0]
                 epoch_dir_to_start[top_dir] = ep["epoch_start"]
 
@@ -466,7 +308,6 @@ class EphysChunk(dj.Manual):
                 continue
 
             # Parse probe_label from filename
-            # e.g., "NeuropixelsV2Beta_ProbeA_AmplifierData_0.bin" -> "ProbeA"
             name_match = re.search(r"_(Probe[A-Z])_AmplifierData", ephys_file.name)
             if not name_match:
                 logger.warning(f"Cannot parse probe label from {ephys_file.name}. Skipping.")
@@ -517,7 +358,7 @@ class EphysChunk(dj.Manual):
 
             # Process the file into a chunk entry
             try:
-                cls._process_ephys_file(
+                process_ephys_file(
                     ephys_file=ephys_file,
                     raw_dir=raw_dir,
                     insertion_key=insertion_key,
@@ -526,121 +367,16 @@ class EphysChunk(dj.Manual):
                     probe_type=probe_type,
                     electrode_config_name=electrode_config_name,
                     sync_models=sync_models,
+                    chunk_table=cls,
                 )
             except Exception as e:
                 logger.error(f"Failed to process {ephys_file}: {e}")
                 continue
 
-    @classmethod
-    def _process_ephys_file(
-        cls,
-        ephys_file: Path,
-        raw_dir: Path,
-        insertion_key: dict,
-        epoch_start: datetime,
-        probe_label: str,
-        probe_type: str,
-        electrode_config_name: str,
-        sync_models: dict,
-    ) -> None:
-        """Process a single ephys binary file into a chunk entry with sync model.
-
-        Args:
-            ephys_file: Path to the amplifier data binary file
-            raw_dir: Root raw data directory
-            insertion_key: ProbeInsertion key (experiment_name, subject, insertion_number)
-            epoch_start: Epoch start datetime for this file's epoch
-            probe_label: File label (e.g., "ProbeA")
-            probe_type: Probe type string
-            electrode_config_name: Electrode configuration name
-            sync_models: Mutable dict cache for sync models (shared across files)
-        """
-        clock_file = ephys_file.with_name(
-            ephys_file.name.replace("AmplifierData", "Clock")
-        )
-        onix_ts = np.memmap(clock_file, mode="r", dtype=np.uint64)
-
-        model_parent_dir = raw_dir / ephys_file.relative_to(raw_dir).parents[-2]
-        if model_parent_dir.as_posix() not in sync_models:
-            device_prefix = ephys_file.name.split(f"_{probe_label}_")[0]
-            device_reader = getattr(social_ephys, device_prefix, None)
-            if device_reader is None:
-                raise ValueError(
-                    f"No sync reader found for device '{device_prefix}'. "
-                    f"Available devices: {list(social_ephys.keys())}"
-                )
-            sync_models[model_parent_dir.as_posix()] = io_api.load(
-                model_parent_dir,
-                device_reader.HarpSyncModel,
-            )
-
-        sync_model = sync_models[model_parent_dir.as_posix()]
-        matched_sync = sync_model.query(
-            f"(clock_start <= {onix_ts[0]} <= clock_end)"
-            f" | "
-            f"(clock_start <= {onix_ts[-1]} <= clock_end)"
-        )
-
-        sync_entries = []
-        with tempfile.TemporaryDirectory() as tmpdir:
-            for idx, (_, r) in enumerate(matched_sync.iterrows()):
-                if idx == 0:
-                    chunk_start = r.model.predict(
-                        np.array(onix_ts[0]).reshape(-1, 1)
-                    ).flatten()[0]
-                    chunk_start = io_api.to_datetime(chunk_start)
-                if idx == len(matched_sync) - 1:
-                    chunk_end = r.model.predict(
-                        np.array(onix_ts[-1]).reshape(-1, 1)
-                    ).flatten()[0]
-                    chunk_end = io_api.to_datetime(chunk_end)
-
-                model_path = Path(tmpdir) / (
-                    ephys_file.stem + f"_{r.clock_start}.joblib"
-                )
-                joblib.dump(r.model, model_path)
-
-                sync_entries.append(
-                    {
-                        "onix_ts_start": r.clock_start,
-                        "onix_ts_end": r.clock_end,
-                        "sync_model": model_path,
-                        "harp_start": r.name,
-                    }
-                )
-
-            chunk_entry = {
-                **insertion_key,
-                "chunk_start": chunk_start,
-                "chunk_end": chunk_end,
-                "epoch_start": epoch_start,
-                "probe_type": probe_type,
-                "electrode_config_name": electrode_config_name,
-            }
-            cls.insert1(chunk_entry)
-            cls.File.insert(
-                [
-                    dict(
-                        **chunk_entry,
-                        directory_type="raw",
-                        file_name=f.name,
-                        file_path=f.relative_to(raw_dir).as_posix(),
-                    )
-                    for f in (ephys_file, clock_file)
-                ],
-                ignore_extra_fields=True,
-            )
-            cls.SyncModel.insert(
-                [{**chunk_entry, **sync_entry} for sync_entry in sync_entries],
-                ignore_extra_fields=True,
-            )
-
 
 @schema
 class EphysBlock(dj.Manual):
-    """
-    User-defined period of time of ephys data (in HARP clock)
-    """
+    """User-defined period of time of ephys data (in HARP clock)."""
 
     definition = """  # A an arbitrary period of time of ephys data
     -> ProbeInsertion
@@ -779,24 +515,4 @@ def create_probe_type(probe_type: str, manufacturer: str, probe_name: str) -> No
         manufacturer: Probe manufacturer (e.g., "neuropixels")
         probe_name: Specific probe model name (e.g., "NP2004")
     """
-    import probeinterface as pi
-
-    electrode_df = pi.get_probe(
-        manufacturer=manufacturer, probe_name=probe_name
-    ).to_dataframe()
-    electrode_df.rename(
-        columns={
-            "contact_ids": "electrode_name",
-            "shank_ids": "shank",
-            "x": "x_coord",
-            "y": "y_coord",
-        },
-        inplace=True,
-    )
-    electrode_df.shank = electrode_df.shank.apply(lambda x: x or 0)
-    electrode_df["probe_type"] = probe_type
-    electrode_df["electrode"] = electrode_df.index
-
-    with ProbeType.connection.transaction:
-        ProbeType.insert1(dict(probe_type=probe_type))
-        ProbeType.Electrode.insert(electrode_df, ignore_extra_fields=True)
+    _create_probe_type(probe_type, manufacturer, probe_name, ProbeType)

--- a/aeon/dj_pipeline/ephys.py
+++ b/aeon/dj_pipeline/ephys.py
@@ -73,21 +73,11 @@ class TargetArea(dj.Lookup):
 class ProbeInsertion(dj.Manual):
     definition = """
     -> acquisition.Experiment
-    insertion_number: int  # auto-assigned, stable across epochs for the same probe
+    -> acquisition.Experiment.Subject
+    insertion_number: int  # unique per (experiment, subject)
     ---
     -> Probe
-    probe_label: varchar(32)  # file label (e.g., "ProbeA") used for file pattern matching in ingest_chunks
     implantation_date=null: datetime(6)
-    """
-
-
-@schema
-class EphysSubject(dj.Manual):
-    definition = """
-    # Links a probe insertion to the subject carrying the probe
-    -> ProbeInsertion
-    ---
-    -> acquisition.Experiment.Subject
     """
 
 
@@ -103,29 +93,48 @@ class InsertionTargetArea(dj.Manual):
 @schema
 class EphysEpoch(dj.Imported):
     definition = """
-    # Checks each epoch for ephys data. Auto-populates ProbeInsertion (Probe must pre-exist).
+    # Per-epoch probe registry. Discovers probes, reads subject-probe mapping, records active insertions.
     -> acquisition.Epoch
     ---
     has_ephys: bool  # whether ephys data was found in this epoch
     n_probes: int    # number of probes discovered (0 if no ephys)
     """
 
+    class Insertion(dj.Part):
+        definition = """
+        # Which ProbeInsertions are active in this epoch
+        -> master
+        -> ProbeInsertion
+        ---
+        probe_label: varchar(32)  # file label discovered from this epoch's files (e.g., "ProbeA")
+        """
+
+    # Mapping from device directory name to probe_type
+    _device_probe_type_map = {
+        "NeuropixelsV2Beta": "neuropixels2.0_beta",
+        "NeuropixelsV2": "neuropixels2.0",
+    }
+
     def make(self, key: Dict[str, Any]) -> None:
-        """Discover ephys data in an epoch and auto-populate ProbeInsertion.
+        """Discover ephys data in an epoch and register active probe insertions.
 
         For each epoch:
         1. Check for ephys device subdirectory (NeuropixelsV2Beta/ or NeuropixelsV2/)
-        2. If found, parse Metadata.yml to discover probes
-        3. Auto-insert ProbeInsertion rows as side effects (Probe must pre-exist)
-        4. Record the epoch as processed
+        2. If found, discover probes from binary files and parse Metadata.yml
+        3. Auto-create Probe entries (probe_type derived from device directory name)
+        4. Read subject-probe mapping from probe_assignments.json or carry forward
+        5. Create/validate ProbeInsertion entries (with subject)
+        6. Insert EphysEpoch.Insertion Part rows
 
-        Probe entries must be created by the user before running this, because
-        probe_type cannot be determined from the metadata files alone.
+        Subject-probe mapping sources (in priority order):
+        - Per-epoch file: probe_assignments.json in the epoch directory
+        - Carry-forward: reuse mapping from the most recent EphysEpoch with has_ephys=True
+        - Pre-existing: manually inserted ProbeInsertion matched by probe serial
 
         Args:
             key: Dictionary containing experiment_name and epoch_start
         """
-        # Get epoch directory (same pattern as EpochConfig.make)
+        # Get epoch directory
         dir_type, epoch_dir = (acquisition.Epoch & key).fetch1(
             "directory_type", "epoch_dir"
         )
@@ -152,19 +161,17 @@ class EphysEpoch(dj.Imported):
                 break
 
         if device_name is None:
-            # No ephys data in this epoch
             self.insert1({**key, "has_ephys": False, "n_probes": 0})
             return
 
         # Discover probes from binary files
         amplifier_files = sorted(device_dir.glob(f"{device_name}_Probe*_AmplifierData_*.bin"))
         if not amplifier_files:
-            # Device directory exists but no amplifier files
             self.insert1({**key, "has_ephys": False, "n_probes": 0})
             return
 
         # Extract unique probe labels from filenames
-        # e.g., "NeuropixelsV2Beta_ProbeA_AmplifierData_0.bin" → "ProbeA"
+        # e.g., "NeuropixelsV2Beta_ProbeA_AmplifierData_0.bin" -> "ProbeA"
         probe_labels = set()
         for f in amplifier_files:
             match = re.search(rf"{device_name}_(Probe[A-Z])_AmplifierData", f.name)
@@ -176,79 +183,203 @@ class EphysEpoch(dj.Imported):
             self.insert1({**key, "has_ephys": False, "n_probes": 0})
             return
 
-        # Sort alphabetically (ProbeA before ProbeB) for consistent insertion_number ordering
         probe_labels = sorted(probe_labels)
 
-        # Parse Metadata.yml for probe identity (serial numbers for V2 hardware)
+        # Parse Metadata.yml for probe identity (serial numbers)
         metadata_path = epoch_path / "Metadata.yml"
         metadata = None
         if metadata_path.exists():
             try:
                 with open(metadata_path) as f:
-                    metadata = json.load(f)  # It's JSON despite .yml extension
+                    metadata = json.load(f)  # JSON despite .yml extension
             except (json.JSONDecodeError, IOError) as e:
                 logger.warning(f"Failed to parse Metadata.yml at {metadata_path}: {e}")
 
         # Build probe info: {label: probe_id}
         probe_info = {}
         for label in probe_labels:
-            probe_id = self._get_probe_id(metadata, device_name, label)
-            probe_info[label] = probe_id
+            probe_info[label] = self._get_probe_id(metadata, device_name, label)
 
-        # Auto-insert ProbeInsertion (Probe entries must pre-exist)
-        n_probes = 0
+        # Auto-create Probe entries (probe_type derived from device directory name)
+        probe_type = self._device_probe_type_map.get(device_name)
+        if probe_type is None:
+            raise ValueError(
+                f"Unknown device '{device_name}'. Cannot determine probe_type. "
+                f"Known devices: {list(self._device_probe_type_map.keys())}"
+            )
         for label in probe_labels:
             probe_id = probe_info[label]
-
-            # Verify Probe entry exists (user must create it with correct probe_type)
             if not (Probe & {"probe": probe_id}):
-                raise ValueError(
-                    f"Probe '{probe_id}' not found. Please create it before running "
-                    f"EphysEpoch.populate(). Example:\n"
-                    f"  Probe.insert1({{'probe': '{probe_id}', "
-                    f"'probe_type': '<your_probe_type>', 'probe_comment': ''}})"
+                if not (ProbeType & {"probe_type": probe_type}):
+                    raise ValueError(
+                        f"ProbeType '{probe_type}' not found. Create it first using "
+                        f"create_probe_type('{probe_type}', ...)."
+                    )
+                Probe.insert1(
+                    {"probe": probe_id, "probe_type": probe_type},
+                    skip_duplicates=True,
                 )
+                logger.info(f"Auto-created Probe entry: {probe_id} (type={probe_type})")
 
-            # Check if ProbeInsertion already exists for this probe in this experiment
-            existing = (
-                ProbeInsertion
-                & {"experiment_name": key["experiment_name"], "probe": probe_id}
+        # Read subject-probe mapping
+        probe_assignments = self._read_probe_assignments(key, epoch_path, probe_labels)
+
+        # Create/validate ProbeInsertion entries and build Insertion Part rows
+        insertion_entries = []
+        for label in probe_labels:
+            probe_id = probe_info[label]
+            subject = probe_assignments[label]["subject"]
+
+            # Find or create ProbeInsertion
+            pi_key = self._find_or_create_probe_insertion(
+                key["experiment_name"], subject, probe_id
+            )
+            insertion_entries.append({
+                **key,
+                **pi_key,
+                "probe_label": label,
+            })
+
+        # Insert master + Part rows
+        self.insert1({**key, "has_ephys": True, "n_probes": len(probe_labels)})
+        self.Insertion.insert(insertion_entries)
+
+    def _read_probe_assignments(
+        self, key: Dict[str, Any], epoch_path: Path, probe_labels: list[str]
+    ) -> dict:
+        """Read subject-probe mapping from file or carry forward from previous epoch.
+
+        Priority:
+        1. probe_assignments.json in epoch directory
+        2. Carry-forward from most recent EphysEpoch with .Insertion entries
+        3. Pre-existing ProbeInsertion matched by probe serial (error if not found)
+
+        Args:
+            key: Epoch key (experiment_name, epoch_start)
+            epoch_path: Path to epoch directory
+            probe_labels: Sorted list of probe labels discovered in this epoch
+
+        Returns:
+            Dict mapping probe_label -> {"subject": str, ...}
+        """
+        assignments_path = epoch_path / "probe_assignments.json"
+        if assignments_path.exists():
+            try:
+                with open(assignments_path) as f:
+                    assignments = json.load(f)
+                # Validate: every discovered probe label must be in the assignments
+                missing = [l for l in probe_labels if l not in assignments]
+                if missing:
+                    raise ValueError(
+                        f"probe_assignments.json missing entries for: {missing}. "
+                        f"File has keys: {list(assignments.keys())}"
+                    )
+                # Validate: every entry must have 'subject'
+                for label, info in assignments.items():
+                    if "subject" not in info:
+                        raise ValueError(
+                            f"probe_assignments.json entry for '{label}' missing 'subject' field."
+                        )
+                logger.info(f"Read probe assignments from {assignments_path}")
+                return assignments
+            except (json.JSONDecodeError, IOError) as e:
+                raise ValueError(
+                    f"Failed to parse probe_assignments.json at {assignments_path}: {e}"
+                ) from e
+
+        # Carry-forward: find most recent EphysEpoch with Insertion entries
+        prev_insertions = (
+            self.Insertion
+            & {"experiment_name": key["experiment_name"]}
+            & f'epoch_start < "{key["epoch_start"]}"'
+        )
+        if prev_insertions:
+            # Get the most recent epoch_start that has insertions
+            latest_epoch_start = prev_insertions.fetch(
+                "epoch_start", order_by="epoch_start DESC", limit=1
+            )[0]
+            prev_entries = (
+                self.Insertion
+                & {"experiment_name": key["experiment_name"], "epoch_start": latest_epoch_start}
             ).fetch(as_dict=True)
 
-            if existing:
-                # Already registered — nothing to do
-                n_probes += 1
-                continue
+            # Build assignments from previous epoch's Insertion entries
+            assignments = {}
+            for entry in prev_entries:
+                assignments[entry["probe_label"]] = {"subject": entry["subject"]}
 
-            # Assign new insertion_number with race condition retry
-            max_retries = 3
-            for attempt in range(max_retries):
-                try:
-                    existing_nums = (
-                        ProbeInsertion & {"experiment_name": key["experiment_name"]}
-                    ).fetch("insertion_number")
-                    new_num = int(existing_nums.max()) + 1 if len(existing_nums) > 0 else 1
+            # Validate: every discovered probe label must be covered
+            missing = [l for l in probe_labels if l not in assignments]
+            if missing:
+                raise ValueError(
+                    f"Carry-forward from epoch {latest_epoch_start} does not cover "
+                    f"probe labels: {missing}. Provide a probe_assignments.json for this epoch."
+                )
+            logger.info(
+                f"Carried forward probe assignments from epoch {latest_epoch_start}"
+            )
+            return assignments
 
-                    ProbeInsertion.insert1(
-                        {
-                            "experiment_name": key["experiment_name"],
-                            "insertion_number": new_num,
-                            "probe": probe_id,
-                            "probe_label": label,
-                        }
-                    )
-                    n_probes += 1
-                    break
-                except dj.errors.DuplicateError:
-                    if attempt < max_retries - 1:
-                        logger.warning(
-                            f"Race condition on insertion_number assignment "
-                            f"(attempt {attempt + 1}/{max_retries}). Retrying..."
-                        )
-                    else:
-                        raise
+        # No file, no previous epoch — error
+        raise ValueError(
+            f"No probe_assignments.json found in {epoch_path} and no previous epoch "
+            f"to carry forward from. For the first epoch with ephys data, a "
+            f"probe_assignments.json file is required. Expected format:\n"
+            f'{{\n  "ProbeA": {{"probe": "<serial>", "subject": "<subject_name>"}},\n'
+            f'  "ProbeB": {{"probe": "<serial>", "subject": "<subject_name>"}}\n}}'
+        )
 
-        self.insert1({**key, "has_ephys": True, "n_probes": n_probes})
+    @staticmethod
+    def _find_or_create_probe_insertion(
+        experiment_name: str, subject: str, probe_id: str
+    ) -> dict:
+        """Find existing or create new ProbeInsertion for this (experiment, subject, probe).
+
+        Returns the ProbeInsertion key: {experiment_name, subject, insertion_number}.
+
+        Args:
+            experiment_name: Experiment name
+            subject: Subject name
+            probe_id: Probe identifier (serial number)
+
+        Returns:
+            Dict with ProbeInsertion PK fields
+        """
+        # Check if a ProbeInsertion already exists for this probe + subject + experiment
+        existing = (
+            ProbeInsertion
+            & {"experiment_name": experiment_name, "subject": subject, "probe": probe_id}
+        ).fetch(as_dict=True)
+        if existing:
+            row = existing[0]
+            return {
+                "experiment_name": row["experiment_name"],
+                "subject": row["subject"],
+                "insertion_number": row["insertion_number"],
+            }
+
+        # Create new ProbeInsertion with auto-assigned insertion_number
+        existing_nums = (
+            ProbeInsertion
+            & {"experiment_name": experiment_name, "subject": subject}
+        ).fetch("insertion_number")
+        new_num = int(existing_nums.max()) + 1 if len(existing_nums) > 0 else 1
+
+        ProbeInsertion.insert1({
+            "experiment_name": experiment_name,
+            "subject": subject,
+            "insertion_number": new_num,
+            "probe": probe_id,
+        })
+        logger.info(
+            f"Created ProbeInsertion: experiment={experiment_name}, "
+            f"subject={subject}, insertion_number={new_num}, probe={probe_id}"
+        )
+        return {
+            "experiment_name": experiment_name,
+            "subject": subject,
+            "insertion_number": new_num,
+        }
 
     @staticmethod
     def _get_probe_id(
@@ -267,7 +398,6 @@ class EphysEpoch(dj.Imported):
         Returns:
             Probe identifier string
         """
-        # Default: use device name + label
         default_id = f"{device_name}_{probe_label}"
 
         if metadata is None:
@@ -275,10 +405,8 @@ class EphysEpoch(dj.Imported):
 
         # V2 hardware: try to extract serial number
         if device_name == "NeuropixelsV2":
-            # V2 metadata has "NeuropixelsV2e" key at top level
             v2e_config = metadata.get("NeuropixelsV2e")
             if v2e_config:
-                # Map probe label to configuration key
                 config_key_map = {
                     "ProbeA": "ProbeConfigurationA",
                     "ProbeB": "ProbeConfigurationB",
@@ -287,7 +415,6 @@ class EphysEpoch(dj.Imported):
                 if config_key and config_key in v2e_config:
                     gain_cal = v2e_config[config_key].get("GainCalibrationFileName")
                     if gain_cal:
-                        # Extract serial from path: ...\{serial}\{serial}_gainCalValues.csv
                         try:
                             serial = Path(gain_cal).parent.name
                             if serial and serial.isdigit():
@@ -295,18 +422,18 @@ class EphysEpoch(dj.Imported):
                         except Exception:
                             pass
 
-        # V2Beta hardware or V2 without serial: use default
         return default_id
 
 
 @schema
 class EphysChunk(dj.Manual):
     definition = """  # A recording period corresponds to a 1-hour ephys data acquisition
-    -> ProbeInsertion
-    chunk_start: datetime(6)  # start of an ephys chunk (in HARP clock)
+    -> ProbeInsertion                      # (experiment_name, subject, insertion_number)
+    chunk_start: datetime(6)               # start of an ephys chunk (in HARP clock)
     ---
-    chunk_end: datetime(6)    # end of an ephys chunk (in HARP clock)
-    -> ElectrodeConfig  # the electrode configuration used for this ephys recording
+    -> EphysEpoch                          # adds epoch_start — "this chunk came from this epoch"
+    chunk_end: datetime(6)                 # end of an ephys chunk (in HARP clock)
+    -> ElectrodeConfig                     # the electrode configuration used for this ephys recording
     """
 
     class File(dj.Part):
@@ -332,13 +459,12 @@ class EphysChunk(dj.Manual):
     def ingest_chunks(cls, experiment_name: str) -> None:
         """Ingest ephys recording chunks with clock synchronization.
 
-        Loops over all ProbeInsertions for this experiment and processes each
-        probe's binary files into chunk entries with sync models.
+        Discovers ephys binary files across all epochs, resolves each file's
+        ProbeInsertion (with subject) via EphysEpoch.Insertion, and creates
+        chunk entries with sync models.
 
-        For each ephys file:
-        1. Extract ONIX timestamps from clock files
-        2. Map to HARP timestamps using sync models
-        3. Store chunk metadata and sync models
+        Files without a subject-probe mapping (no EphysEpoch.Insertion) are
+        skipped with a warning.
 
         Args:
             experiment_name: Name of the experiment to process
@@ -349,25 +475,95 @@ class EphysChunk(dj.Manual):
             logger.error(f"Raw data directory not found for {experiment_name}")
             return
 
-        probe_insertions = (ProbeInsertion & exp_key).fetch(as_dict=True)
-        if not probe_insertions:
+        # Build epoch lookup: {epoch_dir_name: epoch_start} from Epoch table
+        epochs = (acquisition.Epoch & exp_key).fetch(
+            "epoch_start", "epoch_dir", as_dict=True
+        )
+        epoch_dir_to_start = {}
+        for ep in epochs:
+            if ep["epoch_dir"]:
+                # epoch_dir is relative path like "2024-01-15T10-00-00"
+                # Extract the top-level directory name
+                top_dir = Path(ep["epoch_dir"]).parts[0]
+                epoch_dir_to_start[top_dir] = ep["epoch_start"]
+
+        # Build insertion lookup from EphysEpoch.Insertion:
+        # {(epoch_start, probe_label): insertion_key}
+        insertion_lookup = {}
+        insertion_entries = (EphysEpoch.Insertion & exp_key).fetch(as_dict=True)
+        for entry in insertion_entries:
+            lookup_key = (entry["epoch_start"], entry["probe_label"])
+            insertion_lookup[lookup_key] = {
+                "experiment_name": entry["experiment_name"],
+                "subject": entry["subject"],
+                "insertion_number": entry["insertion_number"],
+            }
+
+        if not insertion_lookup:
             logger.warning(
-                f"No ProbeInsertions found for {experiment_name}. "
+                f"No EphysEpoch.Insertion entries found for {experiment_name}. "
                 "Run EphysEpoch.populate() first."
             )
             return
 
-        # Loop over all probe insertions
-        for pi in probe_insertions:
-            insertion_key = {
-                "experiment_name": experiment_name,
-                "insertion_number": pi["insertion_number"],
-            }
-            probe_name = pi["probe"]
-            probe_label = pi["probe_label"]
-            probe_type = (Probe & {"probe": probe_name}).fetch1("probe_type")
+        # Discover ALL ephys binary files across epochs
+        all_ephys_files = sorted(
+            list(raw_dir.rglob("*_AmplifierData*.bin")),
+            key=lambda x: x.as_posix(),
+        )
+
+        if not all_ephys_files:
+            logger.info(f"No ephys amplifier files found in {raw_dir}")
+            return
+
+        # Sync model cache (per parent directory)
+        sync_models = {}
+
+        for ephys_file in all_ephys_files:
+            rel_path = ephys_file.relative_to(raw_dir).as_posix()
+
+            # Skip already-ingested files
+            if cls.File & exp_key & {"file_path": rel_path}:
+                continue
+
+            # Parse probe_label from filename
+            # e.g., "NeuropixelsV2Beta_ProbeA_AmplifierData_0.bin" -> "ProbeA"
+            name_match = re.search(r"_(Probe[A-Z])_AmplifierData", ephys_file.name)
+            if not name_match:
+                logger.warning(f"Cannot parse probe label from {ephys_file.name}. Skipping.")
+                continue
+            probe_label = name_match.group(1)
+
+            # Determine epoch from directory path
+            # File path structure: raw_dir / epoch_dir / device_name / files
+            rel_parts = ephys_file.relative_to(raw_dir).parts
+            if len(rel_parts) < 3:
+                logger.warning(f"Unexpected file path structure: {ephys_file}. Skipping.")
+                continue
+            epoch_dir_name = rel_parts[0]
+
+            epoch_start = epoch_dir_to_start.get(epoch_dir_name)
+            if epoch_start is None:
+                logger.warning(
+                    f"Cannot resolve epoch for {ephys_file} "
+                    f"(epoch_dir={epoch_dir_name} not found in Epoch table). Skipping."
+                )
+                continue
+
+            # Look up ProbeInsertion via EphysEpoch.Insertion
+            lookup_key = (epoch_start, probe_label)
+            insertion_key = insertion_lookup.get(lookup_key)
+            if insertion_key is None:
+                logger.warning(
+                    f"Skipping {rel_path}: no subject-probe mapping for {probe_label} "
+                    f"in epoch {epoch_start}. Register via probe_assignments.json or "
+                    f"manual ProbeInsertion insert, then run EphysEpoch.populate()."
+                )
+                continue
 
             # Resolve electrode config
+            probe_name = (ProbeInsertion & insertion_key).fetch1("probe")
+            probe_type = (Probe & {"probe": probe_name}).fetch1("probe_type")
             configs = (ElectrodeConfig & {"probe_type": probe_type}).fetch(
                 "electrode_config_name"
             )
@@ -380,111 +576,125 @@ class EphysChunk(dj.Manual):
                 )
             electrode_config_name = configs[0]
 
-            # Find ephys binary files using probe_label for pattern matching
-            ephys_files = sorted(
-                list(raw_dir.rglob(f"*{probe_label}_AmplifierData*.bin")),
-                key=lambda x: int(x.stem.split("_")[-1]),
-            )
-
-            if not ephys_files:
-                logger.info(f"No ephys files found for {probe_label} in {raw_dir}")
+            # Process the file into a chunk entry
+            try:
+                cls._process_ephys_file(
+                    ephys_file=ephys_file,
+                    raw_dir=raw_dir,
+                    insertion_key=insertion_key,
+                    epoch_start=epoch_start,
+                    probe_label=probe_label,
+                    probe_type=probe_type,
+                    electrode_config_name=electrode_config_name,
+                    sync_models=sync_models,
+                )
+            except Exception as e:
+                logger.error(f"Failed to process {ephys_file}: {e}")
                 continue
 
-            # Sync model cache (per parent directory)
-            sync_models = {}
+    @classmethod
+    def _process_ephys_file(
+        cls,
+        ephys_file: Path,
+        raw_dir: Path,
+        insertion_key: dict,
+        epoch_start: datetime,
+        probe_label: str,
+        probe_type: str,
+        electrode_config_name: str,
+        sync_models: dict,
+    ) -> None:
+        """Process a single ephys binary file into a chunk entry with sync model.
 
-            def ephys_chunk_from_file(ephys_file: Path) -> None:
-                """Process a single ephys file into a chunk entry."""
-                clock_file = ephys_file.with_name(
-                    ephys_file.name.replace("AmplifierData", "Clock")
+        Args:
+            ephys_file: Path to the amplifier data binary file
+            raw_dir: Root raw data directory
+            insertion_key: ProbeInsertion key (experiment_name, subject, insertion_number)
+            epoch_start: Epoch start datetime for this file's epoch
+            probe_label: File label (e.g., "ProbeA")
+            probe_type: Probe type string
+            electrode_config_name: Electrode configuration name
+            sync_models: Mutable dict cache for sync models (shared across files)
+        """
+        clock_file = ephys_file.with_name(
+            ephys_file.name.replace("AmplifierData", "Clock")
+        )
+        onix_ts = np.memmap(clock_file, mode="r", dtype=np.uint64)
+
+        model_parent_dir = raw_dir / ephys_file.relative_to(raw_dir).parents[-2]
+        if model_parent_dir.as_posix() not in sync_models:
+            device_prefix = ephys_file.name.split(f"_{probe_label}_")[0]
+            device_reader = getattr(social_ephys, device_prefix, None)
+            if device_reader is None:
+                raise ValueError(
+                    f"No sync reader found for device '{device_prefix}'. "
+                    f"Available devices: {list(social_ephys.keys())}"
                 )
-                onix_ts = np.memmap(clock_file, mode="r", dtype=np.uint64)
+            sync_models[model_parent_dir.as_posix()] = io_api.load(
+                model_parent_dir,
+                device_reader.HarpSyncModel,
+            )
 
-                model_parent_dir = raw_dir / ephys_file.relative_to(raw_dir).parents[-2]
-                if model_parent_dir.as_posix() not in sync_models:
-                    # Detect device name from the file prefix for correct sync reader
-                    device_prefix = ephys_file.name.split(f"_{probe_label}_")[0]
-                    device_reader = getattr(social_ephys, device_prefix, None)
-                    if device_reader is None:
-                        raise ValueError(
-                            f"No sync reader found for device '{device_prefix}'. "
-                            f"Available devices: {list(social_ephys.keys())}"
-                        )
-                    sync_models[model_parent_dir.as_posix()] = io_api.load(
-                        model_parent_dir,
-                        device_reader.HarpSyncModel,
-                    )
+        sync_model = sync_models[model_parent_dir.as_posix()]
+        matched_sync = sync_model.query(
+            f"(clock_start <= {onix_ts[0]} <= clock_end)"
+            f" | "
+            f"(clock_start <= {onix_ts[-1]} <= clock_end)"
+        )
 
-                sync_model = sync_models[model_parent_dir.as_posix()]
-                matched_sync = sync_model.query(
-                    f"(clock_start <= {onix_ts[0]} <= clock_end)"
-                    f" | "
-                    f"(clock_start <= {onix_ts[-1]} <= clock_end)"
+        sync_entries = []
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for idx, (_, r) in enumerate(matched_sync.iterrows()):
+                if idx == 0:
+                    chunk_start = r.model.predict(
+                        np.array(onix_ts[0]).reshape(-1, 1)
+                    ).flatten()[0]
+                    chunk_start = io_api.to_datetime(chunk_start)
+                if idx == len(matched_sync) - 1:
+                    chunk_end = r.model.predict(
+                        np.array(onix_ts[-1]).reshape(-1, 1)
+                    ).flatten()[0]
+                    chunk_end = io_api.to_datetime(chunk_end)
+
+                model_path = Path(tmpdir) / (
+                    ephys_file.stem + f"_{r.clock_start}.joblib"
                 )
+                joblib.dump(r.model, model_path)
 
-                sync_entries = []
-                with tempfile.TemporaryDirectory() as tmpdir:
-                    for idx, (_, r) in enumerate(matched_sync.iterrows()):
-                        if idx == 0:
-                            chunk_start = r.model.predict(
-                                np.array(onix_ts[0]).reshape(-1, 1)
-                            ).flatten()[0]
-                            chunk_start = io_api.to_datetime(chunk_start)
-                        if idx == len(matched_sync) - 1:
-                            chunk_end = r.model.predict(
-                                np.array(onix_ts[-1]).reshape(-1, 1)
-                            ).flatten()[0]
-                            chunk_end = io_api.to_datetime(chunk_end)
-
-                        model_path = Path(tmpdir) / (
-                            ephys_file.stem + f"_{r.clock_start}.joblib"
-                        )
-                        joblib.dump(r.model, model_path)
-
-                        sync_entries.append(
-                            {
-                                "onix_ts_start": r.clock_start,
-                                "onix_ts_end": r.clock_end,
-                                "sync_model": model_path,
-                                "harp_start": r.name,
-                            }
-                        )
-
-                    chunk_entry = {
-                        **insertion_key,
-                        "chunk_start": chunk_start,
-                        "chunk_end": chunk_end,
-                        "probe_type": probe_type,
-                        "electrode_config_name": electrode_config_name,
+                sync_entries.append(
+                    {
+                        "onix_ts_start": r.clock_start,
+                        "onix_ts_end": r.clock_end,
+                        "sync_model": model_path,
+                        "harp_start": r.name,
                     }
-                    cls.insert1(chunk_entry)
-                    cls.File.insert(
-                        [
-                            dict(
-                                **chunk_entry,
-                                directory_type="raw",
-                                file_name=f.name,
-                                file_path=f.relative_to(raw_dir).as_posix(),
-                            )
-                            for f in (ephys_file, clock_file)
-                        ],
-                        ignore_extra_fields=True,
-                    )
-                    cls.SyncModel.insert(
-                        [{**chunk_entry, **sync_entry} for sync_entry in sync_entries],
-                        ignore_extra_fields=True,
-                    )
+                )
 
-            for ephys_file in ephys_files:
-                rel_path = ephys_file.relative_to(raw_dir).as_posix()
-                if cls.File & insertion_key & {"file_path": rel_path}:
-                    continue
-
-                try:
-                    ephys_chunk_from_file(ephys_file)
-                except Exception as e:
-                    logger.error(f"Failed to process {ephys_file}: {e}")
-                    continue
+            chunk_entry = {
+                **insertion_key,
+                "chunk_start": chunk_start,
+                "chunk_end": chunk_end,
+                "epoch_start": epoch_start,
+                "probe_type": probe_type,
+                "electrode_config_name": electrode_config_name,
+            }
+            cls.insert1(chunk_entry)
+            cls.File.insert(
+                [
+                    dict(
+                        **chunk_entry,
+                        directory_type="raw",
+                        file_name=f.name,
+                        file_path=f.relative_to(raw_dir).as_posix(),
+                    )
+                    for f in (ephys_file, clock_file)
+                ],
+                ignore_extra_fields=True,
+            )
+            cls.SyncModel.insert(
+                [{**chunk_entry, **sync_entry} for sync_entry in sync_entries],
+                ignore_extra_fields=True,
+            )
 
 
 @schema
@@ -534,7 +744,7 @@ class EphysBlockInfo(dj.Imported):
         - Block duration calculations
 
         Args:
-            key: Dictionary containing experiment_name, insertion_number, block_start, block_end
+            key: Dictionary containing experiment_name, subject, insertion_number, block_start, block_end
         """
 
         def create_ephys_chunk_restriction(start_time: datetime, end_time: datetime) -> str:

--- a/aeon/dj_pipeline/ephys.py
+++ b/aeon/dj_pipeline/ephys.py
@@ -262,71 +262,10 @@ class EphysEpoch(dj.Imported):
         Returns:
             Dict mapping probe_label -> {"subject": str, ...}
         """
-        assignments_path = epoch_path / "probe_assignments.json"
-        if assignments_path.exists():
-            try:
-                with open(assignments_path) as f:
-                    assignments = json.load(f)
-                # Validate: every discovered probe label must be in the assignments
-                missing = [l for l in probe_labels if l not in assignments]
-                if missing:
-                    raise ValueError(
-                        f"probe_assignments.json missing entries for: {missing}. "
-                        f"File has keys: {list(assignments.keys())}"
-                    )
-                # Validate: every entry must have 'subject'
-                for label, info in assignments.items():
-                    if "subject" not in info:
-                        raise ValueError(
-                            f"probe_assignments.json entry for '{label}' missing 'subject' field."
-                        )
-                logger.info(f"Read probe assignments from {assignments_path}")
-                return assignments
-            except (json.JSONDecodeError, IOError) as e:
-                raise ValueError(
-                    f"Failed to parse probe_assignments.json at {assignments_path}: {e}"
-                ) from e
-
-        # Carry-forward: find most recent EphysEpoch with Insertion entries
-        prev_insertions = (
-            self.Insertion
-            & {"experiment_name": key["experiment_name"]}
-            & f'epoch_start < "{key["epoch_start"]}"'
-        )
-        if prev_insertions:
-            # Get the most recent epoch_start that has insertions
-            latest_epoch_start = prev_insertions.fetch(
-                "epoch_start", order_by="epoch_start DESC", limit=1
-            )[0]
-            prev_entries = (
-                self.Insertion
-                & {"experiment_name": key["experiment_name"], "epoch_start": latest_epoch_start}
-            ).fetch(as_dict=True)
-
-            # Build assignments from previous epoch's Insertion entries
-            assignments = {}
-            for entry in prev_entries:
-                assignments[entry["probe_label"]] = {"subject": entry["subject"]}
-
-            # Validate: every discovered probe label must be covered
-            missing = [l for l in probe_labels if l not in assignments]
-            if missing:
-                raise ValueError(
-                    f"Carry-forward from epoch {latest_epoch_start} does not cover "
-                    f"probe labels: {missing}. Provide a probe_assignments.json for this epoch."
-                )
-            logger.info(
-                f"Carried forward probe assignments from epoch {latest_epoch_start}"
-            )
-            return assignments
-
-        # No file, no previous epoch — error
-        raise ValueError(
-            f"No probe_assignments.json found in {epoch_path} and no previous epoch "
-            f"to carry forward from. For the first epoch with ephys data, a "
-            f"probe_assignments.json file is required. Expected format:\n"
-            f'{{\n  "ProbeA": {{"probe": "<serial>", "subject": "<subject_name>"}},\n'
-            f'  "ProbeB": {{"probe": "<serial>", "subject": "<subject_name>"}}\n}}'
+        raise NotImplementedError(
+            "Probe-subject assignment resolution is not yet implemented. "
+            "The exact file format and carry-forward logic will be determined "
+            "once the experimental data conventions are finalized."
         )
 
     @staticmethod

--- a/aeon/dj_pipeline/scripts/ephys_v2_setup.py
+++ b/aeon/dj_pipeline/scripts/ephys_v2_setup.py
@@ -318,8 +318,7 @@ def step_ephys_epoch_populate(dry_run=False):
     print_ok(f"ProbeInsertion entries: {len(probe_insertions)}")
     for pi in probe_insertions:
         print_info(
-            f"  insertion {pi['insertion_number']}: probe={pi['probe']}, "
-            f"label={pi['probe_label']}"
+            f"  insertion {pi['insertion_number']}: subject={pi['subject']}, probe={pi['probe']}"
         )
 
     return True

--- a/aeon/dj_pipeline/scripts/ephys_v2_validate.py
+++ b/aeon/dj_pipeline/scripts/ephys_v2_validate.py
@@ -132,19 +132,27 @@ def check_ephys_epochs(results):
     results.record("EphysEpoch", "ProbeInsertion auto-created", len(probe_insertions) > 0,
                     f"{len(probe_insertions)} insertions")
 
-    # Check PK structure: no 'subject' column
+    # Check PK structure: subject should be in PK
     pi_heading = ephys.ProbeInsertion.heading
     has_subject_pk = "subject" in pi_heading.primary_key
-    results.record("EphysEpoch", "ProbeInsertion PK has NO subject", not has_subject_pk,
+    results.record("EphysEpoch", "ProbeInsertion PK has subject", has_subject_pk,
                     f"PK: {pi_heading.primary_key}")
 
-    # Check probe_label field exists
-    has_probe_label = "probe_label" in pi_heading.names
-    results.record("EphysEpoch", "ProbeInsertion has probe_label field", has_probe_label)
+    # Check probe_label is on EphysEpoch.Insertion (not ProbeInsertion)
+    has_probe_label_on_pi = "probe_label" in pi_heading.names
+    results.record("EphysEpoch", "probe_label NOT on ProbeInsertion", not has_probe_label_on_pi)
 
-    # Check probe_label values
-    if probe_insertions and has_probe_label:
-        labels = [pi["probe_label"] for pi in probe_insertions]
+    insertion_heading = ephys.EphysEpoch.Insertion.heading
+    has_probe_label_on_insertion = "probe_label" in insertion_heading.names
+    results.record("EphysEpoch", "probe_label on EphysEpoch.Insertion", has_probe_label_on_insertion)
+
+    # Check EphysEpoch.Insertion entries exist
+    epoch_insertions = (ephys.EphysEpoch.Insertion & {"experiment_name": EXPERIMENT_NAME}).fetch(as_dict=True)
+    results.record("EphysEpoch", "EphysEpoch.Insertion entries created",
+                    len(epoch_insertions) > 0,
+                    f"{len(epoch_insertions)} entries")
+    if epoch_insertions:
+        labels = [ei["probe_label"] for ei in epoch_insertions]
         results.record("EphysEpoch", "probe_label values populated",
                         all(l for l in labels),
                         f"labels: {labels}")

--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -1421,6 +1421,431 @@ class UnitMatching(dj.Computed):
 
 
 
+# ---- Pair-Based Unit Matching (alternative design) ----
+
+
+@schema
+class UnitMatchingPair(dj.Manual):
+    definition = """
+    # User-specified pair of SyncedSpikes for unit matching.
+    # Convention: earlier_block_start < latter_block_start (canonical ordering to prevent duplicates).
+    -> SyncedSpikes.proj(earlier_block_start='block_start', earlier_block_end='block_end')
+    -> SyncedSpikes.proj(latter_block_start='block_start', latter_block_end='block_end')
+    -> UnitMatchingParamSet
+    """
+
+
+@schema
+class PairMatching(dj.Computed):
+    definition = """
+    -> UnitMatchingPair
+    ---
+    execution_time: datetime
+    execution_duration: float  # hours
+    """
+
+    class Unit(dj.Part):
+        definition = """
+        # Unit correspondence between the earlier and latter blocks in this pair.
+        # Each row records one global unit and its unit IDs in each block.
+        # For matched pairs: both earlier_unit and latter_unit are populated.
+        # For unmatched units (only in one block): one side is null.
+        -> master
+        -> GlobalUnit
+        ---
+        -> [nullable] SortedSpikes.Unit.proj(earlier_block_start='block_start', earlier_block_end='block_end', earlier_unit='unit')
+        -> [nullable] SortedSpikes.Unit.proj(latter_block_start='block_start', latter_block_end='block_end', latter_unit='unit')
+        match_confidence=null: float
+        match_comment='': varchar(1000)
+        """
+
+    class Spikes(dj.Part):
+        definition = """
+        # Deduplicated spike times per (global_unit, chunk). Ownership convention:
+        # the first pair to write a (global_unit, chunk) row wins; later pairs skip.
+        -> master
+        -> GlobalUnit
+        -> ephys.EphysChunk
+        ---
+        spike_times: longblob  # datetime64[ns] (UTC), HARP-synced
+        spike_count: int
+        unique index (experiment_name, subject, insertion_number, global_unit, chunk_start)
+        """
+
+    def make(self, key):
+        """Match units between a pair of ephys blocks.
+
+        Determines which block is the "anchor" (already matched in a previous pair)
+        and which is "new". Compares spike times in the overlap region to identify
+        corresponding units. Matched units inherit the anchor's global unit IDs;
+        unmatched units get new global unit IDs.
+
+        For seed pairs (first pair for an insertion — neither block previously matched),
+        all matched unit pairs get fresh global units, and unmatched units each get their own.
+
+        Constraint enforced here: at least one of the two blocks must have been matched
+        in a previous PairMatching, unless this is the seed pair (no PairMatching entries
+        exist for this insertion + paramset).
+
+        Algorithm (spike_time_overlap):
+        1. Determine anchor vs. new block
+        2. Load synced spike times from both blocks
+        3. Compare spike times in overlap region
+        4. Assign global units (inherit or create new)
+        5. Insert GlobalUnit, PairMatching.Unit, PairMatching.Spikes entries
+        """
+        from spikeinterface.comparison import compare_two_sorters
+        from spikeinterface.core import NumpySorting
+
+        execution_time = datetime.now(UTC)
+        matching_method = (UnitMatchingParamSet & key).fetch1("matching_method")
+        params = (UnitMatchingParamSet & key).fetch1("params")
+
+        insertion_key = {
+            k: key[k] for k in ("experiment_name", "subject", "insertion_number")
+        }
+        paramset_key = {"matching_paramset_id": key["matching_paramset_id"]}
+
+        # ---- Build SyncedSpikes keys for both blocks ----
+        # Shared PK fields (same upstream: insertion, electrode group, sorting params)
+        shared_fields = {
+            k: key[k] for k in key
+            if k not in (
+                "earlier_block_start", "earlier_block_end",
+                "latter_block_start", "latter_block_end",
+                "matching_paramset_id",
+            )
+        }
+        earlier_synced_key = {
+            **shared_fields,
+            "block_start": key["earlier_block_start"],
+            "block_end": key["earlier_block_end"],
+        }
+        latter_synced_key = {
+            **shared_fields,
+            "block_start": key["latter_block_start"],
+            "block_end": key["latter_block_end"],
+        }
+
+        # ---- Determine anchor vs. new block ----
+        # A block is "already matched" if it appears as a unit in any previous PairMatching
+        earlier_matched = bool(
+            self.Unit & insertion_key & paramset_key
+            & f'earlier_block_start = "{key["earlier_block_start"]}" '
+            f'OR latter_block_start = "{key["earlier_block_start"]}"'
+        )
+        latter_matched = bool(
+            self.Unit & insertion_key & paramset_key
+            & f'earlier_block_start = "{key["latter_block_start"]}" '
+            f'OR latter_block_start = "{key["latter_block_start"]}"'
+        )
+
+        # Check if any PairMatching exists for this insertion + paramset (seed detection)
+        any_previous = bool(self & insertion_key & paramset_key)
+
+        is_seed = not any_previous
+        if not is_seed and not earlier_matched and not latter_matched:
+            raise ValueError(
+                "Neither block has been matched in a previous pair. "
+                "At least one block must be already matched, unless this is the "
+                "seed pair (no previous PairMatching for this insertion + paramset)."
+            )
+
+        if is_seed:
+            # Seed: earlier block is the anchor by convention
+            anchor_key, new_key = earlier_synced_key, latter_synced_key
+            anchor_is_earlier = True
+            logger.info("Seed pair — earlier block is anchor by convention.")
+        elif earlier_matched and not latter_matched:
+            anchor_key, new_key = earlier_synced_key, latter_synced_key
+            anchor_is_earlier = True
+        elif latter_matched and not earlier_matched:
+            anchor_key, new_key = latter_synced_key, earlier_synced_key
+            anchor_is_earlier = False
+        else:
+            # Both matched — earlier block is anchor by convention
+            anchor_key, new_key = earlier_synced_key, latter_synced_key
+            anchor_is_earlier = True
+            logger.info("Both blocks already matched — earlier block used as anchor.")
+
+        # ---- Load spike times from both blocks ----
+        def _load_block_units(synced_key):
+            """Load and concatenate spike times per unit from SyncedSpikes."""
+            units = {}
+            for entry in (SyncedSpikes.Unit & synced_key).fetch(as_dict=True):
+                uid = entry["unit"]
+                if uid not in units:
+                    units[uid] = []
+                units[uid].append(entry["spike_times"])
+            for uid in units:
+                concatenated = np.sort(np.concatenate(units[uid]))
+                if concatenated.dtype.kind == "M":  # datetime64
+                    concatenated = concatenated.astype("datetime64[ns]").astype(np.int64) / 1e9
+                units[uid] = concatenated
+            return units
+
+        anchor_units = _load_block_units(anchor_key)
+        new_units = _load_block_units(new_key)
+
+        if not new_units:
+            logger.warning(f"No synced spike data in new block. Inserting empty result.")
+            execution_duration = (datetime.now(UTC) - execution_time).total_seconds() / 3600
+            self.insert1({**key, "execution_time": execution_time, "execution_duration": execution_duration})
+            return
+
+        # ---- Look up anchor block's existing global unit assignments ----
+        # Query previous PairMatching.Unit entries where the anchor block participated
+        # (it could have been the earlier or latter block in a previous pair)
+        anchor_unit_to_global = {}
+        if not is_seed:
+            anchor_bs = anchor_key["block_start"]
+            # Anchor appeared as the earlier block in a previous pair
+            for entry in (
+                self.Unit & insertion_key & paramset_key
+                & f'earlier_block_start = "{anchor_bs}"'
+            ).fetch(as_dict=True):
+                if entry["earlier_unit"] is not None:
+                    anchor_unit_to_global[entry["earlier_unit"]] = entry["global_unit"]
+            # Anchor appeared as the latter block in a previous pair
+            for entry in (
+                self.Unit & insertion_key & paramset_key
+                & f'latter_block_start = "{anchor_bs}"'
+            ).fetch(as_dict=True):
+                if entry["latter_unit"] is not None:
+                    anchor_unit_to_global[entry["latter_unit"]] = entry["global_unit"]
+
+        # ---- Compare spike times in overlap region ----
+        anchor_start = anchor_key["block_start"]
+        anchor_end = anchor_key["block_end"]
+        new_start = new_key["block_start"]
+        new_end = new_key["block_end"]
+
+        # Convert to timestamps if datetime
+        if hasattr(anchor_start, "timestamp"):
+            anchor_start_s, anchor_end_s = anchor_start.timestamp(), anchor_end.timestamp()
+            new_start_s, new_end_s = new_start.timestamp(), new_end.timestamp()
+        else:
+            anchor_start_s, anchor_end_s = float(anchor_start), float(anchor_end)
+            new_start_s, new_end_s = float(new_start), float(new_end)
+
+        overlap_start_s = max(anchor_start_s, new_start_s)
+        overlap_end_s = min(anchor_end_s, new_end_s)
+
+        unit_to_global = {}  # new block's unit_id -> global_unit
+        matched_anchors = {}  # new block's unit_id -> anchor unit_id it matched to
+
+        if overlap_start_s < overlap_end_s and anchor_units:
+            # Build spike trains restricted to overlap window
+            def _restrict_to_overlap(spike_times_s):
+                if len(spike_times_s) == 0:
+                    return np.array([])
+                mask = (spike_times_s >= overlap_start_s) & (spike_times_s <= overlap_end_s)
+                return spike_times_s[mask] - overlap_start_s
+
+            delta_time = params.get("delta_time", 0.4) if params else 0.4
+            sampling_frequency = params.get("sampling_frequency", 30000) if params else 30000
+
+            anchor_trains = {}
+            for uid, times in anchor_units.items():
+                restricted = _restrict_to_overlap(times)
+                if len(restricted) > 0:
+                    anchor_trains[uid] = (restricted * sampling_frequency).astype(np.int64)
+
+            new_trains = {}
+            for uid, times in new_units.items():
+                restricted = _restrict_to_overlap(times)
+                if len(restricted) > 0:
+                    new_trains[uid] = (restricted * sampling_frequency).astype(np.int64)
+
+            if anchor_trains and new_trains:
+                sorting_anchor = NumpySorting.from_unit_dict(
+                    anchor_trains, sampling_frequency=sampling_frequency
+                )
+                sorting_new = NumpySorting.from_unit_dict(
+                    new_trains, sampling_frequency=sampling_frequency
+                )
+                comparison = compare_two_sorters(
+                    sorting1=sorting_anchor,
+                    sorting2=sorting_new,
+                    sorting1_name="anchor",
+                    sorting2_name="new",
+                    delta_time=delta_time,
+                )
+
+                matched_pairs = comparison.get_matching()
+                for anchor_uid, new_uid in matched_pairs.items():
+                    if new_uid == -1 or new_uid in unit_to_global:
+                        continue
+                    if anchor_uid in anchor_unit_to_global:
+                        unit_to_global[new_uid] = anchor_unit_to_global[anchor_uid]
+                        matched_anchors[new_uid] = anchor_uid
+                    elif is_seed:
+                        # Seed: anchor units don't have global IDs yet, will be assigned below
+                        pass
+        else:
+            if not anchor_units:
+                logger.info("Anchor block has no units.")
+            else:
+                logger.warning("No temporal overlap between the two blocks.")
+
+        # ---- Handle seed case: assign global units to anchor block's units first ----
+        existing_ids = (GlobalUnit & insertion_key).fetch("global_unit")
+        next_gu_id = int(existing_ids.max()) + 1 if len(existing_ids) > 0 else 1
+
+        seed_anchor_assignments = {}
+        if is_seed:
+            for uid in anchor_units:
+                seed_anchor_assignments[uid] = next_gu_id
+                anchor_unit_to_global[uid] = next_gu_id
+                next_gu_id += 1
+
+            # Now resolve matched pairs using the freshly-assigned anchor globals
+            if overlap_start_s < overlap_end_s and anchor_units:
+                # Re-check matched_pairs with the now-populated anchor_unit_to_global
+                if anchor_trains and new_trains:
+                    matched_pairs = comparison.get_matching()
+                    for anchor_uid, new_uid in matched_pairs.items():
+                        if new_uid == -1 or new_uid in unit_to_global:
+                            continue
+                        if anchor_uid in anchor_unit_to_global:
+                            unit_to_global[new_uid] = anchor_unit_to_global[anchor_uid]
+                            matched_anchors[new_uid] = anchor_uid
+
+        # ---- Assign new global units for unmatched new-block units ----
+        n_matched = len(unit_to_global)
+        for uid in new_units:
+            if uid not in unit_to_global:
+                unit_to_global[uid] = next_gu_id
+                next_gu_id += 1
+        n_new = len(unit_to_global) - n_matched
+
+        # ---- Get peak electrode for units ----
+        def _get_unit_electrodes(synced_key):
+            electrodes = {}
+            for entry in (SortedSpikes.Unit & synced_key).proj("electrode").fetch(as_dict=True):
+                electrodes[entry["unit"]] = {
+                    "probe_type": entry["probe_type"],
+                    "electrode": entry["electrode"],
+                }
+            return electrodes
+
+        new_electrodes = _get_unit_electrodes(new_key)
+        anchor_electrodes = _get_unit_electrodes(anchor_key) if is_seed else {}
+
+        # ---- Insert GlobalUnit entries ----
+        # Seed: insert anchor block's global units
+        for uid, gu_id in seed_anchor_assignments.items():
+            gu_key = {**insertion_key, "global_unit": gu_id}
+            if uid in anchor_electrodes:
+                GlobalUnit.insert1(
+                    {**gu_key, **paramset_key, **anchor_electrodes[uid]},
+                    skip_duplicates=True,
+                )
+
+        # New block's global units: insert new, update existing
+        for uid, gu_id in unit_to_global.items():
+            gu_key = {**insertion_key, "global_unit": gu_id}
+            if uid not in new_electrodes:
+                raise ValueError(
+                    f"No electrode info for unit {uid} in SortedSpikes.Unit. Key: {new_key}"
+                )
+            electrode = new_electrodes[uid]
+            if not (GlobalUnit & gu_key):
+                GlobalUnit.insert1({**gu_key, **paramset_key, **electrode})
+            else:
+                GlobalUnit.update1({**gu_key, **paramset_key, **electrode})
+
+        # ---- Insert master entry ----
+        execution_duration = (datetime.now(UTC) - execution_time).total_seconds() / 3600
+        self.insert1({
+            **key,
+            "execution_time": execution_time,
+            "execution_duration": execution_duration,
+        })
+
+        # ---- Insert PairMatching.Unit entries ----
+        # Build global_unit -> (earlier_unit, latter_unit) mapping
+        pair_units = {}  # global_unit -> {earlier_unit, latter_unit, match_confidence}
+
+        # Seed: anchor block units
+        if is_seed:
+            for uid, gu_id in seed_anchor_assignments.items():
+                entry = pair_units.setdefault(
+                    gu_id, {"earlier_unit": None, "latter_unit": None, "match_confidence": None}
+                )
+                if anchor_is_earlier:
+                    entry["earlier_unit"] = uid
+                else:
+                    entry["latter_unit"] = uid
+
+        # New block units (matched and unmatched)
+        for new_uid, gu_id in unit_to_global.items():
+            entry = pair_units.setdefault(
+                gu_id, {"earlier_unit": None, "latter_unit": None, "match_confidence": None}
+            )
+            # Place the new unit on the correct side
+            if anchor_is_earlier:
+                entry["latter_unit"] = new_uid
+            else:
+                entry["earlier_unit"] = new_uid
+            # If matched, also record the anchor unit on the other side
+            anchor_uid = matched_anchors.get(new_uid)
+            if anchor_uid is not None:
+                if anchor_is_earlier:
+                    entry["earlier_unit"] = anchor_uid
+                else:
+                    entry["latter_unit"] = anchor_uid
+
+        # Insert Unit Part rows
+        for gu_id, unit_info in pair_units.items():
+            self.Unit.insert1({
+                **key,
+                **insertion_key,
+                "global_unit": gu_id,
+                "earlier_unit": unit_info["earlier_unit"],
+                "latter_unit": unit_info["latter_unit"],
+                "match_confidence": unit_info["match_confidence"],
+            }, ignore_extra_fields=True)
+
+        # ---- Insert PairMatching.Spikes with ownership convention ----
+        def _insert_spikes_for_block(synced_key, block_unit_to_global):
+            chunk_starts = sorted({
+                ck["chunk_start"]
+                for ck in (SyncedSpikes.Unit & synced_key).fetch("KEY")
+            })
+            for uid, gu_id in block_unit_to_global.items():
+                for cs in chunk_starts:
+                    # Ownership check
+                    if self.Spikes & {**insertion_key, "global_unit": gu_id, "chunk_start": cs}:
+                        continue
+                    synced_entry = SyncedSpikes.Unit & {**synced_key, "unit": uid, "chunk_start": cs}
+                    if not synced_entry:
+                        continue
+                    spike_times = synced_entry.fetch1("spike_times")
+                    self.Spikes.insert1({
+                        **key,
+                        **insertion_key,
+                        "global_unit": gu_id,
+                        "chunk_start": cs,
+                        "spike_times": spike_times,
+                        "spike_count": len(spike_times),
+                    }, ignore_extra_fields=True)
+
+        if is_seed:
+            _insert_spikes_for_block(anchor_key, seed_anchor_assignments)
+        _insert_spikes_for_block(new_key, unit_to_global)
+
+        logger.info(
+            f"Pair matching complete:\n"
+            f"  Earlier block: {key['earlier_block_start']}\n"
+            f"  Latter block: {key['latter_block_start']}\n"
+            f"  Seed: {is_seed}\n"
+            f"  {len(unit_to_global)} new-block units processed\n"
+            f"  {n_matched} matched to existing global units\n"
+            f"  {n_new} new global units created"
+        )
+
+
 # ---- Ephys preprocessing with spike interface ----
 
 def ephys_preproc(recording) -> Any:

--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -658,7 +658,7 @@ class SortedSpikes(dj.Imported):
                 & key
         )
 
-        # Check if there's an official curation for this session
+        # Check if there's an official curation for this block
         # If so, use the curated analyzer; otherwise use the raw analyzer
         # Use lazy import to avoid circular dependency
         curation_id = -1
@@ -1082,18 +1082,18 @@ class UnitMatchingMethod(dj.Lookup):
     matching_method_description: varchar(1000)
     """
     contents = [
-        ("spike_time_overlap", "Matches units by comparing spike times during overlapping time windows between sessions"),
+        ("spike_time_overlap", "Matches units by comparing spike times during overlapping time windows between ephys blocks"),
     ]
 
 
 @schema
 class GlobalUnit(dj.Manual):
     definition = """
-    # Persistent neuron identity across sessions for the same probe insertion
+    # Persistent neuron identity across ephys blocks for the same probe insertion
     -> ephys.ProbeInsertion
     global_unit: int  # unique ID within this insertion
     ---
-    -> ephys.ProbeType.Electrode  # peak electrode (denormalized, updated each session)
+    -> ephys.ProbeType.Electrode  # peak electrode (denormalized, updated each block)
     global_unit_comment='': varchar(1000)
     """
 
@@ -1131,9 +1131,9 @@ class UnitMatching(dj.Computed):
 
     @property
     def key_source(self):
-        """Only the earliest unprocessed session per insertion (temporal ordering).
+        """Only the earliest unprocessed ephys block per insertion (temporal ordering).
 
-        Ensures that sessions are processed in block_start order within each insertion.
+        Ensures that blocks are processed in block_start order within each insertion.
         Different insertions can be processed in parallel.
         """
         from aeon.dj_pipeline import spike_sorting_curation
@@ -1146,10 +1146,10 @@ class UnitMatching(dj.Computed):
         return candidates * next_per_insertion & "block_start = next_start"
 
     def make(self, key):
-        """Match units from a new session against existing global units.
+        """Match units from a new ephys block against existing global units.
 
-        Sessions must be processed in temporal order (by block_start).
-        Session N compares its units against previously-matched sessions (1..N-1).
+        Blocks must be processed in temporal order (by block_start).
+        Block N compares its units against previously-matched blocks (1..N-1).
 
         Algorithm (spike_time_overlap):
         1. Verify temporal ordering (guard against direct make() calls)
@@ -1175,32 +1175,32 @@ class UnitMatching(dj.Computed):
         unprocessed_earlier = earlier_eligible - self
         if unprocessed_earlier:
             raise ValueError(
-                f"Temporal ordering violation: {len(unprocessed_earlier)} earlier session(s) "
+                f"Temporal ordering violation: {len(unprocessed_earlier)} earlier block(s) "
                 f"for insertion {insertion_key} not yet processed. "
-                f"Sessions must be processed in block_start order."
+                f"Blocks must be processed in block_start order."
             )
 
-        # ---- Load this session's synced spike times ----
+        # ---- Load this block's synced spike times ----
         block_start, block_end = (ephys.EphysBlock & key).fetch1(
             "block_start", "block_end"
         )
 
-        this_session_units = {}
+        this_block_units = {}
         for unit_entry in (SyncedSpikes.Unit & key).fetch(as_dict=True):
             unit_id = unit_entry["unit"]
-            if unit_id not in this_session_units:
-                this_session_units[unit_id] = []
-            this_session_units[unit_id].append(unit_entry["spike_times"])
+            if unit_id not in this_block_units:
+                this_block_units[unit_id] = []
+            this_block_units[unit_id].append(unit_entry["spike_times"])
 
         # Concatenate spike times across chunks per unit, convert to epoch seconds
-        for unit_id in this_session_units:
-            concatenated = np.sort(np.concatenate(this_session_units[unit_id]))
+        for unit_id in this_block_units:
+            concatenated = np.sort(np.concatenate(this_block_units[unit_id]))
             if concatenated.dtype.kind == "M":  # datetime64
                 concatenated = concatenated.astype("datetime64[ns]").astype(np.int64) / 1e9
-            this_session_units[unit_id] = concatenated
+            this_block_units[unit_id] = concatenated
 
-        if not this_session_units:
-            logger.warning(f"No synced spike data found for session {key}. Skipping.")
+        if not this_block_units:
+            logger.warning(f"No synced spike data found for block {key}. Skipping.")
             self.insert1({
                 **key,
                 "matching_method": matching_method,
@@ -1209,21 +1209,21 @@ class UnitMatching(dj.Computed):
             })
             return
 
-        # ---- Find overlapping previous sessions ----
+        # ---- Find overlapping previous blocks ----
         previously_matched = (self & insertion_key).fetch(as_dict=True)
-        overlapping_sessions = [
+        overlapping_blocks = [
             s for s in previously_matched
             if s["block_start"] < block_end and s["block_end"] > block_start
         ]
 
-        # Map: this session's unit_id -> global_unit (if matched)
+        # Map: this block's unit_id -> global_unit (if matched)
         unit_to_global = {}
 
         if not previously_matched:
-            logger.info("First session for this insertion — all units will be new global units.")
-        elif not overlapping_sessions:
+            logger.info("First block for this insertion — all units will be new global units.")
+        elif not overlapping_blocks:
             logger.warning(
-                f"No overlapping sessions found among {len(previously_matched)} previous sessions. "
+                f"No overlapping blocks found among {len(previously_matched)} previous blocks. "
                 f"All units will be assigned new global unit IDs (no temporal overlap for matching)."
             )
 
@@ -1237,15 +1237,15 @@ class UnitMatching(dj.Computed):
             mask = (spike_times_s >= start_s) & (spike_times_s <= end_s)
             return spike_times_s[mask] - start_s
 
-        if overlapping_sessions:
-            for prev_session in overlapping_sessions:
-                overlap_start = max(block_start, prev_session["block_start"])
-                overlap_end = min(block_end, prev_session["block_end"])
+        if overlapping_blocks:
+            for prev_block in overlapping_blocks:
+                overlap_start = max(block_start, prev_block["block_start"])
+                overlap_end = min(block_end, prev_block["block_end"])
                 overlap_start_s = overlap_start.timestamp()
                 overlap_end_s = overlap_end.timestamp()
 
-                # Load previous session's spike times (prev_session has all PK fields)
-                prev_key = prev_session
+                # Load previous block's spike times (prev_block has all PK fields)
+                prev_key = prev_block
                 prev_units = {}
                 for unit_entry in (SyncedSpikes.Unit & prev_key).fetch(as_dict=True):
                     uid = unit_entry["unit"]
@@ -1263,7 +1263,7 @@ class UnitMatching(dj.Computed):
 
                 # Build spike train dicts for the overlap window (sample indices at 30kHz)
                 this_spike_trains = {}
-                for uid, times in this_session_units.items():
+                for uid, times in this_block_units.items():
                     restricted = _restrict_to_overlap(times, overlap_start_s, overlap_end_s)
                     if len(restricted) > 0:
                         this_spike_trains[uid] = (restricted * 30000).astype(np.int64)
@@ -1297,7 +1297,7 @@ class UnitMatching(dj.Computed):
                     if this_uid == -1 or this_uid in unit_to_global:
                         continue
 
-                    # Look up which global unit the previous session's unit belongs to
+                    # Look up which global unit the previous block's unit belongs to
                     gu_match = self.Unit & {**prev_key, "unit": prev_uid}
                     if gu_match:
                         unit_to_global[this_uid] = gu_match.fetch1("global_unit")
@@ -1307,13 +1307,13 @@ class UnitMatching(dj.Computed):
         next_gu_id = int(existing_ids.max()) + 1 if len(existing_ids) > 0 else 1
         n_matched = len(unit_to_global)
 
-        for unit_id in this_session_units:
+        for unit_id in this_block_units:
             if unit_id not in unit_to_global:
                 unit_to_global[unit_id] = next_gu_id
                 next_gu_id += 1
         n_new = len(unit_to_global) - n_matched
 
-        # ---- Get peak electrode for each unit in this session ----
+        # ---- Get peak electrode for each unit in this block ----
         # electrode is a non-PK attribute on SortedSpikes.Unit, so use proj() to include it
         unit_electrodes = {}
         for entry in (SortedSpikes.Unit & key).proj("electrode").fetch(as_dict=True):
@@ -1335,7 +1335,7 @@ class UnitMatching(dj.Computed):
                 # New global unit
                 GlobalUnit.insert1({**gu_key, **electrode})
             else:
-                # Existing global unit — update electrode to latest session's estimate
+                # Existing global unit — update electrode to latest block's estimate
                 GlobalUnit.update1({**gu_key, **electrode})
 
         # ---- Insert master entry ----
@@ -1357,14 +1357,14 @@ class UnitMatching(dj.Computed):
             }, ignore_extra_fields=True)
 
         # ---- Insert UnitMatching.Spikes with ownership convention ----
-        # For each (global_unit, chunk): skip if an earlier session already owns it
-        this_session_chunks = (SyncedSpikes.Unit & key).fetch("KEY")
-        # Get unique chunk_starts for this session
-        chunk_starts = sorted({ck["chunk_start"] for ck in this_session_chunks})
+        # For each (global_unit, chunk): skip if an earlier block already owns it
+        this_block_chunks = (SyncedSpikes.Unit & key).fetch("KEY")
+        # Get unique chunk_starts for this block
+        chunk_starts = sorted({ck["chunk_start"] for ck in this_block_chunks})
 
         for unit_id, gu_id in unit_to_global.items():
             for chunk_start in chunk_starts:
-                # Ownership check: does any session already own this (insertion, unit, chunk)?
+                # Ownership check: does any block already own this (insertion, unit, chunk)?
                 existing = self.Spikes & {
                     **insertion_key,
                     "global_unit": gu_id,
@@ -1373,7 +1373,7 @@ class UnitMatching(dj.Computed):
                 if existing:
                     logger.debug(
                         f"Ownership skip: global_unit={gu_id}, chunk_start={chunk_start} "
-                        f"already owned by earlier session"
+                        f"already owned by earlier block"
                     )
                     continue
 
@@ -1397,7 +1397,7 @@ class UnitMatching(dj.Computed):
                 }, ignore_extra_fields=True)
 
         logger.info(
-            f"Unit matching complete for session {key['block_start']}:\n"
+            f"Unit matching complete for block {key['block_start']}:\n"
             f"  {len(unit_to_global)} units processed\n"
             f"  {n_matched} matched to existing global units\n"
             f"  {n_new} new global units created"

--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -1087,56 +1087,104 @@ class UnitMatchingMethod(dj.Lookup):
 
 
 @schema
+class GlobalUnit(dj.Manual):
+    definition = """
+    # Persistent neuron identity across sessions for the same probe insertion
+    -> ephys.ProbeInsertion
+    global_unit: int  # unique ID within this insertion
+    ---
+    -> ephys.ProbeType.Electrode  # peak electrode (denormalized, updated each session)
+    global_unit_comment='': varchar(1000)
+    """
+
+
+@schema
 class UnitMatching(dj.Computed):
     definition = """
     -> SyncedSpikes
-    -> UnitMatchingMethod
     ---
+    -> UnitMatchingMethod
     execution_time: datetime
     execution_duration: float  # hours
     """
 
+    class Unit(dj.Part):
+        definition = """
+        -> master
+        -> SortedSpikes.Unit
+        ---
+        -> GlobalUnit
+        match_confidence=null: float
+        match_comment='': varchar(1000)
+        """
+
+    class Spikes(dj.Part):
+        definition = """
+        -> master
+        -> GlobalUnit
+        -> ephys.EphysChunk
+        ---
+        spike_times: longblob  # datetime64[ns] (UTC), HARP-synced
+        spike_count: int
+        unique index (experiment_name, insertion_number, global_unit, chunk_start)
+        """
+
     @property
     def key_source(self):
-        """Only process sessions that have been officially curated."""
+        """Only the earliest unprocessed session per insertion (temporal ordering).
+
+        Ensures that sessions are processed in block_start order within each insertion.
+        Different insertions can be processed in parallel.
+        """
         from aeon.dj_pipeline import spike_sorting_curation
-        curated = SyncedSpikes * UnitMatchingMethod & spike_sorting_curation.ApplyOfficialCuration
-        return curated - self
+
+        eligible = SyncedSpikes & spike_sorting_curation.ApplyOfficialCuration
+        candidates = eligible - self
+        next_per_insertion = dj.U(
+            "experiment_name", "insertion_number"
+        ).aggr(candidates, next_start="MIN(block_start)")
+        return candidates * next_per_insertion & "block_start = next_start"
 
     def make(self, key):
-        """Match units from a new session against existing universal units.
+        """Match units from a new session against existing global units.
 
-        IMPORTANT: Sessions must be processed in temporal order (by block_start).
-        Session N compares its units against all previously-matched sessions (1..N-1).
-        If sessions are processed out of order, universal unit assignments will be wrong.
+        Sessions must be processed in temporal order (by block_start).
+        Session N compares its units against previously-matched sessions (1..N-1).
 
         Algorithm (spike_time_overlap):
-        1. Find all previously matched sessions for the same insertion that
-           overlap in time with this session
-        2. For each overlapping pair, use SpikeInterface's compare_two_sorters()
-           to find matching units based on spike time coincidence
-        3. Matched units get linked to existing universal units
-        4. Unmatched units become new universal units
+        1. Verify temporal ordering (guard against direct make() calls)
+        2. Find overlapping previous blocks and compare spike times
+        3. Matched units inherit existing global unit IDs
+        4. Unmatched units become new global units
+        5. Insert GlobalUnit, UnitMatching.Unit, UnitMatching.Spikes entries
         """
         from spikeinterface.comparison import compare_two_sorters
         from spikeinterface.core import NumpySorting
+        from aeon.dj_pipeline import spike_sorting_curation
 
         execution_time = datetime.now(UTC)
+        matching_method = "spike_time_overlap"
 
-        matching_method = key["matching_method"]
         insertion_key = {
             k: key[k] for k in ("experiment_name", "insertion_number")
         }
 
-        # Scope for universal unit ID assignment
-        scope_key = {**insertion_key, "matching_method": matching_method}
+        # ---- Temporal ordering guard ----
+        eligible = SyncedSpikes & spike_sorting_curation.ApplyOfficialCuration
+        earlier_eligible = eligible & insertion_key & f'block_start < "{key["block_start"]}"'
+        unprocessed_earlier = earlier_eligible - self
+        if unprocessed_earlier:
+            raise ValueError(
+                f"Temporal ordering violation: {len(unprocessed_earlier)} earlier session(s) "
+                f"for insertion {insertion_key} not yet processed. "
+                f"Sessions must be processed in block_start order."
+            )
 
-        # Get this session's block time range
+        # ---- Load this session's synced spike times ----
         block_start, block_end = (ephys.EphysBlock & key).fetch1(
             "block_start", "block_end"
         )
 
-        # Get this session's synced spike times by unit (as epoch seconds)
         this_session_units = {}
         for unit_entry in (SyncedSpikes.Unit & key).fetch(as_dict=True):
             unit_id = unit_entry["unit"]
@@ -1144,40 +1192,45 @@ class UnitMatching(dj.Computed):
                 this_session_units[unit_id] = []
             this_session_units[unit_id].append(unit_entry["spike_times"])
 
-        # Concatenate spike times across chunks for each unit, convert to epoch seconds
+        # Concatenate spike times across chunks per unit, convert to epoch seconds
         for unit_id in this_session_units:
             concatenated = np.sort(np.concatenate(this_session_units[unit_id]))
-            # SyncedSpikes.Unit stores datetime64[ns] arrays; convert to epoch seconds
-            # for overlap comparison and SpikeInterface compatibility
-            if concatenated.dtype.kind == 'M':  # datetime64
-                concatenated = concatenated.astype('datetime64[ns]').astype(np.int64) / 1e9
+            if concatenated.dtype.kind == "M":  # datetime64
+                concatenated = concatenated.astype("datetime64[ns]").astype(np.int64) / 1e9
             this_session_units[unit_id] = concatenated
 
         if not this_session_units:
             logger.warning(f"No synced spike data found for session {key}. Skipping.")
-            self.insert1({**key, "execution_time": execution_time,
-                          "execution_duration": 0.0})
+            self.insert1({
+                **key,
+                "matching_method": matching_method,
+                "execution_time": execution_time,
+                "execution_duration": 0.0,
+            })
             return
 
-        # Find previously matched sessions for the same insertion that overlap in time
-        # block_start and block_end are already in the PK (inherited from EphysBlock)
-        previously_matched = (
-            self & insertion_key
-        ).fetch(as_dict=True)
-
+        # ---- Find overlapping previous sessions ----
+        previously_matched = (self & insertion_key).fetch(as_dict=True)
         overlapping_sessions = [
             s for s in previously_matched
             if s["block_start"] < block_end and s["block_end"] > block_start
         ]
 
-        # Map: this session's unit_id -> universal_unit (if matched)
-        unit_to_universal = {}
+        # Map: this session's unit_id -> global_unit (if matched)
+        unit_to_global = {}
+
+        if not previously_matched:
+            logger.info("First session for this insertion — all units will be new global units.")
+        elif not overlapping_sessions:
+            logger.warning(
+                f"No overlapping sessions found among {len(previously_matched)} previous sessions. "
+                f"All units will be assigned new global unit IDs (no temporal overlap for matching)."
+            )
 
         def _restrict_to_overlap(spike_times_s, start_s, end_s):
             """Restrict spike times (epoch seconds) to overlap window.
 
             Returns times relative to start of overlap window (in seconds).
-            Returns empty array if no spikes fall within the window.
             """
             if len(spike_times_s) == 0:
                 return np.array([])
@@ -1185,21 +1238,14 @@ class UnitMatching(dj.Computed):
             return spike_times_s[mask] - start_s
 
         if overlapping_sessions:
-            # Get overlap window and compare
             for prev_session in overlapping_sessions:
                 overlap_start = max(block_start, prev_session["block_start"])
                 overlap_end = min(block_end, prev_session["block_end"])
-
-                # Convert overlap bounds to epoch seconds (matching spike time format)
                 overlap_start_s = overlap_start.timestamp()
                 overlap_end_s = overlap_end.timestamp()
 
-                # Get previous session's spike times
-                prev_key = {
-                    k: prev_session[k]
-                    for k in ("experiment_name", "insertion_number",
-                              "block_start", "block_end", "electrode_group", "paramset_id")
-                }
+                # Load previous session's spike times (prev_session has all PK fields)
+                prev_key = prev_session
                 prev_units = {}
                 for unit_entry in (SyncedSpikes.Unit & prev_key).fetch(as_dict=True):
                     uid = unit_entry["unit"]
@@ -1208,8 +1254,8 @@ class UnitMatching(dj.Computed):
                     prev_units[uid].append(unit_entry["spike_times"])
                 for uid in prev_units:
                     concatenated = np.sort(np.concatenate(prev_units[uid]))
-                    if concatenated.dtype.kind == 'M':
-                        concatenated = concatenated.astype('datetime64[ns]').astype(np.int64) / 1e9
+                    if concatenated.dtype.kind == "M":
+                        concatenated = concatenated.astype("datetime64[ns]").astype(np.int64) / 1e9
                     prev_units[uid] = concatenated
 
                 if not prev_units:
@@ -1231,193 +1277,133 @@ class UnitMatching(dj.Computed):
                 if not this_spike_trains or not prev_spike_trains:
                     continue
 
-                # Create NumpySorting objects
+                # Compare using SpikeInterface
                 sorting_this = NumpySorting.from_unit_dict(
                     this_spike_trains, sampling_frequency=30000
                 )
                 sorting_prev = NumpySorting.from_unit_dict(
                     prev_spike_trains, sampling_frequency=30000
                 )
-
-                # Compare using SpikeInterface
                 comparison = compare_two_sorters(
                     sorting1=sorting_prev,
                     sorting2=sorting_this,
                     sorting1_name="previous",
                     sorting2_name="current",
-                    delta_time=0.4,  # ms — default spike time coincidence window
+                    delta_time=0.4,  # ms
                 )
 
-                # Get matched pairs: (prev_unit_id, this_unit_id) with agreement > threshold
                 matched_pairs = comparison.get_matching()
-                # matched_pairs is a dict: {prev_unit_id: this_unit_id} (-1 if no match)
-
                 for prev_uid, this_uid in matched_pairs.items():
-                    if this_uid == -1 or this_uid in unit_to_universal:
+                    if this_uid == -1 or this_uid in unit_to_global:
                         continue
 
-                    # Find which universal unit the previous session's unit belongs to
-                    prev_sorted_key = {
-                        k: prev_session[k]
-                        for k in ("experiment_name", "insertion_number",
-                                  "block_start", "block_end", "electrode_group", "paramset_id")
-                    }
-                    uu_match = (
-                        UniversalUnit.Matched
-                        & {**prev_sorted_key, "unit": prev_uid, "matching_method": matching_method}
-                    ).fetch(as_dict=True)
+                    # Look up which global unit the previous session's unit belongs to
+                    gu_match = self.Unit & {**prev_key, "unit": prev_uid}
+                    if gu_match:
+                        unit_to_global[this_uid] = gu_match.fetch1("global_unit")
 
-                    if uu_match:
-                        unit_to_universal[this_uid] = uu_match[0]["universal_unit"]
-
-        # Assign new universal units for unmatched units
-        existing_max = (UniversalUnit & scope_key).fetch("universal_unit")
-        next_uu_id = int(existing_max.max()) + 1 if len(existing_max) > 0 else 1
-        n_matched = len(unit_to_universal)  # count before adding new ones
+        # ---- Assign new global units for unmatched units ----
+        existing_ids = (GlobalUnit & insertion_key).fetch("global_unit")
+        next_gu_id = int(existing_ids.max()) + 1 if len(existing_ids) > 0 else 1
+        n_matched = len(unit_to_global)
 
         for unit_id in this_session_units:
-            if unit_id not in unit_to_universal:
-                unit_to_universal[unit_id] = next_uu_id
-                next_uu_id += 1
-        n_new = len(unit_to_universal) - n_matched
+            if unit_id not in unit_to_global:
+                unit_to_global[unit_id] = next_gu_id
+                next_gu_id += 1
+        n_new = len(unit_to_global) - n_matched
 
-        # Insert UniversalUnit entries (new ones only)
-        for unit_id, uu_id in unit_to_universal.items():
-            uu_key = {**scope_key, "universal_unit": uu_id}
-            if not (UniversalUnit & uu_key):
-                UniversalUnit.insert1(uu_key)
+        # ---- Get peak electrode for each unit in this session ----
+        # electrode is a non-PK attribute on SortedSpikes.Unit, so use proj() to include it
+        unit_electrodes = {}
+        for entry in (SortedSpikes.Unit & key).proj("electrode").fetch(as_dict=True):
+            unit_electrodes[entry["unit"]] = {
+                "probe_type": entry["probe_type"],
+                "electrode": entry["electrode"],
+            }
 
-        # Insert UniversalUnit.Matched entries
-        sorted_key_fields = {
-            k: key[k]
-            for k in ("experiment_name", "insertion_number",
-                      "block_start", "block_end", "electrode_group", "paramset_id")
-        }
-        for unit_id, uu_id in unit_to_universal.items():
-            UniversalUnit.Matched.insert1(
-                {
-                    **scope_key,
-                    "universal_unit": uu_id,
-                    **sorted_key_fields,
-                    "unit": unit_id,
-                },
-                skip_duplicates=True,
-            )
+        # ---- Insert GlobalUnit entries (new) + update electrode (matched) ----
+        for unit_id, gu_id in unit_to_global.items():
+            gu_key = {**insertion_key, "global_unit": gu_id}
+            if unit_id not in unit_electrodes:
+                raise ValueError(
+                    f"No electrode info found for unit {unit_id} in SortedSpikes.Unit. "
+                    f"Key: {key}"
+                )
+            electrode = unit_electrodes[unit_id]
+            if not (GlobalUnit & gu_key):
+                # New global unit
+                GlobalUnit.insert1({**gu_key, **electrode})
+            else:
+                # Existing global unit — update electrode to latest session's estimate
+                GlobalUnit.update1({**gu_key, **electrode})
 
-        # Insert UnitMatching entry
+        # ---- Insert master entry ----
         execution_duration = (datetime.now(UTC) - execution_time).total_seconds() / 3600
         self.insert1({
             **key,
+            "matching_method": matching_method,
             "execution_time": execution_time,
             "execution_duration": execution_duration,
         })
 
+        # ---- Insert UnitMatching.Unit entries ----
+        for unit_id, gu_id in unit_to_global.items():
+            self.Unit.insert1({
+                **key,
+                "unit": unit_id,
+                **insertion_key,
+                "global_unit": gu_id,
+            }, ignore_extra_fields=True)
+
+        # ---- Insert UnitMatching.Spikes with ownership convention ----
+        # For each (global_unit, chunk): skip if an earlier session already owns it
+        this_session_chunks = (SyncedSpikes.Unit & key).fetch("KEY")
+        # Get unique chunk_starts for this session
+        chunk_starts = sorted({ck["chunk_start"] for ck in this_session_chunks})
+
+        for unit_id, gu_id in unit_to_global.items():
+            for chunk_start in chunk_starts:
+                # Ownership check: does any session already own this (insertion, unit, chunk)?
+                existing = self.Spikes & {
+                    **insertion_key,
+                    "global_unit": gu_id,
+                    "chunk_start": chunk_start,
+                }
+                if existing:
+                    logger.debug(
+                        f"Ownership skip: global_unit={gu_id}, chunk_start={chunk_start} "
+                        f"already owned by earlier session"
+                    )
+                    continue
+
+                # Get spike times for this unit in this chunk from SyncedSpikes
+                synced_entry = SyncedSpikes.Unit & {
+                    **key,
+                    "unit": unit_id,
+                    "chunk_start": chunk_start,
+                }
+                if not synced_entry:
+                    continue  # no spikes for this unit in this chunk
+
+                spike_times = synced_entry.fetch1("spike_times")
+                self.Spikes.insert1({
+                    **key,
+                    **insertion_key,
+                    "global_unit": gu_id,
+                    "chunk_start": chunk_start,
+                    "spike_times": spike_times,
+                    "spike_count": len(spike_times),
+                }, ignore_extra_fields=True)
+
         logger.info(
             f"Unit matching complete for session {key['block_start']}:\n"
-            f"  {len(unit_to_universal)} units processed\n"
-            f"  {n_matched} matched to existing universal units\n"
-            f"  {n_new} new universal units created"
+            f"  {len(unit_to_global)} units processed\n"
+            f"  {n_matched} matched to existing global units\n"
+            f"  {n_new} new global units created"
         )
 
 
-@schema
-class UniversalUnit(dj.Manual):
-    definition = """
-    # Persistent neuron identity across sessions for the same probe insertion
-    -> ephys.ProbeInsertion
-    -> UnitMatchingMethod
-    universal_unit: int  # unique ID within this experiment+insertion+method
-    ---
-    universal_unit_comment='': varchar(1000)
-    """
-
-    class Matched(dj.Part):
-        definition = """
-        # Links a session-specific unit to a universal unit
-        -> master
-        -> SortedSpikes.Unit
-        ---
-        match_confidence=null: float
-        match_comment='': varchar(1000)
-        """
-
-
-@schema
-class ChunkedSpikeTimes(dj.Computed):
-    definition = """
-    # HARP-synced spike times per universal unit per ephys chunk — the primary analysis table
-    -> UniversalUnit
-    -> ephys.EphysChunk
-    ---
-    spike_times: longblob  # datetime64[ns] HARP-synced spike times for this universal unit in this chunk
-    spike_count: int       # number of spikes
-    """
-
-    @property
-    def key_source(self):
-        """All (UniversalUnit, EphysChunk) combinations for the same insertion.
-
-        NOTE on key_source scope (discuss with team):
-        This full cartesian approach produces rows with spike_count=0 for chunks where
-        the universal unit has no data (e.g., the neuron wasn't recorded in that session).
-        This is simpler for researchers (every unit x chunk exists, no need to handle
-        missing rows), but produces more rows.
-
-        Alternative: restricted key_source (no empty rows):
-            return (UniversalUnit * ephys.EphysChunk
-                    & (UniversalUnit.Matched * SyncedSpikes.Unit)) - self
-        The restricted set is more efficient but means "no row" = "no data for this chunk."
-        """
-        return (UniversalUnit * ephys.EphysChunk) - self
-
-    def make(self, key):
-        """Aggregate HARP-synced spike times by universal unit and ephys chunk.
-
-        For a given (UniversalUnit, EphysChunk) pair:
-        1. Look up all matched session units via UniversalUnit.Matched
-        2. For each matched unit, fetch spike times from SyncedSpikes.Unit for this chunk
-        3. Concatenate and sort the spike times
-        4. Insert with spike_count
-
-        If multiple matched units contribute spikes to the same chunk (overlapping blocks),
-        the spike times are merged. This is the intended behavior — the universal unit
-        represents one neuron, and overlapping blocks may both capture it.
-        """
-        # Get all session units matched to this universal unit
-        matched_units = (UniversalUnit.Matched & key).fetch(as_dict=True)
-
-        all_spike_times = []
-        for matched in matched_units:
-            # Build the SyncedSpikes.Unit key for this matched unit + chunk
-            synced_unit_key = {
-                "experiment_name": matched["experiment_name"],
-                "insertion_number": matched["insertion_number"],
-                "block_start": matched["block_start"],
-                "block_end": matched["block_end"],
-                "electrode_group": matched["electrode_group"],
-                "paramset_id": matched["paramset_id"],
-                "unit": matched["unit"],
-                "chunk_start": key["chunk_start"],
-            }
-
-            # Fetch spike times for this unit in this chunk (may not exist)
-            synced_entry = SyncedSpikes.Unit & synced_unit_key
-            if synced_entry:
-                spike_times = synced_entry.fetch1("spike_times")
-                all_spike_times.append(spike_times)
-
-        # Concatenate and sort all spike times from all matched units
-        # Spike times are stored as datetime64[ns] (absolute HARP timestamps)
-        if all_spike_times:
-            merged_times = np.sort(np.concatenate(all_spike_times))
-        else:
-            merged_times = np.array([], dtype='datetime64[ns]')
-
-        self.insert1({
-            **key,
-            "spike_times": merged_times,
-            "spike_count": len(merged_times),
-        })
 
 
 # ---- Ephys preprocessing with spike interface ----

--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -136,6 +136,7 @@ class PreProcessing(dj.Computed):
         end_str = key["block_end"].strftime("%Y-%m-%dT%H-%M-%S")
 
         output_dir = (sorting_root_dir / key["experiment_name"]
+                      / key["subject"]
                       / f"insertion_{key['insertion_number']}"
                       / "ephys_blocks"
                       / f"{start_str}_{end_str}"
@@ -1126,7 +1127,7 @@ class UnitMatching(dj.Computed):
         ---
         spike_times: longblob  # datetime64[ns] (UTC), HARP-synced
         spike_count: int
-        unique index (experiment_name, insertion_number, global_unit, chunk_start)
+        unique index (experiment_name, subject, insertion_number, global_unit, chunk_start)
         """
 
     @property
@@ -1141,7 +1142,7 @@ class UnitMatching(dj.Computed):
         eligible = SyncedSpikes & spike_sorting_curation.ApplyOfficialCuration
         candidates = eligible - self
         next_per_insertion = dj.U(
-            "experiment_name", "insertion_number"
+            "experiment_name", "subject", "insertion_number"
         ).aggr(candidates, next_start="MIN(block_start)")
         return candidates * next_per_insertion & "block_start = next_start"
 
@@ -1166,7 +1167,7 @@ class UnitMatching(dj.Computed):
         matching_method = "spike_time_overlap"
 
         insertion_key = {
-            k: key[k] for k in ("experiment_name", "insertion_number")
+            k: key[k] for k in ("experiment_name", "subject", "insertion_number")
         }
 
         # ---- Temporal ordering guard ----

--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -1093,6 +1093,7 @@ class UnitMatchingParamSet(dj.Lookup):
     matching_paramset_id: smallint
     ---
     -> UnitMatchingMethod
+    seed_block_start: datetime(6)  # block_start of the seed block (first to process)
     matching_paramset_description='': varchar(1000)
     params: longblob  # dictionary of all applicable parameters
     """
@@ -1144,31 +1145,58 @@ class UnitMatching(dj.Computed):
 
     @property
     def key_source(self):
-        """Only the earliest unprocessed ephys block per (insertion, paramset) (temporal ordering).
+        """Yield the seed block (if unprocessed), then frontier blocks on both ends.
 
-        Ensures that blocks are processed in block_start order within each
-        (insertion, paramset) combination. Different insertions/paramsets can
-        be processed in parallel.
+        For each (insertion, paramset):
+        - If seed is unprocessed -> yield the seed
+        - Else -> yield the forward frontier (MIN unprocessed > processed max)
+                  and the backward frontier (MAX unprocessed < processed min)
+        Only blocks with ApplyOfficialCuration are eligible.
         """
         from aeon.dj_pipeline import spike_sorting_curation
 
         eligible = SyncedSpikes & spike_sorting_curation.ApplyOfficialCuration
-        # Cross with all paramsets to produce (block x paramset) candidates
         all_candidates = eligible * UnitMatchingParamSet
-        candidates = all_candidates - self
-        next_per_group = dj.U(
+        candidates = all_candidates - self  # unprocessed only
+
+        # Case 1: seed block itself is unprocessed -> yield it
+        seed_candidates = candidates & "block_start = seed_block_start"
+
+        # Case 2: seed already processed -> find frontiers
+        processed = all_candidates & self  # already done
+        # Bounds of the processed region
+        group_keys = (
             "experiment_name", "subject", "insertion_number", "matching_paramset_id"
-        ).aggr(candidates, next_start="MIN(block_start)")
-        return candidates * next_per_group & "block_start = next_start"
+        )
+        processed_bounds = dj.U(*group_keys).aggr(
+            processed, proc_min="MIN(block_start)", proc_max="MAX(block_start)"
+        )
+
+        # Forward frontier: nearest unprocessed block AFTER processed max
+        fwd = dj.U(*group_keys).aggr(
+            candidates * processed_bounds & "block_start > proc_max",
+            fwd_start="MIN(block_start)",
+        )
+        fwd_candidates = candidates * fwd & "block_start = fwd_start"
+
+        # Backward frontier: nearest unprocessed block BEFORE processed min
+        bwd = dj.U(*group_keys).aggr(
+            candidates * processed_bounds & "block_start < proc_min",
+            bwd_start="MAX(block_start)",
+        )
+        bwd_candidates = candidates * bwd & "block_start = bwd_start"
+
+        return seed_candidates + fwd_candidates + bwd_candidates
 
     def make(self, key):
         """Match units from a new ephys block against existing global units.
 
-        Blocks must be processed in temporal order (by block_start).
-        Block N compares its units against previously-matched blocks (1..N-1).
+        Seed-based bidirectional propagation: the seed block (specified in
+        UnitMatchingParamSet) is processed first, then matching propagates
+        outward in both directions from the seed.
 
         Algorithm (spike_time_overlap):
-        1. Verify temporal ordering (guard against direct make() calls)
+        1. Verify seed-first + overlap constraints
         2. Find overlapping previous blocks and compare spike times
         3. Matched units inherit existing global unit IDs
         4. Unmatched units become new global units
@@ -1176,7 +1204,6 @@ class UnitMatching(dj.Computed):
         """
         from spikeinterface.comparison import compare_two_sorters
         from spikeinterface.core import NumpySorting
-        from aeon.dj_pipeline import spike_sorting_curation
 
         execution_time = datetime.now(UTC)
         matching_method = (UnitMatchingParamSet & key).fetch1("matching_method")
@@ -1186,21 +1213,33 @@ class UnitMatching(dj.Computed):
         }
         paramset_key = {"matching_paramset_id": key["matching_paramset_id"]}
 
-        # ---- Temporal ordering guard ----
-        eligible = SyncedSpikes & spike_sorting_curation.ApplyOfficialCuration
-        earlier_eligible = eligible & insertion_key & f'block_start < "{key["block_start"]}"'
-        unprocessed_earlier = (earlier_eligible * UnitMatchingParamSet & paramset_key) - self
-        if unprocessed_earlier:
-            raise ValueError(
-                f"Temporal ordering violation: {len(unprocessed_earlier)} earlier block(s) "
-                f"for insertion {insertion_key} not yet processed. "
-                f"Blocks must be processed in block_start order."
-            )
-
-        # ---- Load this block's synced spike times ----
+        # ---- Load block boundaries (used by guard and later) ----
         block_start, block_end = (ephys.EphysBlock & key).fetch1(
             "block_start", "block_end"
         )
+
+        # ---- Seed / overlap guard ----
+        previously_matched = (self & insertion_key & paramset_key).fetch(as_dict=True)
+
+        if not previously_matched:
+            # First block must be the seed
+            seed_block_start = (UnitMatchingParamSet & key).fetch1("seed_block_start")
+            if key["block_start"] != seed_block_start:
+                raise ValueError(
+                    f"First block must be the seed (block_start={seed_block_start}), "
+                    f"got block_start={key['block_start']}."
+                )
+        else:
+            # Subsequent blocks: must overlap with at least one processed block
+            has_overlap = any(
+                s["block_start"] < block_end and s["block_end"] > block_start
+                for s in previously_matched
+            )
+            if not has_overlap:
+                raise ValueError(
+                    f"Block {key['block_start']} does not overlap with any previously matched block. "
+                    f"There may be unprocessed intermediate blocks (check curation status)."
+                )
 
         this_block_units = {}
         for unit_entry in (SyncedSpikes.Unit & key).fetch(as_dict=True):
@@ -1225,8 +1264,7 @@ class UnitMatching(dj.Computed):
             })
             return
 
-        # ---- Find overlapping previous blocks ----
-        previously_matched = (self & insertion_key & paramset_key).fetch(as_dict=True)
+        # ---- Find overlapping previous blocks (reuse previously_matched from guard) ----
         overlapping_blocks = [
             s for s in previously_matched
             if s["block_start"] < block_end and s["block_end"] > block_start
@@ -1414,433 +1452,6 @@ class UnitMatching(dj.Computed):
         logger.info(
             f"Unit matching complete for block {key['block_start']}:\n"
             f"  {len(unit_to_global)} units processed\n"
-            f"  {n_matched} matched to existing global units\n"
-            f"  {n_new} new global units created"
-        )
-
-
-
-
-# ---- Pair-Based Unit Matching (alternative design) ----
-
-
-@schema
-class UnitMatchingPair(dj.Manual):
-    definition = """
-    # User-specified pair of SyncedSpikes for unit matching.
-    # Convention: earlier_block_start < latter_block_start (canonical ordering to prevent duplicates).
-    -> SyncedSpikes.proj(earlier_block_start='block_start', earlier_block_end='block_end')
-    -> SyncedSpikes.proj(latter_block_start='block_start', latter_block_end='block_end')
-    -> UnitMatchingParamSet
-    """
-
-
-@schema
-class PairMatching(dj.Computed):
-    definition = """
-    -> UnitMatchingPair
-    ---
-    execution_time: datetime
-    execution_duration: float  # hours
-    """
-
-    class Unit(dj.Part):
-        definition = """
-        # Unit correspondence between the earlier and latter blocks in this pair.
-        # Each row records one global unit and its unit IDs in each block.
-        # For matched pairs: both earlier_unit and latter_unit are populated.
-        # For unmatched units (only in one block): one side is null.
-        -> master
-        -> GlobalUnit
-        ---
-        -> [nullable] SortedSpikes.Unit.proj(earlier_block_start='block_start', earlier_block_end='block_end', earlier_unit='unit')
-        -> [nullable] SortedSpikes.Unit.proj(latter_block_start='block_start', latter_block_end='block_end', latter_unit='unit')
-        match_confidence=null: float
-        match_comment='': varchar(1000)
-        """
-
-    class Spikes(dj.Part):
-        definition = """
-        # Deduplicated spike times per (global_unit, chunk). Ownership convention:
-        # the first pair to write a (global_unit, chunk) row wins; later pairs skip.
-        -> master
-        -> GlobalUnit
-        -> ephys.EphysChunk
-        ---
-        spike_times: longblob  # datetime64[ns] (UTC), HARP-synced
-        spike_count: int
-        unique index (experiment_name, subject, insertion_number, global_unit, chunk_start)
-        """
-
-    def make(self, key):
-        """Match units between a pair of ephys blocks.
-
-        Determines which block is the "anchor" (already matched in a previous pair)
-        and which is "new". Compares spike times in the overlap region to identify
-        corresponding units. Matched units inherit the anchor's global unit IDs;
-        unmatched units get new global unit IDs.
-
-        For seed pairs (first pair for an insertion — neither block previously matched),
-        all matched unit pairs get fresh global units, and unmatched units each get their own.
-
-        Constraint enforced here: at least one of the two blocks must have been matched
-        in a previous PairMatching, unless this is the seed pair (no PairMatching entries
-        exist for this insertion + paramset).
-
-        Algorithm (spike_time_overlap):
-        1. Determine anchor vs. new block
-        2. Load synced spike times from both blocks
-        3. Compare spike times in overlap region
-        4. Assign global units (inherit or create new)
-        5. Insert GlobalUnit, PairMatching.Unit, PairMatching.Spikes entries
-        """
-        from spikeinterface.comparison import compare_two_sorters
-        from spikeinterface.core import NumpySorting
-
-        execution_time = datetime.now(UTC)
-        matching_method = (UnitMatchingParamSet & key).fetch1("matching_method")
-        params = (UnitMatchingParamSet & key).fetch1("params")
-
-        insertion_key = {
-            k: key[k] for k in ("experiment_name", "subject", "insertion_number")
-        }
-        paramset_key = {"matching_paramset_id": key["matching_paramset_id"]}
-
-        # ---- Build SyncedSpikes keys for both blocks ----
-        # Shared PK fields (same upstream: insertion, electrode group, sorting params)
-        shared_fields = {
-            k: key[k] for k in key
-            if k not in (
-                "earlier_block_start", "earlier_block_end",
-                "latter_block_start", "latter_block_end",
-                "matching_paramset_id",
-            )
-        }
-        earlier_synced_key = {
-            **shared_fields,
-            "block_start": key["earlier_block_start"],
-            "block_end": key["earlier_block_end"],
-        }
-        latter_synced_key = {
-            **shared_fields,
-            "block_start": key["latter_block_start"],
-            "block_end": key["latter_block_end"],
-        }
-
-        # ---- Determine anchor vs. new block ----
-        # A block is "already matched" if it appears as a unit in any previous PairMatching
-        earlier_matched = bool(
-            self.Unit & insertion_key & paramset_key
-            & f'earlier_block_start = "{key["earlier_block_start"]}" '
-            f'OR latter_block_start = "{key["earlier_block_start"]}"'
-        )
-        latter_matched = bool(
-            self.Unit & insertion_key & paramset_key
-            & f'earlier_block_start = "{key["latter_block_start"]}" '
-            f'OR latter_block_start = "{key["latter_block_start"]}"'
-        )
-
-        # Check if any PairMatching exists for this insertion + paramset (seed detection)
-        any_previous = bool(self & insertion_key & paramset_key)
-
-        is_seed = not any_previous
-        if not is_seed and not earlier_matched and not latter_matched:
-            raise ValueError(
-                "Neither block has been matched in a previous pair. "
-                "At least one block must be already matched, unless this is the "
-                "seed pair (no previous PairMatching for this insertion + paramset)."
-            )
-
-        if is_seed:
-            # Seed: earlier block is the anchor by convention
-            anchor_key, new_key = earlier_synced_key, latter_synced_key
-            anchor_is_earlier = True
-            logger.info("Seed pair — earlier block is anchor by convention.")
-        elif earlier_matched and not latter_matched:
-            anchor_key, new_key = earlier_synced_key, latter_synced_key
-            anchor_is_earlier = True
-        elif latter_matched and not earlier_matched:
-            anchor_key, new_key = latter_synced_key, earlier_synced_key
-            anchor_is_earlier = False
-        else:
-            # Both matched — earlier block is anchor by convention
-            anchor_key, new_key = earlier_synced_key, latter_synced_key
-            anchor_is_earlier = True
-            logger.info("Both blocks already matched — earlier block used as anchor.")
-
-        # ---- Load spike times from both blocks ----
-        def _load_block_units(synced_key):
-            """Load and concatenate spike times per unit from SyncedSpikes."""
-            units = {}
-            for entry in (SyncedSpikes.Unit & synced_key).fetch(as_dict=True):
-                uid = entry["unit"]
-                if uid not in units:
-                    units[uid] = []
-                units[uid].append(entry["spike_times"])
-            for uid in units:
-                concatenated = np.sort(np.concatenate(units[uid]))
-                if concatenated.dtype.kind == "M":  # datetime64
-                    concatenated = concatenated.astype("datetime64[ns]").astype(np.int64) / 1e9
-                units[uid] = concatenated
-            return units
-
-        anchor_units = _load_block_units(anchor_key)
-        new_units = _load_block_units(new_key)
-
-        if not new_units:
-            logger.warning(f"No synced spike data in new block. Inserting empty result.")
-            execution_duration = (datetime.now(UTC) - execution_time).total_seconds() / 3600
-            self.insert1({**key, "execution_time": execution_time, "execution_duration": execution_duration})
-            return
-
-        # ---- Look up anchor block's existing global unit assignments ----
-        # Query previous PairMatching.Unit entries where the anchor block participated
-        # (it could have been the earlier or latter block in a previous pair)
-        anchor_unit_to_global = {}
-        if not is_seed:
-            anchor_bs = anchor_key["block_start"]
-            # Anchor appeared as the earlier block in a previous pair
-            for entry in (
-                self.Unit & insertion_key & paramset_key
-                & f'earlier_block_start = "{anchor_bs}"'
-            ).fetch(as_dict=True):
-                if entry["earlier_unit"] is not None:
-                    anchor_unit_to_global[entry["earlier_unit"]] = entry["global_unit"]
-            # Anchor appeared as the latter block in a previous pair
-            for entry in (
-                self.Unit & insertion_key & paramset_key
-                & f'latter_block_start = "{anchor_bs}"'
-            ).fetch(as_dict=True):
-                if entry["latter_unit"] is not None:
-                    anchor_unit_to_global[entry["latter_unit"]] = entry["global_unit"]
-
-        # ---- Compare spike times in overlap region ----
-        anchor_start = anchor_key["block_start"]
-        anchor_end = anchor_key["block_end"]
-        new_start = new_key["block_start"]
-        new_end = new_key["block_end"]
-
-        # Convert to timestamps if datetime
-        if hasattr(anchor_start, "timestamp"):
-            anchor_start_s, anchor_end_s = anchor_start.timestamp(), anchor_end.timestamp()
-            new_start_s, new_end_s = new_start.timestamp(), new_end.timestamp()
-        else:
-            anchor_start_s, anchor_end_s = float(anchor_start), float(anchor_end)
-            new_start_s, new_end_s = float(new_start), float(new_end)
-
-        overlap_start_s = max(anchor_start_s, new_start_s)
-        overlap_end_s = min(anchor_end_s, new_end_s)
-
-        unit_to_global = {}  # new block's unit_id -> global_unit
-        matched_anchors = {}  # new block's unit_id -> anchor unit_id it matched to
-
-        if overlap_start_s < overlap_end_s and anchor_units:
-            # Build spike trains restricted to overlap window
-            def _restrict_to_overlap(spike_times_s):
-                if len(spike_times_s) == 0:
-                    return np.array([])
-                mask = (spike_times_s >= overlap_start_s) & (spike_times_s <= overlap_end_s)
-                return spike_times_s[mask] - overlap_start_s
-
-            delta_time = params.get("delta_time", 0.4) if params else 0.4
-            sampling_frequency = params.get("sampling_frequency", 30000) if params else 30000
-
-            anchor_trains = {}
-            for uid, times in anchor_units.items():
-                restricted = _restrict_to_overlap(times)
-                if len(restricted) > 0:
-                    anchor_trains[uid] = (restricted * sampling_frequency).astype(np.int64)
-
-            new_trains = {}
-            for uid, times in new_units.items():
-                restricted = _restrict_to_overlap(times)
-                if len(restricted) > 0:
-                    new_trains[uid] = (restricted * sampling_frequency).astype(np.int64)
-
-            if anchor_trains and new_trains:
-                sorting_anchor = NumpySorting.from_unit_dict(
-                    anchor_trains, sampling_frequency=sampling_frequency
-                )
-                sorting_new = NumpySorting.from_unit_dict(
-                    new_trains, sampling_frequency=sampling_frequency
-                )
-                comparison = compare_two_sorters(
-                    sorting1=sorting_anchor,
-                    sorting2=sorting_new,
-                    sorting1_name="anchor",
-                    sorting2_name="new",
-                    delta_time=delta_time,
-                )
-
-                matched_pairs = comparison.get_matching()
-                for anchor_uid, new_uid in matched_pairs.items():
-                    if new_uid == -1 or new_uid in unit_to_global:
-                        continue
-                    if anchor_uid in anchor_unit_to_global:
-                        unit_to_global[new_uid] = anchor_unit_to_global[anchor_uid]
-                        matched_anchors[new_uid] = anchor_uid
-                    elif is_seed:
-                        # Seed: anchor units don't have global IDs yet, will be assigned below
-                        pass
-        else:
-            if not anchor_units:
-                logger.info("Anchor block has no units.")
-            else:
-                logger.warning("No temporal overlap between the two blocks.")
-
-        # ---- Handle seed case: assign global units to anchor block's units first ----
-        existing_ids = (GlobalUnit & insertion_key).fetch("global_unit")
-        next_gu_id = int(existing_ids.max()) + 1 if len(existing_ids) > 0 else 1
-
-        seed_anchor_assignments = {}
-        if is_seed:
-            for uid in anchor_units:
-                seed_anchor_assignments[uid] = next_gu_id
-                anchor_unit_to_global[uid] = next_gu_id
-                next_gu_id += 1
-
-            # Now resolve matched pairs using the freshly-assigned anchor globals
-            if overlap_start_s < overlap_end_s and anchor_units:
-                # Re-check matched_pairs with the now-populated anchor_unit_to_global
-                if anchor_trains and new_trains:
-                    matched_pairs = comparison.get_matching()
-                    for anchor_uid, new_uid in matched_pairs.items():
-                        if new_uid == -1 or new_uid in unit_to_global:
-                            continue
-                        if anchor_uid in anchor_unit_to_global:
-                            unit_to_global[new_uid] = anchor_unit_to_global[anchor_uid]
-                            matched_anchors[new_uid] = anchor_uid
-
-        # ---- Assign new global units for unmatched new-block units ----
-        n_matched = len(unit_to_global)
-        for uid in new_units:
-            if uid not in unit_to_global:
-                unit_to_global[uid] = next_gu_id
-                next_gu_id += 1
-        n_new = len(unit_to_global) - n_matched
-
-        # ---- Get peak electrode for units ----
-        def _get_unit_electrodes(synced_key):
-            electrodes = {}
-            for entry in (SortedSpikes.Unit & synced_key).proj("electrode").fetch(as_dict=True):
-                electrodes[entry["unit"]] = {
-                    "probe_type": entry["probe_type"],
-                    "electrode": entry["electrode"],
-                }
-            return electrodes
-
-        new_electrodes = _get_unit_electrodes(new_key)
-        anchor_electrodes = _get_unit_electrodes(anchor_key) if is_seed else {}
-
-        # ---- Insert GlobalUnit entries ----
-        # Seed: insert anchor block's global units
-        for uid, gu_id in seed_anchor_assignments.items():
-            gu_key = {**insertion_key, "global_unit": gu_id}
-            if uid in anchor_electrodes:
-                GlobalUnit.insert1(
-                    {**gu_key, **paramset_key, **anchor_electrodes[uid]},
-                    skip_duplicates=True,
-                )
-
-        # New block's global units: insert new, update existing
-        for uid, gu_id in unit_to_global.items():
-            gu_key = {**insertion_key, "global_unit": gu_id}
-            if uid not in new_electrodes:
-                raise ValueError(
-                    f"No electrode info for unit {uid} in SortedSpikes.Unit. Key: {new_key}"
-                )
-            electrode = new_electrodes[uid]
-            if not (GlobalUnit & gu_key):
-                GlobalUnit.insert1({**gu_key, **paramset_key, **electrode})
-            else:
-                GlobalUnit.update1({**gu_key, **paramset_key, **electrode})
-
-        # ---- Insert master entry ----
-        execution_duration = (datetime.now(UTC) - execution_time).total_seconds() / 3600
-        self.insert1({
-            **key,
-            "execution_time": execution_time,
-            "execution_duration": execution_duration,
-        })
-
-        # ---- Insert PairMatching.Unit entries ----
-        # Build global_unit -> (earlier_unit, latter_unit) mapping
-        pair_units = {}  # global_unit -> {earlier_unit, latter_unit, match_confidence}
-
-        # Seed: anchor block units
-        if is_seed:
-            for uid, gu_id in seed_anchor_assignments.items():
-                entry = pair_units.setdefault(
-                    gu_id, {"earlier_unit": None, "latter_unit": None, "match_confidence": None}
-                )
-                if anchor_is_earlier:
-                    entry["earlier_unit"] = uid
-                else:
-                    entry["latter_unit"] = uid
-
-        # New block units (matched and unmatched)
-        for new_uid, gu_id in unit_to_global.items():
-            entry = pair_units.setdefault(
-                gu_id, {"earlier_unit": None, "latter_unit": None, "match_confidence": None}
-            )
-            # Place the new unit on the correct side
-            if anchor_is_earlier:
-                entry["latter_unit"] = new_uid
-            else:
-                entry["earlier_unit"] = new_uid
-            # If matched, also record the anchor unit on the other side
-            anchor_uid = matched_anchors.get(new_uid)
-            if anchor_uid is not None:
-                if anchor_is_earlier:
-                    entry["earlier_unit"] = anchor_uid
-                else:
-                    entry["latter_unit"] = anchor_uid
-
-        # Insert Unit Part rows
-        for gu_id, unit_info in pair_units.items():
-            self.Unit.insert1({
-                **key,
-                **insertion_key,
-                "global_unit": gu_id,
-                "earlier_unit": unit_info["earlier_unit"],
-                "latter_unit": unit_info["latter_unit"],
-                "match_confidence": unit_info["match_confidence"],
-            }, ignore_extra_fields=True)
-
-        # ---- Insert PairMatching.Spikes with ownership convention ----
-        def _insert_spikes_for_block(synced_key, block_unit_to_global):
-            chunk_starts = sorted({
-                ck["chunk_start"]
-                for ck in (SyncedSpikes.Unit & synced_key).fetch("KEY")
-            })
-            for uid, gu_id in block_unit_to_global.items():
-                for cs in chunk_starts:
-                    # Ownership check
-                    if self.Spikes & {**insertion_key, "global_unit": gu_id, "chunk_start": cs}:
-                        continue
-                    synced_entry = SyncedSpikes.Unit & {**synced_key, "unit": uid, "chunk_start": cs}
-                    if not synced_entry:
-                        continue
-                    spike_times = synced_entry.fetch1("spike_times")
-                    self.Spikes.insert1({
-                        **key,
-                        **insertion_key,
-                        "global_unit": gu_id,
-                        "chunk_start": cs,
-                        "spike_times": spike_times,
-                        "spike_count": len(spike_times),
-                    }, ignore_extra_fields=True)
-
-        if is_seed:
-            _insert_spikes_for_block(anchor_key, seed_anchor_assignments)
-        _insert_spikes_for_block(new_key, unit_to_global)
-
-        logger.info(
-            f"Pair matching complete:\n"
-            f"  Earlier block: {key['earlier_block_start']}\n"
-            f"  Latter block: {key['latter_block_start']}\n"
-            f"  Seed: {is_seed}\n"
-            f"  {len(unit_to_global)} new-block units processed\n"
             f"  {n_matched} matched to existing global units\n"
             f"  {n_new} new global units created"
         )

--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -1088,12 +1088,24 @@ class UnitMatchingMethod(dj.Lookup):
 
 
 @schema
+class UnitMatchingParamSet(dj.Lookup):
+    definition = """  # Parameter set for unit matching
+    matching_paramset_id: smallint
+    ---
+    -> UnitMatchingMethod
+    matching_paramset_description='': varchar(1000)
+    params: longblob  # dictionary of all applicable parameters
+    """
+
+
+@schema
 class GlobalUnit(dj.Manual):
     definition = """
     # Persistent neuron identity across ephys blocks for the same probe insertion
     -> ephys.ProbeInsertion
     global_unit: int  # unique ID within this insertion
     ---
+    -> UnitMatchingParamSet
     -> ephys.ProbeType.Electrode  # peak electrode (denormalized, updated each block)
     global_unit_comment='': varchar(1000)
     """
@@ -1103,8 +1115,8 @@ class GlobalUnit(dj.Manual):
 class UnitMatching(dj.Computed):
     definition = """
     -> SyncedSpikes
+    -> UnitMatchingParamSet
     ---
-    -> UnitMatchingMethod
     execution_time: datetime
     execution_duration: float  # hours
     """
@@ -1132,19 +1144,22 @@ class UnitMatching(dj.Computed):
 
     @property
     def key_source(self):
-        """Only the earliest unprocessed ephys block per insertion (temporal ordering).
+        """Only the earliest unprocessed ephys block per (insertion, paramset) (temporal ordering).
 
-        Ensures that blocks are processed in block_start order within each insertion.
-        Different insertions can be processed in parallel.
+        Ensures that blocks are processed in block_start order within each
+        (insertion, paramset) combination. Different insertions/paramsets can
+        be processed in parallel.
         """
         from aeon.dj_pipeline import spike_sorting_curation
 
         eligible = SyncedSpikes & spike_sorting_curation.ApplyOfficialCuration
-        candidates = eligible - self
-        next_per_insertion = dj.U(
-            "experiment_name", "subject", "insertion_number"
+        # Cross with all paramsets to produce (block x paramset) candidates
+        all_candidates = eligible * UnitMatchingParamSet
+        candidates = all_candidates - self
+        next_per_group = dj.U(
+            "experiment_name", "subject", "insertion_number", "matching_paramset_id"
         ).aggr(candidates, next_start="MIN(block_start)")
-        return candidates * next_per_insertion & "block_start = next_start"
+        return candidates * next_per_group & "block_start = next_start"
 
     def make(self, key):
         """Match units from a new ephys block against existing global units.
@@ -1164,16 +1179,17 @@ class UnitMatching(dj.Computed):
         from aeon.dj_pipeline import spike_sorting_curation
 
         execution_time = datetime.now(UTC)
-        matching_method = "spike_time_overlap"
+        matching_method = (UnitMatchingParamSet & key).fetch1("matching_method")
 
         insertion_key = {
             k: key[k] for k in ("experiment_name", "subject", "insertion_number")
         }
+        paramset_key = {"matching_paramset_id": key["matching_paramset_id"]}
 
         # ---- Temporal ordering guard ----
         eligible = SyncedSpikes & spike_sorting_curation.ApplyOfficialCuration
         earlier_eligible = eligible & insertion_key & f'block_start < "{key["block_start"]}"'
-        unprocessed_earlier = earlier_eligible - self
+        unprocessed_earlier = (earlier_eligible * UnitMatchingParamSet & paramset_key) - self
         if unprocessed_earlier:
             raise ValueError(
                 f"Temporal ordering violation: {len(unprocessed_earlier)} earlier block(s) "
@@ -1204,14 +1220,13 @@ class UnitMatching(dj.Computed):
             logger.warning(f"No synced spike data found for block {key}. Skipping.")
             self.insert1({
                 **key,
-                "matching_method": matching_method,
                 "execution_time": execution_time,
                 "execution_duration": 0.0,
             })
             return
 
         # ---- Find overlapping previous blocks ----
-        previously_matched = (self & insertion_key).fetch(as_dict=True)
+        previously_matched = (self & insertion_key & paramset_key).fetch(as_dict=True)
         overlapping_blocks = [
             s for s in previously_matched
             if s["block_start"] < block_end and s["block_end"] > block_start
@@ -1304,7 +1319,7 @@ class UnitMatching(dj.Computed):
                         unit_to_global[this_uid] = gu_match.fetch1("global_unit")
 
         # ---- Assign new global units for unmatched units ----
-        existing_ids = (GlobalUnit & insertion_key).fetch("global_unit")
+        existing_ids = (GlobalUnit & insertion_key & paramset_key).fetch("global_unit")
         next_gu_id = int(existing_ids.max()) + 1 if len(existing_ids) > 0 else 1
         n_matched = len(unit_to_global)
 
@@ -1325,7 +1340,7 @@ class UnitMatching(dj.Computed):
 
         # ---- Insert GlobalUnit entries (new) + update electrode (matched) ----
         for unit_id, gu_id in unit_to_global.items():
-            gu_key = {**insertion_key, "global_unit": gu_id}
+            gu_key = {**insertion_key, **paramset_key, "global_unit": gu_id}
             if unit_id not in unit_electrodes:
                 raise ValueError(
                     f"No electrode info found for unit {unit_id} in SortedSpikes.Unit. "
@@ -1343,7 +1358,6 @@ class UnitMatching(dj.Computed):
         execution_duration = (datetime.now(UTC) - execution_time).total_seconds() / 3600
         self.insert1({
             **key,
-            "matching_method": matching_method,
             "execution_time": execution_time,
             "execution_duration": execution_duration,
         })

--- a/aeon/dj_pipeline/spike_sorting_curation.py
+++ b/aeon/dj_pipeline/spike_sorting_curation.py
@@ -532,6 +532,7 @@ def restore_raw_sorting(key: dict) -> None:
     Args:
         key: Dictionary key identifying the sorting task. Must contain:
             - experiment_name
+            - subject
             - insertion_number
             - block_start (datetime or string)
             - block_end (datetime or string)
@@ -565,7 +566,7 @@ def restore_raw_sorting(key: dict) -> None:
 
     # Step 3: Delete orphaned GlobalUnit entries
     # (those with no remaining UnitMatching.Unit references from any block)
-    insertion_key = {k: key[k] for k in ("experiment_name", "insertion_number")}
+    insertion_key = {k: key[k] for k in ("experiment_name", "subject", "insertion_number")}
     n_orphans = 0
     for gu_key in (spike_sorting.GlobalUnit & insertion_key).fetch("KEY"):
         if len(spike_sorting.UnitMatching.Unit & gu_key) == 0:

--- a/aeon/dj_pipeline/spike_sorting_curation.py
+++ b/aeon/dj_pipeline/spike_sorting_curation.py
@@ -518,17 +518,13 @@ def make_curation_official(key: dict, curation_id: int) -> None:
 
 
 def restore_raw_sorting(key: dict) -> None:
-    """
-    Restore raw (uncurated) sorting by removing official curation.
+    """Restore raw (uncurated) sorting by removing official curation.
 
     This function:
     1. Deletes the OfficialCuration entry (which cascades to ApplyOfficialCuration)
-    2. Cleans up unit matching data that references this session's units:
-       a. Deletes UnitMatching for this session
-       b. Deletes UniversalUnit.Matched rows for this session's units (force=True
-          to bypass Part-table protection)
-       c. Deletes orphaned UniversalUnit rows (those with zero remaining Matched children)
-    3. Deletes the curated SortedSpikes entry (which cascades to downstream tables)
+    2. Deletes UnitMatching for this session (cascades to .Unit and .Spikes Part rows)
+    3. Deletes orphaned GlobalUnit entries (those with no remaining UnitMatching.Unit refs)
+    4. Deletes the curated SortedSpikes entry (which cascades to downstream tables)
 
     After restoring, re-run SortedSpikes.populate() + SyncedSpikes.populate() to load
     the new curation, then re-run UnitMatching.populate() to re-match units.
@@ -539,6 +535,8 @@ def restore_raw_sorting(key: dict) -> None:
             - insertion_number
             - block_start (datetime or string)
             - block_end (datetime or string)
+            - probe_type
+            - electrode_config_name
             - electrode_group
             - paramset_id
     """
@@ -551,47 +549,33 @@ def restore_raw_sorting(key: dict) -> None:
     curation_id = official_curation.fetch1("curation_id")
     logger.info(f"Restoring raw sorting (removing official curation_id={curation_id})...")
 
-    # Step 1: Delete OfficialCuration entry (this will cascade to ApplyOfficialCuration)
+    # Step 1: Delete OfficialCuration entry (cascades to ApplyOfficialCuration)
     logger.info("Deleting OfficialCuration entry...")
     official_curation.delete(safemode=False)
     logger.info("OfficialCuration and ApplyOfficialCuration entries deleted.")
 
-    # Step 2: Clean up unit matching data before deleting SortedSpikes
-    # Without this cleanup, SortedSpikes.delete() would fail because
-    # UniversalUnit.Matched references SortedSpikes.Unit, and DataJoint's
-    # Part-table protection blocks deletion when the Part's master (UniversalUnit)
-    # is not in the deletion set.
-
-    # 2a: Delete UnitMatching for this session (Computed table, normal delete)
+    # Step 2: Delete UnitMatching for this session
+    # Cascades to UnitMatching.Unit and UnitMatching.Spikes Part rows
     unit_matching_entries = spike_sorting.UnitMatching & key
     if unit_matching_entries:
         n_um = len(unit_matching_entries)
         logger.info(f"Deleting {n_um} UnitMatching entries for this session...")
         unit_matching_entries.delete(safemode=False)
+        logger.info("UnitMatching entries deleted (cascaded to Unit and Spikes parts).")
 
-    # 2b: Delete UniversalUnit.Matched rows for this session's units
-    #   Part.delete(force=True) allows deleting Part rows without their master
-    block_unit_keys = (spike_sorting.SortedSpikes.Unit & key).fetch("KEY")
-    if block_unit_keys:
-        matched_to_delete = spike_sorting.UniversalUnit.Matched & block_unit_keys
-        if matched_to_delete:
-            n_matched = len(matched_to_delete)
-            logger.info(f"Deleting {n_matched} UniversalUnit.Matched entries for this session's units...")
-            matched_to_delete.delete(force=True)
-
-    # 2c: Delete orphaned UniversalUnit rows (those with zero remaining Matched children)
-    #   Scope: only check universal units for this insertion
+    # Step 3: Delete orphaned GlobalUnit entries
+    # (those with no remaining UnitMatching.Unit references from any block)
     insertion_key = {k: key[k] for k in ("experiment_name", "insertion_number")}
     n_orphans = 0
-    for uu_key in (spike_sorting.UniversalUnit & insertion_key).fetch("KEY"):
-        if len(spike_sorting.UniversalUnit.Matched & uu_key) == 0:
-            logger.info(f"Deleting orphaned UniversalUnit {uu_key['universal_unit']}...")
-            (spike_sorting.UniversalUnit & uu_key).delete(safemode=False)
+    for gu_key in (spike_sorting.GlobalUnit & insertion_key).fetch("KEY"):
+        if len(spike_sorting.UnitMatching.Unit & gu_key) == 0:
+            logger.info(f"Deleting orphaned GlobalUnit {gu_key['global_unit']}...")
+            (spike_sorting.GlobalUnit & gu_key).delete(safemode=False)
             n_orphans += 1
     if n_orphans:
-        logger.info(f"Deleted {n_orphans} orphaned UniversalUnit entries.")
+        logger.info(f"Deleted {n_orphans} orphaned GlobalUnit entries.")
 
-    # Step 3: Delete the SortedSpikes entry (this will cascade to downstream tables)
+    # Step 4: Delete the SortedSpikes entry (cascades to downstream tables)
     sorted_spikes_entry = spike_sorting.SortedSpikes & key
     if sorted_spikes_entry:
         logger.info("Deleting SortedSpikes entry and downstream tables...")
@@ -602,8 +586,7 @@ def restore_raw_sorting(key: dict) -> None:
             "  1. Run SortedSpikes.populate() to load the raw sorting results\n"
             "  2. Run SyncedSpikes.populate() to sync spike times\n"
             "  3. Apply new curation if needed (make_curation_official + ApplyOfficialCuration.populate)\n"
-            "  4. Run UnitMatching.populate() to re-match units\n"
-            "  5. Run ChunkedSpikeTimes.populate() to regenerate chunked output"
+            "  4. Run UnitMatching.populate() to re-match units and generate Spikes"
         )
     else:
         logger.info("No SortedSpikes entry found (run populate to load the raw sorting results back into the pipeline).")

--- a/aeon/dj_pipeline/spike_sorting_curation.py
+++ b/aeon/dj_pipeline/spike_sorting_curation.py
@@ -164,7 +164,7 @@ class ApplyOfficialCuration(dj.Imported):
         if current_curation_id == curation_id:
             # This curation is already applied
             logger.info(
-                f"Curation (curation_id={curation_id}) is already applied to this session. "
+                f"Curation (curation_id={curation_id}) is already applied to this block. "
                 "No action needed. If you need to reprocess, restore the raw uncurated version first."
             )
             return
@@ -172,7 +172,7 @@ class ApplyOfficialCuration(dj.Imported):
         if current_curation_id is not None and current_curation_id != -1:
             # A different curation is already applied
             raise ValueError(
-                f"A different curation (curation_id={current_curation_id}) has already been applied to this session. "
+                f"A different curation (curation_id={current_curation_id}) has already been applied to this block. "
                 f"Cannot apply curation_id={curation_id}. "
                 "If you want to apply a new curation, the data needs to be reverted to the uncurated version first."
             )
@@ -267,7 +267,7 @@ def launch_spikeinterface_gui(
     if not analyzer_dir.exists():
         raise FileNotFoundError(
             f"Sorting analyzer directory not found: {analyzer_dir}\n"
-            f"Please verify the key is correct and that PreProcessing has been run for this session."
+            f"Please verify the key is correct and that PreProcessing has been run for this block."
         )
 
     # Handle parent curation if specified
@@ -497,7 +497,7 @@ def make_curation_official(key: dict, curation_id: int) -> None:
         existing_curation = (OfficialCuration & sorted_spikes_key).fetch1()
         if existing_curation["curation_id"] != curation_id:
             raise ValueError(
-                f"An official curation already exists for this session "
+                f"An official curation already exists for this block "
                 f"(curation_id={existing_curation['curation_id']}). "
                 f"Please remove it first if you want to set a different one."
             )
@@ -522,8 +522,8 @@ def restore_raw_sorting(key: dict) -> None:
 
     This function:
     1. Deletes the OfficialCuration entry (which cascades to ApplyOfficialCuration)
-    2. Deletes UnitMatching for this session (cascades to .Unit and .Spikes Part rows)
-    3. Deletes orphaned GlobalUnit entries (those with no remaining UnitMatching.Unit refs)
+    2. Deletes UnitMatching for this block (cascades to .Unit and .Spikes Part rows)
+    3. Deletes orphaned GlobalUnit entries (those with no remaining UnitMatching.Unit references)
     4. Deletes the curated SortedSpikes entry (which cascades to downstream tables)
 
     After restoring, re-run SortedSpikes.populate() + SyncedSpikes.populate() to load
@@ -554,12 +554,12 @@ def restore_raw_sorting(key: dict) -> None:
     official_curation.delete(safemode=False)
     logger.info("OfficialCuration and ApplyOfficialCuration entries deleted.")
 
-    # Step 2: Delete UnitMatching for this session
+    # Step 2: Delete UnitMatching for this block
     # Cascades to UnitMatching.Unit and UnitMatching.Spikes Part rows
     unit_matching_entries = spike_sorting.UnitMatching & key
     if unit_matching_entries:
         n_um = len(unit_matching_entries)
-        logger.info(f"Deleting {n_um} UnitMatching entries for this session...")
+        logger.info(f"Deleting {n_um} UnitMatching entries for this block...")
         unit_matching_entries.delete(safemode=False)
         logger.info("UnitMatching entries deleted (cascaded to Unit and Spikes parts).")
 

--- a/aeon/dj_pipeline/utils/ephys_utils.py
+++ b/aeon/dj_pipeline/utils/ephys_utils.py
@@ -1,0 +1,349 @@
+"""Utility functions for the ephys pipeline.
+
+Helpers for probe discovery, subject-probe mapping, sync model processing,
+and probe type creation. Used by ephys.py table classes.
+"""
+
+import json
+import re
+import tempfile
+from pathlib import Path
+from datetime import datetime
+
+import numpy as np
+import joblib
+
+import datajoint as dj
+
+from swc.aeon.io import api as io_api
+from aeon.schema.ephys import social_ephys
+
+logger = dj.logger
+
+# Mapping from device directory name to probe_type
+DEVICE_PROBE_TYPE_MAP = {
+    "NeuropixelsV2Beta": "neuropixels2.0_beta",
+    "NeuropixelsV2": "neuropixels2.0",
+}
+
+
+def get_probe_id(metadata: dict | None, device_name: str, probe_label: str) -> str:
+    """Extract probe identifier from metadata.
+
+    For V2Beta hardware (no serial numbers): probe ID = "{device_name}_{label}"
+    For V2 hardware: probe ID = serial number from GainCalibrationFileName
+
+    Args:
+        metadata: Parsed Metadata.yml dict, or None
+        device_name: Hardware device name (e.g., "NeuropixelsV2Beta", "NeuropixelsV2")
+        probe_label: Probe label from filename (e.g., "ProbeA", "ProbeB")
+
+    Returns:
+        Probe identifier string
+    """
+    default_id = f"{device_name}_{probe_label}"
+
+    if metadata is None:
+        return default_id
+
+    # V2 hardware: try to extract serial number
+    if device_name == "NeuropixelsV2":
+        v2e_config = metadata.get("NeuropixelsV2e")
+        if v2e_config:
+            config_key_map = {
+                "ProbeA": "ProbeConfigurationA",
+                "ProbeB": "ProbeConfigurationB",
+            }
+            config_key = config_key_map.get(probe_label)
+            if config_key and config_key in v2e_config:
+                gain_cal = v2e_config[config_key].get("GainCalibrationFileName")
+                if gain_cal:
+                    try:
+                        serial = Path(gain_cal).parent.name
+                        if serial and serial.isdigit():
+                            return serial
+                    except Exception:
+                        pass
+
+    return default_id
+
+
+def find_or_create_probe_insertion(
+    experiment_name: str, subject: str, probe_id: str,
+    probe_insertion_table, probe_table,
+) -> dict:
+    """Find existing or create new ProbeInsertion for this (experiment, subject, probe).
+
+    Returns the ProbeInsertion key: {experiment_name, subject, insertion_number}.
+
+    Args:
+        experiment_name: Experiment name
+        subject: Subject name
+        probe_id: Probe identifier (serial number)
+        probe_insertion_table: The ProbeInsertion table class
+        probe_table: The Probe table class
+
+    Returns:
+        Dict with ProbeInsertion PK fields
+    """
+    # Check if a ProbeInsertion already exists for this probe + subject + experiment
+    existing = (
+        probe_insertion_table
+        & {"experiment_name": experiment_name, "subject": subject, "probe": probe_id}
+    ).fetch(as_dict=True)
+    if existing:
+        row = existing[0]
+        return {
+            "experiment_name": row["experiment_name"],
+            "subject": row["subject"],
+            "insertion_number": row["insertion_number"],
+        }
+
+    # Create new ProbeInsertion with auto-assigned insertion_number
+    existing_nums = (
+        probe_insertion_table
+        & {"experiment_name": experiment_name, "subject": subject}
+    ).fetch("insertion_number")
+    new_num = int(existing_nums.max()) + 1 if len(existing_nums) > 0 else 1
+
+    probe_insertion_table.insert1({
+        "experiment_name": experiment_name,
+        "subject": subject,
+        "insertion_number": new_num,
+        "probe": probe_id,
+    })
+    logger.info(
+        f"Created ProbeInsertion: experiment={experiment_name}, "
+        f"subject={subject}, insertion_number={new_num}, probe={probe_id}"
+    )
+    return {
+        "experiment_name": experiment_name,
+        "subject": subject,
+        "insertion_number": new_num,
+    }
+
+
+def read_probe_assignments(
+    key: dict, epoch_path: Path, probe_labels: list[str],
+    insertion_table,
+) -> dict:
+    """Read subject-probe mapping from file or carry forward from previous epoch.
+
+    Priority:
+    1. probe_assignments.json in epoch directory
+    2. Carry-forward from most recent EphysEpoch with .Insertion entries
+    3. Pre-existing ProbeInsertion matched by probe serial (error if not found)
+
+    Args:
+        key: Epoch key (experiment_name, epoch_start)
+        epoch_path: Path to epoch directory
+        probe_labels: Sorted list of probe labels discovered in this epoch
+        insertion_table: The EphysEpoch.Insertion Part table class
+
+    Returns:
+        Dict mapping probe_label -> {"subject": str, ...}
+    """
+    raise NotImplementedError(
+        "Probe-subject assignment resolution is not yet implemented. "
+        "The exact file format and carry-forward logic will be determined "
+        "once the experimental data conventions are finalized."
+    )
+
+
+def discover_epoch_probes(epoch_path: Path) -> tuple[str | None, Path | None, list[str]]:
+    """Discover ephys device and probe labels in an epoch directory.
+
+    Looks for known device subdirectories (NeuropixelsV2Beta, NeuropixelsV2)
+    and parses probe labels from amplifier binary filenames.
+
+    Args:
+        epoch_path: Path to the epoch directory
+
+    Returns:
+        Tuple of (device_name, device_dir, sorted_probe_labels).
+        If no ephys data found, returns (None, None, []).
+    """
+    device_name = None
+    device_dir = None
+    for subdir_name in ("NeuropixelsV2Beta", "NeuropixelsV2"):
+        candidate = epoch_path / subdir_name
+        if candidate.exists() and candidate.is_dir():
+            device_name = subdir_name
+            device_dir = candidate
+            break
+
+    if device_name is None:
+        return None, None, []
+
+    amplifier_files = sorted(device_dir.glob(f"{device_name}_Probe*_AmplifierData_*.bin"))
+    if not amplifier_files:
+        return device_name, device_dir, []
+
+    # e.g., "NeuropixelsV2Beta_ProbeA_AmplifierData_0.bin" -> "ProbeA"
+    probe_labels = set()
+    for f in amplifier_files:
+        match = re.search(rf"{device_name}_(Probe[A-Z])_AmplifierData", f.name)
+        if match:
+            probe_labels.add(match.group(1))
+
+    return device_name, device_dir, sorted(probe_labels)
+
+
+def parse_epoch_metadata(epoch_path: Path) -> dict | None:
+    """Parse Metadata.yml (JSON format) from an epoch directory.
+
+    Args:
+        epoch_path: Path to the epoch directory
+
+    Returns:
+        Parsed metadata dict, or None if not found or unparseable.
+    """
+    metadata_path = epoch_path / "Metadata.yml"
+    if not metadata_path.exists():
+        return None
+    try:
+        with open(metadata_path) as f:
+            return json.load(f)  # JSON despite .yml extension
+    except (json.JSONDecodeError, IOError) as e:
+        logger.warning(f"Failed to parse Metadata.yml at {metadata_path}: {e}")
+        return None
+
+
+def process_ephys_file(
+    ephys_file: Path,
+    raw_dir: Path,
+    insertion_key: dict,
+    epoch_start: datetime,
+    probe_label: str,
+    probe_type: str,
+    electrode_config_name: str,
+    sync_models: dict,
+    chunk_table,
+) -> None:
+    """Process a single ephys binary file into a chunk entry with sync model.
+
+    Args:
+        ephys_file: Path to the amplifier data binary file
+        raw_dir: Root raw data directory
+        insertion_key: ProbeInsertion key (experiment_name, subject, insertion_number)
+        epoch_start: Epoch start datetime for this file's epoch
+        probe_label: File label (e.g., "ProbeA")
+        probe_type: Probe type string
+        electrode_config_name: Electrode configuration name
+        sync_models: Mutable dict cache for sync models (shared across files)
+        chunk_table: The EphysChunk table class (for inserts)
+    """
+    clock_file = ephys_file.with_name(
+        ephys_file.name.replace("AmplifierData", "Clock")
+    )
+    onix_ts = np.memmap(clock_file, mode="r", dtype=np.uint64)
+
+    model_parent_dir = raw_dir / ephys_file.relative_to(raw_dir).parents[-2]
+    if model_parent_dir.as_posix() not in sync_models:
+        device_prefix = ephys_file.name.split(f"_{probe_label}_")[0]
+        device_reader = getattr(social_ephys, device_prefix, None)
+        if device_reader is None:
+            raise ValueError(
+                f"No sync reader found for device '{device_prefix}'. "
+                f"Available devices: {list(social_ephys.keys())}"
+            )
+        sync_models[model_parent_dir.as_posix()] = io_api.load(
+            model_parent_dir,
+            device_reader.HarpSyncModel,
+        )
+
+    sync_model = sync_models[model_parent_dir.as_posix()]
+    matched_sync = sync_model.query(
+        f"(clock_start <= {onix_ts[0]} <= clock_end)"
+        f" | "
+        f"(clock_start <= {onix_ts[-1]} <= clock_end)"
+    )
+
+    sync_entries = []
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for idx, (_, r) in enumerate(matched_sync.iterrows()):
+            if idx == 0:
+                chunk_start = r.model.predict(
+                    np.array(onix_ts[0]).reshape(-1, 1)
+                ).flatten()[0]
+                chunk_start = io_api.to_datetime(chunk_start)
+            if idx == len(matched_sync) - 1:
+                chunk_end = r.model.predict(
+                    np.array(onix_ts[-1]).reshape(-1, 1)
+                ).flatten()[0]
+                chunk_end = io_api.to_datetime(chunk_end)
+
+            model_path = Path(tmpdir) / (
+                ephys_file.stem + f"_{r.clock_start}.joblib"
+            )
+            joblib.dump(r.model, model_path)
+
+            sync_entries.append(
+                {
+                    "onix_ts_start": r.clock_start,
+                    "onix_ts_end": r.clock_end,
+                    "sync_model": model_path,
+                    "harp_start": r.name,
+                }
+            )
+
+        chunk_entry = {
+            **insertion_key,
+            "chunk_start": chunk_start,
+            "chunk_end": chunk_end,
+            "epoch_start": epoch_start,
+            "probe_type": probe_type,
+            "electrode_config_name": electrode_config_name,
+        }
+        chunk_table.insert1(chunk_entry)
+        chunk_table.File.insert(
+            [
+                dict(
+                    **chunk_entry,
+                    directory_type="raw",
+                    file_name=f.name,
+                    file_path=f.relative_to(raw_dir).as_posix(),
+                )
+                for f in (ephys_file, clock_file)
+            ],
+            ignore_extra_fields=True,
+        )
+        chunk_table.SyncModel.insert(
+            [{**chunk_entry, **sync_entry} for sync_entry in sync_entries],
+            ignore_extra_fields=True,
+        )
+
+
+def create_probe_type(
+    probe_type: str, manufacturer: str, probe_name: str,
+    probe_type_table,
+) -> None:
+    """Create a new probe type with electrode geometry from probeinterface.
+
+    Args:
+        probe_type: Unique identifier for the probe type
+        manufacturer: Probe manufacturer (e.g., "neuropixels")
+        probe_name: Specific probe model name (e.g., "NP2004")
+        probe_type_table: The ProbeType table class
+    """
+    import probeinterface as pi
+
+    electrode_df = pi.get_probe(
+        manufacturer=manufacturer, probe_name=probe_name
+    ).to_dataframe()
+    electrode_df.rename(
+        columns={
+            "contact_ids": "electrode_name",
+            "shank_ids": "shank",
+            "x": "x_coord",
+            "y": "y_coord",
+        },
+        inplace=True,
+    )
+    electrode_df.shank = electrode_df.shank.apply(lambda x: x or 0)
+    electrode_df["probe_type"] = probe_type
+    electrode_df["electrode"] = electrode_df.index
+
+    with probe_type_table.connection.transaction:
+        probe_type_table.insert1(dict(probe_type=probe_type))
+        probe_type_table.Electrode.insert(electrode_df, ignore_extra_fields=True)


### PR DESCRIPTION
## Summary
- Add design spec for unit matching system (`SPEC_unit_matching.md`)
- Key design refinements over `es/ephys_revamp`:
  - `UnitMatchingMethod` as non-PK FK (one matching result per session)
  - `Matched` as Part of `UnitMatching` (not `UniversalUnit`) for clean cascade
  - `ChunkedSpikeTimes` as Part of `UnitMatching` with ownership convention + `unique index` enforcement
  - Drop standalone `ChunkedSpikeTimes` Computed table
