### PR TITLE
Pin spikeinterface to upstream (fix merged)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dev = [
   "tox",
 ]
 gpu = ["cupy", "dask"]
-spike_sorting = ["spikeinterface[full] @ git+https://github.com/esutlie/spikeinterface.git@fix/pip-direct-url-quotes",
+spike_sorting = ["spikeinterface[full] @ git+https://github.com/SpikeInterface/spikeinterface.git@652f8566c1f7",
   "spython", "cuda-python", "spikeinterface-gui", "PySide6<6.8", "pyqtgraph"]
 
 [project.scripts]


### PR DESCRIPTION
The Singularity container fix (PR #4438) has been merged to SpikeInterface main, so we can switch from the fork pin to upstream. Pinned to the merge commit (652f856) since 0.104.0 isn't released yet.

This is a post-v0.2.0 dependency-only change, no code changes.