### PR TITLE
Forward-compatible MariaDB json column workaround

### DIFF
--- a/aeon/dj_pipeline/utils/codec.py
+++ b/aeon/dj_pipeline/utils/codec.py
@@ -7,6 +7,8 @@ Individual data columns store JSON summary stats (min, max, mean, dtype, count).
 The `stream_df` column uses <aeon_stream> codec for lazy DataFrame loading.
 """
 
+import json
+
 import datajoint as dj
 import numpy as np
 import pandas as pd
@@ -48,7 +50,20 @@ class AeonStreamCodec(dj.Codec):
         return "json"
 
     def encode(self, value, *, key=None, store_name=None):
-        """Validate and store the stream reference dict as JSON."""
+        """Validate and pass through the stream reference.
+
+        Accepts both a dict (MySQL / future fixed MariaDB, where DataJoint
+        will call ``json.dumps`` after this) and a pre-serialized JSON string
+        (current MariaDB, where the ``make()`` method serializes via
+        ``json_serialized()`` because DataJoint won't).
+        """
+        if isinstance(value, str):
+            # Pre-serialized by make() for MariaDB — validate by parsing.
+            parsed = json.loads(value)
+            missing = self._REQUIRED_KEYS - parsed.keys()
+            if missing:
+                raise ValueError(f"AeonStreamCodec missing required keys: {missing}")
+            return value
         if not isinstance(value, dict):
             raise TypeError(f"AeonStreamCodec expects a dict, got {type(value).__name__}")
         missing = self._REQUIRED_KEYS - value.keys()
@@ -62,6 +77,12 @@ class AeonStreamCodec(dj.Codec):
 
         from aeon.dj_pipeline import acquisition
         from aeon.dj_pipeline.utils.load_metadata import get_stream_reader_for_epoch
+
+        # MariaDB returns longtext as a raw string; MySQL returns json as a dict.
+        # DJ's codec fetch path normally auto-parses via final_dtype, but handle
+        # both for safety.
+        if isinstance(stored, str):
+            stored = json.loads(stored)
 
         data_dirs = acquisition.Experiment.get_data_directories(
             {"experiment_name": stored["experiment_name"]}

--- a/aeon/dj_pipeline/utils/json_serialization.py
+++ b/aeon/dj_pipeline/utils/json_serialization.py
@@ -1,0 +1,48 @@
+"""Manual JSON serialization for MariaDB json columns.
+
+MariaDB 10.3 aliases ``json`` to ``longtext``. When DataJoint reads the column
+type back from the database, it sees ``longtext`` instead of ``json`` and sets
+``attr.json = False``. This means DataJoint skips the automatic
+``json.dumps()`` on insert and ``json.loads()`` on fetch that it normally does
+for json columns. The result is a TypeError on insert (dict passed where string
+expected) and raw JSON strings returned on fetch.
+
+This module provides a helper that serializes values to JSON strings only when
+DataJoint won't do it itself. It checks ``attr.json`` at runtime, so the same
+code works on both MariaDB (manual serialization) and MySQL (DataJoint handles
+it), and will stop serializing automatically if DataJoint fixes the underlying
+issue.
+
+See: https://github.com/datajoint/datajoint-python/issues/1438
+"""
+
+import json
+
+
+def json_serialized(value, needs_serialize):
+    """Serialize a value to a JSON string only when DataJoint won't.
+
+    On MariaDB, ``attr.json`` is ``False`` for json columns (reported as
+    ``longtext``), so DataJoint skips serialization. On MySQL (or after a
+    future DataJoint fix), ``attr.json`` is ``True`` and DataJoint handles it.
+    This function adapts automatically based on the caller's check.
+
+    Parameters
+    ----------
+    value : dict, list, or str
+        The value to serialize. If already a string, returned as-is.
+    needs_serialize : bool
+        ``True`` when DataJoint won't serialize (``attr.json`` is ``False``).
+        Callers should compute this once per table via::
+
+            needs_serialize = not self.heading.attributes['some_json_col'].json
+
+    Returns
+    -------
+    dict, list, or str
+        The original value when DataJoint will handle serialization,
+        or a JSON string when it won't.
+    """
+    if not needs_serialize or isinstance(value, str):
+        return value
+    return json.dumps(value)

--- a/aeon/dj_pipeline/utils/streams_maker.py
+++ b/aeon/dj_pipeline/utils/streams_maker.py
@@ -230,6 +230,7 @@ def get_device_stream_template(device_type: str, stream_type: str, streams_modul
             from swc.aeon.io import api as io_api
 
             from aeon.dj_pipeline.utils.codec import column_stats, timestamp_stats
+            from aeon.dj_pipeline.utils.json_serialization import json_serialized
             from aeon.dj_pipeline.utils.load_metadata import get_stream_reader_for_epoch
 
             chunk_start, chunk_end, epoch_start = (acquisition.Chunk & key).fetch1(
@@ -249,27 +250,39 @@ def get_device_stream_template(device_type: str, stream_type: str, streams_modul
                 end=pd.Timestamp(chunk_end),
             )
 
-            # Summary stats for JSON columns
+            # MariaDB aliases json to longtext; check once whether DJ handles
+            # json serialization (attr.json=True) or we must do it ourselves.
+            _needs_serialize = not self.heading.attributes["timestamps"].json
+
             row = {
                 **key,
                 "sample_count": len(stream_data),
-                "timestamps": timestamp_stats(stream_data.index) if len(stream_data) > 0 else {},
+                "timestamps": json_serialized(
+                    timestamp_stats(stream_data.index) if len(stream_data) > 0 else {},
+                    _needs_serialize,
+                ),
             }
             for col in stream_reader.columns:
                 if col.startswith("_"):
                     continue
                 clean_col = re.sub(r"\([^)]*\)", "", col)
-                row[clean_col] = column_stats(stream_data[col].values) if len(stream_data) > 0 else {}
+                row[clean_col] = json_serialized(
+                    column_stats(stream_data[col].values) if len(stream_data) > 0 else {},
+                    _needs_serialize,
+                )
 
             # Codec reference for stream_df (self-contained for decode)
-            row["stream_df"] = {
-                "stream_type": "{stream_type}",
-                "experiment_name": key["experiment_name"],
-                "device_name": device_name,
-                "chunk_start": str(chunk_start),
-                "chunk_end": str(chunk_end),
-                "epoch_start": str(epoch_start),
-            }
+            row["stream_df"] = json_serialized(
+                {
+                    "stream_type": "{stream_type}",
+                    "experiment_name": key["experiment_name"],
+                    "device_name": device_name,
+                    "chunk_start": str(chunk_start),
+                    "chunk_end": str(chunk_end),
+                    "epoch_start": str(epoch_start),
+                },
+                _needs_serialize,
+            )
 
             self.insert1(row, ignore_extra_fields=True)
 


### PR DESCRIPTION
## Summary

MariaDB aliases `json` columns to `longtext`, which causes DataJoint to skip automatic JSON serialization on insert and deserialization on fetch. This adds a runtime workaround that checks `attr.json` at populate time and serializes manually when needed. It works on both MariaDB and MySQL, and will stop serializing automatically once DataJoint fixes the root cause.

Tested on HPC against aeon-db (MariaDB 10.3). All 9 stream tables populate successfully and codec fetch returns a DataFrame as expected.

See datajoint/datajoint-python#1438

## Changes

- **New: `aeon/dj_pipeline/utils/json_serialization.py`** - `json_serialized(value, needs_serialize)` helper that serializes to JSON only when DataJoint won't
- **Modified: `aeon/dj_pipeline/utils/codec.py`** - `encode()` now accepts both dict (MySQL) and pre-serialized string (MariaDB). `decode()` handles both string and dict input on fetch.
- **Modified: `aeon/dj_pipeline/utils/streams_maker.py`** - `make()` template checks `attr.json` once per call and wraps all json column values with `json_serialized()`