### PR TITLE
Follow-up fixes for v0.4.0 merge

### DIFF
--- a/aeon/dj_pipeline/acquisition.py
+++ b/aeon/dj_pipeline/acquisition.py
@@ -388,7 +388,7 @@ class EpochConfig(dj.Imported):
             ),  # Flat device dict for ingest_epoch_metadata_from_rig
         }
 
-        # Insert new entries for streams.DeviceType, streams.Device using Rig
+        # Insert new entries for streams.DeviceType, streams.DeviceName using Rig
         # Note: StreamType and DeviceType catalog populated at worker startup
         # ExperimentDevice and DeviceDataStream tables created at worker startup
         insert_device_types(rig, metadata_filepath)

--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -79,7 +79,7 @@ class SortingParamSet(dj.Lookup):
     ---
     -> SortingMethod    
     paramset_description='': varchar(1000)
-    params: longblob  # dictionary of all applicable parameters
+    params: <blob>  # dictionary of all applicable parameters
     """
 
 
@@ -799,7 +799,7 @@ class Waveform(dj.Imported):
         -> master
         -> SortedSpikes.Unit
         ---
-        unit_waveform: longblob  # (uV) mean waveform for a given unit at its representative electrode
+        unit_waveform: <blob>  # (uV) mean waveform for a given unit at its representative electrode
         """
 
     class ChannelWaveform(dj.Part):
@@ -809,7 +809,7 @@ class Waveform(dj.Imported):
         -> SortedSpikes.Unit
         -> ephys.ElectrodeConfig.Electrode  
         --- 
-        channel_waveform: longblob   # (uV) mean waveform across spikes of the given unit at the given electrode
+        channel_waveform: <blob>   # (uV) mean waveform across spikes of the given unit at the given electrode
         """
         
     def make(self, key):
@@ -1098,7 +1098,7 @@ class UnitMatchingParamSet(dj.Lookup):
     -> UnitMatchingMethod
     seed_block_start: datetime(6)  # block_start of the seed block (first to process)
     matching_paramset_description='': varchar(1000)
-    params: longblob  # dictionary of all applicable parameters
+    params: <blob>  # dictionary of all applicable parameters
     """
 
 

--- a/aeon/dj_pipeline/utils/load_metadata.py
+++ b/aeon/dj_pipeline/utils/load_metadata.py
@@ -940,7 +940,7 @@ def get_device_info(rig: "BaseSchema") -> dict[str, dict]:
             try:
                 reader = getattr(device, method_name)
             except Exception as e:
-                logger.warning(f"Failed to access {method_name} on {device_name}: {e}. Skipping...")
+                logger.debug(f"Failed to access {method_name} on {device_name}: {e}. Skipping...")
                 continue
 
             stream_type = to_pascal_case(method_name)

--- a/aeon/dj_pipeline/utils/load_metadata.py
+++ b/aeon/dj_pipeline/utils/load_metadata.py
@@ -498,7 +498,6 @@ def insert_device_types(rig: "BaseSchema", metadata_filepath: Path) -> None:
     - streams.DeviceType: Catalog of device types (e.g., "SpinnakerCamera")
     - streams.DeviceType.Stream: Links device types to stream types
     - streams.DeviceName: Catalog of device instance names (e.g., "CameraTop")
-    - streams.Device: Physical devices with serial numbers (optional)
 
     Args:
         rig: Rig instance (Pydantic BaseSchema) containing device collections
@@ -558,17 +557,6 @@ def insert_device_types(rig: "BaseSchema", metadata_filepath: Path) -> None:
         if not streams.DeviceName & {"device_name": device_name}
     ]
 
-    # Device entries - only for devices with serial numbers (optional hardware tracking)
-    new_devices = [
-        {
-            "device_serial_number": device_sn[device_name],
-            "device_type": device_config["device_type"],
-        }
-        for device_name, device_config in device_info.items()
-        if device_sn.get(device_name)
-        and not streams.Device & {"device_serial_number": device_sn[device_name]}
-    ]
-
     # Insert new entries.
     if new_device_types:
         streams.DeviceType.insert(new_device_types)
@@ -591,10 +579,6 @@ def insert_device_types(rig: "BaseSchema", metadata_filepath: Path) -> None:
     # Insert DeviceName entries (must be after DeviceType due to FK)
     if new_device_names:
         streams.DeviceName.insert(new_device_names)
-
-    # Insert Device entries (optional, for hardware tracking)
-    if new_devices:
-        streams.Device.insert(new_devices)
 
 
 def flatten_rig_devices(rig_config: dict) -> dict[str, dict]:

--- a/aeon/dj_pipeline/utils/stats.py
+++ b/aeon/dj_pipeline/utils/stats.py
@@ -8,12 +8,13 @@ DataFrame loading.
 """
 
 import numpy as np
+import pandas as pd
 
 
 def column_stats(values):
     """Compute JSON-serializable summary stats for a numpy array."""
     stats = {"dtype": str(values.dtype), "count": int(len(values))}
-    if len(values) > 0 and np.issubdtype(values.dtype, np.number):
+    if len(values) > 0 and pd.api.types.is_numeric_dtype(values.dtype):
         finite = values[np.isfinite(values)]
         if len(finite) > 0:
             stats["min"] = float(np.min(finite))

--- a/aeon/dj_pipeline/utils/streams_maker.py
+++ b/aeon/dj_pipeline/utils/streams_maker.py
@@ -77,14 +77,6 @@ class DeviceName(dj.Lookup):
     """
 
 
-class Device(dj.Lookup):
-    definition = """  # Physical devices identified by serial number or port
-    device_serial_number: varchar(12)
-    ---
-    -> DeviceType
-    """
-
-
 # region Helper functions for creating device tables.
 
 
@@ -296,7 +288,7 @@ def main(create_tables=True):
                 'schema = dj.Schema(get_schema_name("streams"))\n\n\n'
             )
             f.write(imports_str)
-            for table_class in (StreamType, DeviceType, DeviceName, Device):
+            for table_class in (StreamType, DeviceType, DeviceName):
                 device_table_def = inspect.getsource(table_class).lstrip()
                 full_def = "@schema \n" + device_table_def + "\n\n"
                 f.write(full_def)

--- a/tests/dj_pipeline/conftest.py
+++ b/tests/dj_pipeline/conftest.py
@@ -108,7 +108,6 @@ def streams_schema(dj_config_integration):
         "StreamType": streams.StreamType,
         "DeviceType": streams.DeviceType,
         "DeviceName": streams.DeviceName,
-        "Device": streams.Device,
         "schema": streams.schema,
         "schema_name": streams.schema.database,
     }
@@ -159,7 +158,6 @@ def clean_streams_tables(pipeline_integration):
     streams = pipeline_integration["streams"]
 
     # Pre-test cleanup (order matters due to FK constraints)
-    streams.Device().delete()
     streams.DeviceName().delete()
     streams.DeviceType().delete()
     streams.StreamType().delete()
@@ -167,7 +165,6 @@ def clean_streams_tables(pipeline_integration):
     yield
 
     # Post-test cleanup (same order)
-    streams.Device().delete()
     streams.DeviceName().delete()
     streams.DeviceType().delete()
     streams.StreamType().delete()

--- a/tests/dj_pipeline/test_full_ingestion.py
+++ b/tests/dj_pipeline/test_full_ingestion.py
@@ -136,16 +136,6 @@ class TestEpochConfigMake:
         assert len(metadata["cameras"]) == cfg["expected_camera_count"]
         assert len(metadata["feeders"]) == cfg["expected_feeder_count"]
 
-    def test_streams_device_registered(self, test_epochs, full_pipeline, golden_dataset_config):
-        """Verify streams.Device populated by EpochConfig.make()."""
-        acquisition = full_pipeline["acquisition"]
-        streams = full_pipeline["streams"]
-
-        acquisition.EpochConfig.populate()
-
-        devices = streams.Device.to_dicts()
-        assert len(devices) > 0
-
 
 class TestChunkIngestion:
     """Test Chunk.ingest_chunks() with golden dataset."""

--- a/tests/dj_pipeline/utils/test_load_metadata_integration.py
+++ b/tests/dj_pipeline/utils/test_load_metadata_integration.py
@@ -248,24 +248,6 @@ class TestInsertDeviceTypes:
         assert "Feeder1" in names
         assert "Feeder2" in names
 
-    def test_inserts_devices(self, pipeline_integration, test_rig, tmp_path, monkeypatch):
-        from aeon.dj_pipeline.utils import streams_maker
-        from aeon.dj_pipeline.utils.load_metadata import insert_device_types, insert_stream_types
-
-        monkeypatch.setattr(streams_maker, "schema_name", pipeline_integration["schema_name"])
-
-        streams = pipeline_integration["streams"]
-        metadata_filepath = tmp_path / "Metadata.json"
-        metadata_filepath.write_text("{}")
-
-        insert_stream_types(test_rig)
-        insert_device_types(test_rig, metadata_filepath)
-
-        # Cameras have serial_number, feeders have port_name (optional hardware tracking)
-        devices = streams.Device().to_dicts()
-        serial_numbers = [d["device_serial_number"] for d in devices]
-        assert "21053810" in serial_numbers  # CameraTop serial
-
     def test_handles_existing_device_types(self, pipeline_integration, test_rig, tmp_path, monkeypatch):
         from aeon.dj_pipeline.utils import streams_maker
         from aeon.dj_pipeline.utils.load_metadata import insert_device_types, insert_stream_types

--- a/tests/dj_pipeline/utils/test_stats_unit.py
+++ b/tests/dj_pipeline/utils/test_stats_unit.py
@@ -67,6 +67,16 @@ class TestColumnStats:
 
         assert column_stats(values) == expected
 
+    def test_column_stats_pandas_extension_dtype(self):
+        """pd.api.types.is_numeric_dtype handles pandas extension dtypes that np.issubdtype cannot."""
+        from aeon.dj_pipeline.utils.stats import column_stats
+
+        values = pd.array([1, 2, None, 4], dtype=pd.Int64Dtype())
+        result = column_stats(values.to_numpy(dtype="float64", na_value=np.nan))
+        assert result["count"] == 4
+        assert result["min"] == 1.0
+        assert result["max"] == 4.0
+
     @pytest.mark.parametrize(
         "values",
         [


### PR DESCRIPTION
## Summary

Assorted fixes found during foragingABC v0.4.0 testing with Adrian. These were originally on `es/foragingABC_v04` and PR #553, cleaned up here for main.

- **CameraPosition warning** — `get_device_info()` tries to access position tracking on all cameras, but only CameraTop has it defined. Downgraded the resulting warning to debug level since it fires on every epoch for every non-CameraTop camera and isn't actionable.
- **Remove `streams.Device`** — Vestigial table with no foreign key references. Serial numbers are already stored as optional attributes in the ExperimentDevice tables.
- **Fix `column_stats` crash on pandas extension dtypes** — `np.issubdtype` doesn't handle pandas extension dtypes like `Int64Dtype`, which shows up on FeederDeliverPellet columns. Switched to `pd.api.types.is_numeric_dtype`.
- **Convert `longblob` to `<blob>` in spike_sorting.py** — DJ 2.x replaces `longblob` with the built-in `<blob>` codec. Updated the four remaining `longblob` columns in SortingParamSet, Waveform, and UnitMatchingParamSet.

Note for deployment: `streams.py` on HPC needs to be deleted and regenerated after merging, since it's auto-generated from `streams_maker.py`. The stream tables themselves don't need to be recreated for this PR since the table definitions didn't change (that would only be needed if we change the column types from `json` to `<blob>`, which is not in this PR).