### PR TITLE
Add EnvironmentState, MessageLog, LightEvents tables to acquisition

### DIFF
--- a/aeon/dj_pipeline/acquisition.py
+++ b/aeon/dj_pipeline/acquisition.py
@@ -547,88 +547,8 @@ class Chunk(dj.Manual):
 # Each table stores sample_count + timestamp stats for quick browsing,
 # plus an <aeon_stream> codec reference for lazy DataFrame loading. The
 # raw column values live in the codec payload, not as separate JSON
-# attributes.
-
-
-def _environment_row(df, *, key, chunk_window, stream_type: str) -> dict:
-    """Build the insert row for an Environment-prefixed stream table.
-
-    Pure function: no DB, no filesystem. Receives the already-loaded
-    DataFrame (or None when no reader was resolved) and returns the dict
-    to insert.
-
-    Args:
-        df: DataFrame from io_api.load, or None when the Rig did not
-            expose the @data_reader for this stream (e.g., LightEvents
-            on non-foragingABC).
-        key: Chunk PK dict ({"experiment_name", "chunk_start"}).
-        chunk_window: (chunk_start, chunk_end, epoch_start) triple as
-            returned by (Chunk & key).fetch1("chunk_start", "chunk_end",
-            "epoch_start").
-        stream_type: PascalCase stream type name (e.g., "EnvironmentState").
-    """
-    from aeon.dj_pipeline.utils.stats import timestamp_stats
-
-    chunk_start, chunk_end, epoch_start = chunk_window
-
-    if df is None:
-        return {
-            **key,
-            "sample_count": 0,
-            "timestamps": {},
-            "stream_df": None,
-        }
-
-    return {
-        **key,
-        "sample_count": len(df),
-        "timestamps": timestamp_stats(df.index) if len(df) > 0 else {},
-        "stream_df": {
-            "stream_type": stream_type,
-            "experiment_name": key["experiment_name"],
-            "device_name": "Environment",
-            "chunk_start": str(chunk_start),
-            "chunk_end": str(chunk_end),
-            "epoch_start": str(epoch_start),
-        },
-    }
-
-
-def _make_environment_stream(table, key, *, stream_type: str):
-    """Populate one row of an Environment-prefixed stream table.
-
-    Resolves the reader via get_stream_reader_for_epoch (default=None),
-    loads the chunk window via swc.aeon.io.api.load, then delegates to
-    _environment_row to build the insert dict.
-    """
-    import pandas as pd
-
-    from aeon.dj_pipeline.utils.load_metadata import get_stream_reader_for_epoch
-
-    chunk_start, chunk_end, epoch_start = (Chunk & key).fetch1("chunk_start", "chunk_end", "epoch_start")
-    data_dirs = Experiment.get_data_directories(key)
-
-    stream_reader = get_stream_reader_for_epoch(
-        key["experiment_name"], "Environment", stream_type, epoch_start, default=None
-    )
-
-    if stream_reader is None:
-        df = None
-    else:
-        df = io_api.load(
-            root=data_dirs,
-            reader=stream_reader,
-            start=pd.Timestamp(chunk_start),
-            end=pd.Timestamp(chunk_end),
-        )
-
-    row = _environment_row(
-        df,
-        key=key,
-        chunk_window=(chunk_start, chunk_end, epoch_start),
-        stream_type=stream_type,
-    )
-    table.insert1(row, ignore_extra_fields=True)
+# attributes. The shared make() implementation lives in the HELPERS
+# section at the bottom of this file.
 
 
 @schema
@@ -743,3 +663,87 @@ def create_chunk_restriction(experiment_name, start_time, end_time):
         f' AND chunk_start < "{max(end_query.to_arrays("chunk_end"))}"'
     )
     return time_restriction
+
+
+# ---- Environment-stream helpers (used by EnvironmentState / MessageLog / LightEvents) ----
+
+
+def _environment_row(df, *, key, chunk_window, stream_type: str) -> dict:
+    """Build the insert row for an Environment-prefixed stream table.
+
+    Pure function: no DB, no filesystem. Receives the already-loaded
+    DataFrame (or None when no reader was resolved) and returns the dict
+    to insert.
+
+    Args:
+        df: DataFrame from io_api.load, or None when the Rig did not
+            expose the @data_reader for this stream (e.g., LightEvents
+            on non-foragingABC).
+        key: Chunk PK dict ({"experiment_name", "chunk_start"}).
+        chunk_window: (chunk_start, chunk_end, epoch_start) triple as
+            returned by (Chunk & key).fetch1("chunk_start", "chunk_end",
+            "epoch_start").
+        stream_type: PascalCase stream type name (e.g., "EnvironmentState").
+    """
+    from aeon.dj_pipeline.utils.stats import timestamp_stats
+
+    chunk_start, chunk_end, epoch_start = chunk_window
+
+    if df is None:
+        return {
+            **key,
+            "sample_count": 0,
+            "timestamps": {},
+            "stream_df": None,
+        }
+
+    return {
+        **key,
+        "sample_count": len(df),
+        "timestamps": timestamp_stats(df.index) if len(df) > 0 else {},
+        "stream_df": {
+            "stream_type": stream_type,
+            "experiment_name": key["experiment_name"],
+            "device_name": "Environment",
+            "chunk_start": str(chunk_start),
+            "chunk_end": str(chunk_end),
+            "epoch_start": str(epoch_start),
+        },
+    }
+
+
+def _make_environment_stream(table, key, *, stream_type: str):
+    """Populate one row of an Environment-prefixed stream table.
+
+    Resolves the reader via get_stream_reader_for_epoch (default=None),
+    loads the chunk window via swc.aeon.io.api.load, then delegates to
+    _environment_row to build the insert dict.
+    """
+    import pandas as pd
+
+    from aeon.dj_pipeline.utils.load_metadata import get_stream_reader_for_epoch
+
+    chunk_start, chunk_end, epoch_start = (Chunk & key).fetch1("chunk_start", "chunk_end", "epoch_start")
+    data_dirs = Experiment.get_data_directories(key)
+
+    stream_reader = get_stream_reader_for_epoch(
+        key["experiment_name"], "Environment", stream_type, epoch_start, default=None
+    )
+
+    if stream_reader is None:
+        df = None
+    else:
+        df = io_api.load(
+            root=data_dirs,
+            reader=stream_reader,
+            start=pd.Timestamp(chunk_start),
+            end=pd.Timestamp(chunk_end),
+        )
+
+    row = _environment_row(
+        df,
+        key=key,
+        chunk_window=(chunk_start, chunk_end, epoch_start),
+        stream_type=stream_type,
+    )
+    table.insert1(row, ignore_extra_fields=True)

--- a/aeon/dj_pipeline/acquisition.py
+++ b/aeon/dj_pipeline/acquisition.py
@@ -5,6 +5,7 @@ import json
 import pathlib
 
 import datajoint as dj
+import pandas as pd
 from swc.aeon.io import api as io_api
 from swc.aeon.io import reader as io_reader
 
@@ -719,8 +720,6 @@ def _make_environment_stream(table, key, *, stream_type: str):
     loads the chunk window via swc.aeon.io.api.load, then delegates to
     _environment_row to build the insert dict.
     """
-    import pandas as pd
-
     from aeon.dj_pipeline.utils.load_metadata import get_stream_reader_for_epoch
 
     chunk_start, chunk_end, epoch_start = (Chunk & key).fetch1("chunk_start", "chunk_end", "epoch_start")

--- a/aeon/dj_pipeline/acquisition.py
+++ b/aeon/dj_pipeline/acquisition.py
@@ -654,7 +654,22 @@ def create_chunk_restriction(experiment_name, start_time, end_time):
 
 
 def _environment_row(df, *, key, chunk_window, stream_type: str) -> dict:
-    """Build the insert row for an Environment-prefixed stream table (pure)."""
+    """Build the insert row for an Environment-prefixed stream table.
+
+    Pure function — no DB, no filesystem.
+
+    Args:
+        df: DataFrame from io_api.load, or None when no reader was resolved
+            (e.g., LightEvents on non-foragingABC).
+        key: Chunk PK dict (``{"experiment_name", "chunk_start"}``).
+        chunk_window: ``(chunk_start, chunk_end, epoch_start)`` triple.
+        stream_type: PascalCase stream type name (e.g. ``"EnvironmentState"``).
+
+    Returns:
+        Dict to insert: ``sample_count``, ``timestamps`` stats, and an
+        ``<aeon_stream>`` codec ref (``stream_df``) — or ``stream_df=None``
+        when ``df`` is None.
+    """
     from aeon.dj_pipeline.utils.stats import timestamp_stats
 
     chunk_start, chunk_end, epoch_start = chunk_window
@@ -683,7 +698,17 @@ def _environment_row(df, *, key, chunk_window, stream_type: str) -> dict:
 
 
 def _make_environment_stream(table, key, *, stream_type: str):
-    """Resolve the Environment reader for `stream_type` and insert one row."""
+    """Resolve the Environment reader, load the chunk window, and insert one row.
+
+    Resolves the reader via ``get_stream_reader_for_epoch(default=None)``,
+    loads the chunk window via ``swc.aeon.io.api.load``, then delegates to
+    ``_environment_row`` to build the insert dict.
+
+    Args:
+        table: The dj.Imported table instance whose make() is delegating here.
+        key: Chunk PK dict (``{"experiment_name", "chunk_start"}``).
+        stream_type: PascalCase stream type name (e.g. ``"EnvironmentState"``).
+    """
     from aeon.dj_pipeline.utils.load_metadata import get_stream_reader_for_epoch
 
     chunk_start, chunk_end, epoch_start = (Chunk & key).fetch1("chunk_start", "chunk_end", "epoch_start")

--- a/aeon/dj_pipeline/acquisition.py
+++ b/aeon/dj_pipeline/acquisition.py
@@ -544,12 +544,13 @@ class Chunk(dj.Manual):
 #   - MessageLog        (Environment_MessageLog_*)
 #   - LightEvents       (Environment_LightEvents_*, foragingABC-only)
 #
-# All three follow the same codec-based pattern as auto-generated stream
-# tables in `streams_maker`: per-column JSON summary stats plus an
-# <aeon_stream> reference for lazy DataFrame loading.
+# Each table stores sample_count + timestamp stats for quick browsing,
+# plus an <aeon_stream> codec reference for lazy DataFrame loading. The
+# raw column values live in the codec payload, not as separate JSON
+# attributes.
 
 
-def _environment_row(df, *, key, chunk_window, stream_type: str, columns: list[str]) -> dict:
+def _environment_row(df, *, key, chunk_window, stream_type: str) -> dict:
     """Build the insert row for an Environment-prefixed stream table.
 
     Pure function: no DB, no filesystem. Receives the already-loaded
@@ -565,9 +566,8 @@ def _environment_row(df, *, key, chunk_window, stream_type: str, columns: list[s
             returned by (Chunk & key).fetch1("chunk_start", "chunk_end",
             "epoch_start").
         stream_type: PascalCase stream type name (e.g., "EnvironmentState").
-        columns: data column names whose JSON summary stats to compute.
     """
-    from aeon.dj_pipeline.utils.stats import column_stats, timestamp_stats
+    from aeon.dj_pipeline.utils.stats import timestamp_stats
 
     chunk_start, chunk_end, epoch_start = chunk_window
 
@@ -576,7 +576,6 @@ def _environment_row(df, *, key, chunk_window, stream_type: str, columns: list[s
             **key,
             "sample_count": 0,
             "timestamps": {},
-            **{c: {} for c in columns},
             "stream_df": None,
         }
 
@@ -584,7 +583,6 @@ def _environment_row(df, *, key, chunk_window, stream_type: str, columns: list[s
         **key,
         "sample_count": len(df),
         "timestamps": timestamp_stats(df.index) if len(df) > 0 else {},
-        **{c: column_stats(df[c].values) if len(df) > 0 else {} for c in columns},
         "stream_df": {
             "stream_type": stream_type,
             "experiment_name": key["experiment_name"],
@@ -596,7 +594,7 @@ def _environment_row(df, *, key, chunk_window, stream_type: str, columns: list[s
     }
 
 
-def _make_environment_stream(table, key, *, stream_type: str, columns: list[str]):
+def _make_environment_stream(table, key, *, stream_type: str):
     """Populate one row of an Environment-prefixed stream table.
 
     Resolves the reader via get_stream_reader_for_epoch (default=None),
@@ -629,7 +627,6 @@ def _make_environment_stream(table, key, *, stream_type: str, columns: list[str]
         key=key,
         chunk_window=(chunk_start, chunk_end, epoch_start),
         stream_type=stream_type,
-        columns=columns,
     )
     table.insert1(row, ignore_extra_fields=True)
 
@@ -641,13 +638,12 @@ class EnvironmentState(dj.Imported):
     ---
     sample_count: int32           # number of data points in this chunk
     timestamps: json              # {{min, max, count, sampling_rate_hz}}
-    state: json                   # column summary stats
     stream_df=null: <aeon_stream> # codec ref for lazy DataFrame loading
     """
 
     def make(self, key):
         """Populate from Environment_EnvironmentState_* CSV reader."""
-        _make_environment_stream(self, key, stream_type="EnvironmentState", columns=["state"])
+        _make_environment_stream(self, key, stream_type="EnvironmentState")
 
 
 @schema
@@ -657,17 +653,12 @@ class MessageLog(dj.Imported):
     ---
     sample_count: int32
     timestamps: json
-    priority: json
-    type: json
-    message: json
     stream_df=null: <aeon_stream>
     """
 
     def make(self, key):
         """Populate from Environment_MessageLog_* Log reader."""
-        _make_environment_stream(
-            self, key, stream_type="MessageLog", columns=["priority", "type", "message"]
-        )
+        _make_environment_stream(self, key, stream_type="MessageLog")
 
 
 @schema
@@ -677,8 +668,6 @@ class LightEvents(dj.Imported):
     ---
     sample_count: int32
     timestamps: json
-    channel: json
-    value: json
     stream_df=null: <aeon_stream>
     """
 
@@ -689,7 +678,7 @@ class LightEvents(dj.Imported):
         expose `light_events` (anything other than foragingABC), the helper
         inserts sample_count=0 with stream_df=None.
         """
-        _make_environment_stream(self, key, stream_type="LightEvents", columns=["channel", "value"])
+        _make_environment_stream(self, key, stream_type="LightEvents")
 
 
 # ---- HELPERS ----

--- a/aeon/dj_pipeline/acquisition.py
+++ b/aeon/dj_pipeline/acquisition.py
@@ -572,7 +572,7 @@ class MessageLog(dj.Imported):
 
 @schema
 class LightEvents(dj.Imported):
-    definition = """  # Per-chunk Environment_LightEvents_* stream (foragingABC only)
+    definition = """  # Per-chunk Environment_LightEvents_* stream
     -> Chunk
     ---
     sample_count: int32
@@ -581,11 +581,7 @@ class LightEvents(dj.Imported):
     """
 
     def make(self, key):
-        """Populate from Environment_LightEvents_* CSV reader.
-
-        On non-foragingABC rigs (no `light_events` reader), inserts
-        sample_count=0 with stream_df=None.
-        """
+        """Populate from Environment_LightEvents_* CSV reader."""
         _make_environment_stream(self, key, stream_type="LightEvents")
 
 
@@ -660,7 +656,7 @@ def _environment_row(df, *, key, chunk_window, stream_type: str) -> dict:
 
     Args:
         df: DataFrame from io_api.load, or None when no reader was resolved
-            (e.g., LightEvents on non-foragingABC).
+            for the given stream type on this experiment's rig.
         key: Chunk PK dict (``{"experiment_name", "chunk_start"}``).
         chunk_window: ``(chunk_start, chunk_end, epoch_start)`` triple.
         stream_type: PascalCase stream type name (e.g. ``"EnvironmentState"``).
@@ -703,6 +699,10 @@ def _make_environment_stream(table, key, *, stream_type: str):
     Resolves the reader via ``get_stream_reader_for_epoch(default=None)``,
     loads the chunk window via ``swc.aeon.io.api.load``, then delegates to
     ``_environment_row`` to build the insert dict.
+
+    When the experiment's rig doesn't expose a reader for ``stream_type``
+    (e.g. ``light_events`` on a non-foragingABC rig), inserts a row with
+    ``sample_count=0`` and ``stream_df=None`` instead of skipping.
 
     Args:
         table: The dj.Imported table instance whose make() is delegating here.

--- a/aeon/dj_pipeline/acquisition.py
+++ b/aeon/dj_pipeline/acquisition.py
@@ -723,7 +723,6 @@ def _make_environment_stream(table, key, *, stream_type: str):
     from aeon.dj_pipeline.utils.load_metadata import get_stream_reader_for_epoch
 
     chunk_start, chunk_end, epoch_start = (Chunk & key).fetch1("chunk_start", "chunk_end", "epoch_start")
-    data_dirs = Experiment.get_data_directories(key)
 
     stream_reader = get_stream_reader_for_epoch(
         key["experiment_name"], "Environment", stream_type, epoch_start, default=None
@@ -733,7 +732,7 @@ def _make_environment_stream(table, key, *, stream_type: str):
         df = None
     else:
         df = io_api.load(
-            root=data_dirs,
+            root=Experiment.get_data_directories(key),
             reader=stream_reader,
             start=pd.Timestamp(chunk_start),
             end=pd.Timestamp(chunk_end),

--- a/aeon/dj_pipeline/acquisition.py
+++ b/aeon/dj_pipeline/acquisition.py
@@ -536,6 +536,162 @@ class Chunk(dj.Manual):
             cls.File.insert(file_list)
 
 
+# ------------------- ENVIRONMENT STREAMS --------------------
+#
+# Three explicit per-chunk tables for Environment-prefixed streams that
+# are global to the experiment (not tied to a discoverable rig device):
+#   - EnvironmentState  (Environment_EnvironmentState_*)
+#   - MessageLog        (Environment_MessageLog_*)
+#   - LightEvents       (Environment_LightEvents_*, foragingABC-only)
+#
+# All three follow the same codec-based pattern as auto-generated stream
+# tables in `streams_maker`: per-column JSON summary stats plus an
+# <aeon_stream> reference for lazy DataFrame loading.
+
+
+def _environment_row(df, *, key, chunk_window, stream_type: str, columns: list[str]) -> dict:
+    """Build the insert row for an Environment-prefixed stream table.
+
+    Pure function: no DB, no filesystem. Receives the already-loaded
+    DataFrame (or None when no reader was resolved) and returns the dict
+    to insert.
+
+    Args:
+        df: DataFrame from io_api.load, or None when the Rig did not
+            expose the @data_reader for this stream (e.g., LightEvents
+            on non-foragingABC).
+        key: Chunk PK dict ({"experiment_name", "chunk_start"}).
+        chunk_window: (chunk_start, chunk_end, epoch_start) triple as
+            returned by (Chunk & key).fetch1("chunk_start", "chunk_end",
+            "epoch_start").
+        stream_type: PascalCase stream type name (e.g., "EnvironmentState").
+        columns: data column names whose JSON summary stats to compute.
+    """
+    from aeon.dj_pipeline.utils.stats import column_stats, timestamp_stats
+
+    chunk_start, chunk_end, epoch_start = chunk_window
+
+    if df is None:
+        return {
+            **key,
+            "sample_count": 0,
+            "timestamps": {},
+            **{c: {} for c in columns},
+            "stream_df": None,
+        }
+
+    return {
+        **key,
+        "sample_count": len(df),
+        "timestamps": timestamp_stats(df.index) if len(df) > 0 else {},
+        **{c: column_stats(df[c].values) if len(df) > 0 else {} for c in columns},
+        "stream_df": {
+            "stream_type": stream_type,
+            "experiment_name": key["experiment_name"],
+            "device_name": "Environment",
+            "chunk_start": str(chunk_start),
+            "chunk_end": str(chunk_end),
+            "epoch_start": str(epoch_start),
+        },
+    }
+
+
+def _make_environment_stream(table, key, *, stream_type: str, columns: list[str]):
+    """Populate one row of an Environment-prefixed stream table.
+
+    Resolves the reader via get_stream_reader_for_epoch (default=None),
+    loads the chunk window via swc.aeon.io.api.load, then delegates to
+    _environment_row to build the insert dict.
+    """
+    import pandas as pd
+
+    from aeon.dj_pipeline.utils.load_metadata import get_stream_reader_for_epoch
+
+    chunk_start, chunk_end, epoch_start = (Chunk & key).fetch1("chunk_start", "chunk_end", "epoch_start")
+    data_dirs = Experiment.get_data_directories(key)
+
+    stream_reader = get_stream_reader_for_epoch(
+        key["experiment_name"], "Environment", stream_type, epoch_start, default=None
+    )
+
+    if stream_reader is None:
+        df = None
+    else:
+        df = io_api.load(
+            root=data_dirs,
+            reader=stream_reader,
+            start=pd.Timestamp(chunk_start),
+            end=pd.Timestamp(chunk_end),
+        )
+
+    row = _environment_row(
+        df,
+        key=key,
+        chunk_window=(chunk_start, chunk_end, epoch_start),
+        stream_type=stream_type,
+        columns=columns,
+    )
+    table.insert1(row, ignore_extra_fields=True)
+
+
+@schema
+class EnvironmentState(dj.Imported):
+    definition = """  # Per-chunk Environment_EnvironmentState_* stream
+    -> Chunk
+    ---
+    sample_count: int32           # number of data points in this chunk
+    timestamps: json              # {{min, max, count, sampling_rate_hz}}
+    state: json                   # column summary stats
+    stream_df=null: <aeon_stream> # codec ref for lazy DataFrame loading
+    """
+
+    def make(self, key):
+        """Populate from Environment_EnvironmentState_* CSV reader."""
+        _make_environment_stream(self, key, stream_type="EnvironmentState", columns=["state"])
+
+
+@schema
+class MessageLog(dj.Imported):
+    definition = """  # Per-chunk Environment_MessageLog_* stream
+    -> Chunk
+    ---
+    sample_count: int32
+    timestamps: json
+    priority: json
+    type: json
+    message: json
+    stream_df=null: <aeon_stream>
+    """
+
+    def make(self, key):
+        """Populate from Environment_MessageLog_* Log reader."""
+        _make_environment_stream(
+            self, key, stream_type="MessageLog", columns=["priority", "type", "message"]
+        )
+
+
+@schema
+class LightEvents(dj.Imported):
+    definition = """  # Per-chunk Environment_LightEvents_* stream (foragingABC only)
+    -> Chunk
+    ---
+    sample_count: int32
+    timestamps: json
+    channel: json
+    value: json
+    stream_df=null: <aeon_stream>
+    """
+
+    def make(self, key):
+        """Populate from Environment_LightEvents_* CSV reader.
+
+        Always inserts a row per chunk. For experiments whose Rig does not
+        expose `light_events` (anything other than foragingABC), the helper
+        inserts sample_count=0 with stream_df=None.
+        """
+        _make_environment_stream(self, key, stream_type="LightEvents", columns=["channel", "value"])
+
+
 # ---- HELPERS ----
 
 

--- a/aeon/dj_pipeline/acquisition.py
+++ b/aeon/dj_pipeline/acquisition.py
@@ -538,18 +538,6 @@ class Chunk(dj.Manual):
 
 
 # ------------------- ENVIRONMENT STREAMS --------------------
-#
-# Three explicit per-chunk tables for Environment-prefixed streams that
-# are global to the experiment (not tied to a discoverable rig device):
-#   - EnvironmentState  (Environment_EnvironmentState_*)
-#   - MessageLog        (Environment_MessageLog_*)
-#   - LightEvents       (Environment_LightEvents_*, foragingABC-only)
-#
-# Each table stores sample_count + timestamp stats for quick browsing,
-# plus an <aeon_stream> codec reference for lazy DataFrame loading. The
-# raw column values live in the codec payload, not as separate JSON
-# attributes. The shared make() implementation lives in the HELPERS
-# section at the bottom of this file.
 
 
 @schema
@@ -557,9 +545,9 @@ class EnvironmentState(dj.Imported):
     definition = """  # Per-chunk Environment_EnvironmentState_* stream
     -> Chunk
     ---
-    sample_count: int32           # number of data points in this chunk
-    timestamps: json              # {{min, max, count, sampling_rate_hz}}
-    stream_df=null: <aeon_stream> # codec ref for lazy DataFrame loading
+    sample_count: int32
+    timestamps: json
+    stream_df=null: <aeon_stream>
     """
 
     def make(self, key):
@@ -595,9 +583,8 @@ class LightEvents(dj.Imported):
     def make(self, key):
         """Populate from Environment_LightEvents_* CSV reader.
 
-        Always inserts a row per chunk. For experiments whose Rig does not
-        expose `light_events` (anything other than foragingABC), the helper
-        inserts sample_count=0 with stream_df=None.
+        On non-foragingABC rigs (no `light_events` reader), inserts
+        sample_count=0 with stream_df=None.
         """
         _make_environment_stream(self, key, stream_type="LightEvents")
 
@@ -666,26 +653,8 @@ def create_chunk_restriction(experiment_name, start_time, end_time):
     return time_restriction
 
 
-# ---- Environment-stream helpers (used by EnvironmentState / MessageLog / LightEvents) ----
-
-
 def _environment_row(df, *, key, chunk_window, stream_type: str) -> dict:
-    """Build the insert row for an Environment-prefixed stream table.
-
-    Pure function: no DB, no filesystem. Receives the already-loaded
-    DataFrame (or None when no reader was resolved) and returns the dict
-    to insert.
-
-    Args:
-        df: DataFrame from io_api.load, or None when the Rig did not
-            expose the @data_reader for this stream (e.g., LightEvents
-            on non-foragingABC).
-        key: Chunk PK dict ({"experiment_name", "chunk_start"}).
-        chunk_window: (chunk_start, chunk_end, epoch_start) triple as
-            returned by (Chunk & key).fetch1("chunk_start", "chunk_end",
-            "epoch_start").
-        stream_type: PascalCase stream type name (e.g., "EnvironmentState").
-    """
+    """Build the insert row for an Environment-prefixed stream table (pure)."""
     from aeon.dj_pipeline.utils.stats import timestamp_stats
 
     chunk_start, chunk_end, epoch_start = chunk_window
@@ -714,12 +683,7 @@ def _environment_row(df, *, key, chunk_window, stream_type: str) -> dict:
 
 
 def _make_environment_stream(table, key, *, stream_type: str):
-    """Populate one row of an Environment-prefixed stream table.
-
-    Resolves the reader via get_stream_reader_for_epoch (default=None),
-    loads the chunk window via swc.aeon.io.api.load, then delegates to
-    _environment_row to build the insert dict.
-    """
+    """Resolve the Environment reader for `stream_type` and insert one row."""
     from aeon.dj_pipeline.utils.load_metadata import get_stream_reader_for_epoch
 
     chunk_start, chunk_end, epoch_start = (Chunk & key).fetch1("chunk_start", "chunk_end", "epoch_start")

--- a/aeon/dj_pipeline/utils/load_metadata.py
+++ b/aeon/dj_pipeline/utils/load_metadata.py
@@ -422,7 +422,15 @@ _MISSING = object()
 
 
 def _load_rig_for_epoch(experiment_name: str, epoch_start):
-    """Reconstruct the Rig for a given epoch from EpochConfig.Meta."""
+    """Reconstruct the Rig for a given epoch from EpochConfig.Meta.
+
+    Args:
+        experiment_name: Name of the experiment.
+        epoch_start: Start time of the epoch.
+
+    Returns:
+        Rig instance validated from the epoch's stored metadata.
+    """
     from aeon.dj_pipeline import acquisition
 
     schema_name = (acquisition.Experiment.DevicesSchema & {"experiment_name": experiment_name}).fetch1(
@@ -459,8 +467,10 @@ def get_stream_reader_for_epoch(
         device_name: Name of device instance (e.g., "CameraTop")
         stream_type: Type of stream in PascalCase (e.g., "Video")
         epoch_start: Start time of the epoch
-        default: Returned when the device or @data_reader is missing.
-            If omitted, the original ValueError / AttributeError propagates.
+        default: Value to return when the device is not present in the Rig
+            or the @data_reader method is missing on the device. If omitted,
+            the original ValueError / AttributeError propagates (backward
+            compatible).
 
     Returns:
         Reader instance configured for the device/stream, or `default`

--- a/aeon/dj_pipeline/utils/load_metadata.py
+++ b/aeon/dj_pipeline/utils/load_metadata.py
@@ -480,15 +480,8 @@ def get_stream_reader_for_epoch(
 
     try:
         device = _find_device_in_rig(rig, device_name)
-    except ValueError:
-        if default is _MISSING:
-            raise
-        return default
-
-    stream_method = to_snake_case(stream_type)  # "Video" → "video"
-    try:
-        return getattr(device, stream_method)
-    except AttributeError:
+        return getattr(device, to_snake_case(stream_type))
+    except (ValueError, AttributeError):
         if default is _MISSING:
             raise
         return default
@@ -535,7 +528,7 @@ def insert_device_types(rig: "BaseSchema", metadata_filepath: Path) -> None:
     streams = dj.VirtualModule("streams", get_schema_name("streams"))
 
     device_info: dict[str, dict] = get_device_info(rig)
-    device_type_mapper, device_sn = get_device_mapper_from_rig(rig)
+    device_type_mapper, _device_sn = get_device_mapper_from_rig(rig)
 
     # Add device type to device_info. Only include devices that:
     # 1. Have a device_type defined in metadata
@@ -769,12 +762,16 @@ def ingest_epoch_metadata_from_rig(
             current_device_query = table - table.RemovalTime & experiment_key & device_key
 
             if current_device_query:
-                current_device_config: list[dict] = (table.Attribute & current_device_query).proj(
-                    "experiment_name",
-                    "device_name",
-                    "attribute_name",
-                    "attribute_value",
-                ).to_dicts()
+                current_device_config: list[dict] = (
+                    (table.Attribute & current_device_query)
+                    .proj(
+                        "experiment_name",
+                        "device_name",
+                        "attribute_name",
+                        "attribute_value",
+                    )
+                    .to_dicts()
+                )
                 new_device_config: list[dict] = [
                     {k: v for k, v in entry.items() if dj.utils.from_camel_case(table.__name__) not in k}
                     for entry in table_attribute_entry

--- a/aeon/dj_pipeline/utils/load_metadata.py
+++ b/aeon/dj_pipeline/utils/load_metadata.py
@@ -422,11 +422,7 @@ _MISSING = object()
 
 
 def _load_rig_for_epoch(experiment_name: str, epoch_start):
-    """Reconstruct the Rig instance for a given epoch from EpochConfig.Meta.
-
-    Split out so it can be monkeypatched in unit tests of get_stream_reader_for_epoch
-    without standing up a real DataJoint connection.
-    """
+    """Reconstruct the Rig for a given epoch from EpochConfig.Meta."""
     from aeon.dj_pipeline import acquisition
 
     schema_name = (acquisition.Experiment.DevicesSchema & {"experiment_name": experiment_name}).fetch1(
@@ -463,10 +459,8 @@ def get_stream_reader_for_epoch(
         device_name: Name of device instance (e.g., "CameraTop")
         stream_type: Type of stream in PascalCase (e.g., "Video")
         epoch_start: Start time of the epoch
-        default: Value to return when the device is not present in the Rig
-            or the @data_reader method is missing on the device. If omitted,
-            the original ValueError / AttributeError propagates (backward
-            compatible).
+        default: Returned when the device or @data_reader is missing.
+            If omitted, the original ValueError / AttributeError propagates.
 
     Returns:
         Reader instance configured for the device/stream, or `default`

--- a/aeon/dj_pipeline/utils/load_metadata.py
+++ b/aeon/dj_pipeline/utils/load_metadata.py
@@ -418,11 +418,40 @@ def _find_device_in_rig(rig, device_name: str):
     raise ValueError(f"Device '{device_name}' not found in Rig")
 
 
+_MISSING = object()
+
+
+def _load_rig_for_epoch(experiment_name: str, epoch_start):
+    """Reconstruct the Rig instance for a given epoch from EpochConfig.Meta.
+
+    Split out so it can be monkeypatched in unit tests of get_stream_reader_for_epoch
+    without standing up a real DataJoint connection.
+    """
+    from aeon.dj_pipeline import acquisition
+
+    schema_name = (acquisition.Experiment.DevicesSchema & {"experiment_name": experiment_name}).fetch1(
+        "devices_schema_name"
+    )
+
+    epoch_key = {"experiment_name": experiment_name, "epoch_start": epoch_start}
+    rig_metadata = (acquisition.EpochConfig.Meta & epoch_key).fetch1("metadata")
+
+    # MariaDB 10.3 aliases `json` columns to `longtext`, so DataJoint's auto
+    # json.loads() doesn't fire. Deserialize manually if needed.
+    if isinstance(rig_metadata, str):
+        rig_metadata = json.loads(rig_metadata)
+
+    experiment_class = get_experiment_pydantic(schema_name)
+    rig_class = experiment_class.model_fields["rig"].annotation
+    return rig_class.model_validate(rig_metadata)
+
+
 def get_stream_reader_for_epoch(
     experiment_name: str,
     device_name: str,
     stream_type: str,
     epoch_start,
+    default=_MISSING,
 ):
     """Get stream reader for a specific epoch.
 
@@ -434,35 +463,31 @@ def get_stream_reader_for_epoch(
         device_name: Name of device instance (e.g., "CameraTop")
         stream_type: Type of stream in PascalCase (e.g., "Video")
         epoch_start: Start time of the epoch
+        default: Value to return when the device is not present in the Rig
+            or the @data_reader method is missing on the device. If omitted,
+            the original ValueError / AttributeError propagates (backward
+            compatible).
 
     Returns:
-        Reader instance configured for the device/stream
+        Reader instance configured for the device/stream, or `default`
+        when not resolvable.
     """
-    from aeon.dj_pipeline import acquisition
+    rig = _load_rig_for_epoch(experiment_name, epoch_start)
 
-    # Get Experiment class path (e.g., "swc.aeon.exp.foragingABC.experiment:Experiment")
-    schema_name = (acquisition.Experiment.DevicesSchema & {"experiment_name": experiment_name}).fetch1(
-        "devices_schema_name"
-    )
+    try:
+        device = _find_device_in_rig(rig, device_name)
+    except ValueError:
+        if default is _MISSING:
+            raise
+        return default
 
-    # Get rig metadata for the specific epoch
-    epoch_key = {"experiment_name": experiment_name, "epoch_start": epoch_start}
-    rig_metadata = (acquisition.EpochConfig.Meta & epoch_key).fetch1("metadata")
-
-    # MariaDB 10.3 aliases `json` columns to `longtext`, so DataJoint's auto
-    # json.loads() doesn't fire. Deserialize manually if needed.
-    if isinstance(rig_metadata, str):
-        rig_metadata = json.loads(rig_metadata)
-
-    # Get Rig class from Experiment class and reconstruct directly
-    experiment_class = get_experiment_pydantic(schema_name)
-    rig_class = experiment_class.model_fields["rig"].annotation
-    rig = rig_class.model_validate(rig_metadata)
-
-    # Find device in Rig and access stream reader
-    device = _find_device_in_rig(rig, device_name)
     stream_method = to_snake_case(stream_type)  # "Video" → "video"
-    return getattr(device, stream_method)
+    try:
+        return getattr(device, stream_method)
+    except AttributeError:
+        if default is _MISSING:
+            raise
+        return default
 
 
 def insert_stream_types(rig: "BaseSchema") -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aeon_mecha"
-version = "0.4.1"
+version = "0.4.2"
 requires-python = ">=3.11,<3.13"
 description = '''
     Code for managing acquired data from Project Aeon experiments. Includes general file IO,

--- a/tests/dj_pipeline/conftest.py
+++ b/tests/dj_pipeline/conftest.py
@@ -218,11 +218,14 @@ def full_pipeline(dj_config_integration, streams_schema, golden_dataset_config):
     modules, all schemas (lab, subject, acquisition, streams) are already
     activated with test_aeon_* databases. No manual re-decoration needed.
 
+    Requires swc.aeon_exp (private package) — skips if not installed.
+
     Steps:
     1. Populate catalog from Pydantic class (populate_catalog_from_pydantic)
     2. Create ExperimentDevice and DeviceDataStream tables via streams_maker.main()
     3. Tests can then call EpochConfig.make() for DML
     """
+    pytest.importorskip("swc.aeon_exp", reason="requires swc.aeon_exp package")
     import datajoint as dj
 
     from aeon.dj_pipeline import acquisition, lab, subject

--- a/tests/dj_pipeline/test_acquisition_environment_integration.py
+++ b/tests/dj_pipeline/test_acquisition_environment_integration.py
@@ -1,0 +1,127 @@
+"""Integration tests for Environment-prefixed stream tables in acquisition.py.
+
+These run against the testcontainers MySQL fixture (`pipeline_integration`),
+which activates schemas with the test_aeon_ prefix.
+"""
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+class TestEnvironmentStreamTableDefinitions:
+    """Confirm the three new tables are activated in the acquisition schema.
+
+    Checks the expected primary key (-> Chunk only) and that stream_df is nullable.
+    """
+
+    @pytest.fixture
+    def acquisition_module(self, pipeline_integration):
+        from aeon.dj_pipeline import acquisition
+
+        return acquisition
+
+    def test_environment_state_table_exists(self, acquisition_module):
+        assert acquisition_module.EnvironmentState.full_table_name
+        attrs = acquisition_module.EnvironmentState.heading.attributes
+        assert set(acquisition_module.EnvironmentState.primary_key) == {
+            "experiment_name",
+            "chunk_start",
+        }
+        assert "state" in attrs
+        assert "stream_df" in attrs
+        assert attrs["stream_df"].nullable
+
+    def test_message_log_table_exists(self, acquisition_module):
+        attrs = acquisition_module.MessageLog.heading.attributes
+        assert set(acquisition_module.MessageLog.primary_key) == {
+            "experiment_name",
+            "chunk_start",
+        }
+        for col in ("priority", "type", "message"):
+            assert col in attrs
+        assert attrs["stream_df"].nullable
+
+    def test_light_events_table_exists(self, acquisition_module):
+        attrs = acquisition_module.LightEvents.heading.attributes
+        assert set(acquisition_module.LightEvents.primary_key) == {
+            "experiment_name",
+            "chunk_start",
+        }
+        for col in ("channel", "value"):
+            assert col in attrs
+        assert attrs["stream_df"].nullable
+
+
+class TestEnvironmentStreamPopulate:
+    """End-to-end populate against the foragingABC golden chunk.
+
+    Skips when:
+      - the golden dataset isn't on disk (require_golden_data fixture skips), or
+      - the Pydantic Environment device doesn't expose @data_reader methods yet
+        (upstream PR not merged).
+    """
+
+    @pytest.fixture(scope="class")
+    def populated_chunks(self, full_pipeline, test_experiment, test_epochs, require_golden_data):
+        """Drive Chunk + EpochConfig ingestion so the new tables have key_source rows."""
+        acquisition = full_pipeline["acquisition"]
+        cfg_name = test_experiment["experiment_name"]
+
+        # Make sure the upstream Environment device exposes the @data_readers
+        # we depend on; skip cleanly otherwise.
+        from aeon.dj_pipeline.utils.load_metadata import (
+            get_experiment_pydantic,
+        )
+
+        exp_class = get_experiment_pydantic(
+            (acquisition.Experiment.DevicesSchema & {"experiment_name": cfg_name}).fetch1(
+                "devices_schema_name"
+            )
+        )
+        rig_cls = exp_class.model_fields["rig"].annotation
+        env_field = rig_cls.model_fields.get("environment")
+        if env_field is None:
+            pytest.skip("Rig has no `environment` field — upstream PR not merged")
+        env_cls = env_field.annotation
+        if not all(hasattr(env_cls, name) for name in ("environment_state", "message_log")):
+            pytest.skip(
+                "Upstream Environment device missing @data_reader methods "
+                "environment_state/message_log — pull aeon_api/foragingABC main first"
+            )
+
+        # Ingest chunks for the experiment, then run EpochConfig so the
+        # rig metadata is on disk for get_stream_reader_for_epoch().
+        acquisition.Chunk.ingest_chunks(cfg_name)
+        acquisition.EpochConfig.populate({"experiment_name": cfg_name})
+
+        chunks = (acquisition.Chunk & {"experiment_name": cfg_name}).fetch("KEY")
+        if not chunks:
+            pytest.skip("No chunks ingested from golden dataset")
+        return chunks
+
+    def test_environment_state_populates(self, full_pipeline, populated_chunks):
+        acquisition = full_pipeline["acquisition"]
+        acquisition.EnvironmentState.populate(populated_chunks[:1], display_progress=False)
+        assert len(acquisition.EnvironmentState & populated_chunks[0]) == 1
+        row = (acquisition.EnvironmentState & populated_chunks[0]).fetch1()
+        assert row["sample_count"] >= 0
+        assert isinstance(row["timestamps"], dict)
+
+    def test_message_log_populates(self, full_pipeline, populated_chunks):
+        acquisition = full_pipeline["acquisition"]
+        acquisition.MessageLog.populate(populated_chunks[:1], display_progress=False)
+        assert len(acquisition.MessageLog & populated_chunks[0]) == 1
+
+    def test_light_events_populates_foragingabc(self, full_pipeline, populated_chunks):
+        """ForagingABC golden dataset DOES have light_events.
+
+        Sample_count may be 0 for chunks where no light events fired, but the row must
+        exist and stream_df must NOT be null (reader was resolved).
+        """
+        acquisition = full_pipeline["acquisition"]
+        acquisition.LightEvents.populate(populated_chunks[:1], display_progress=False)
+        row = (acquisition.LightEvents & populated_chunks[0]).fetch1()
+        assert row["stream_df"] is not None
+        assert row["stream_df"]["stream_type"] == "LightEvents"
+        assert row["stream_df"]["device_name"] == "Environment"

--- a/tests/dj_pipeline/test_acquisition_environment_integration.py
+++ b/tests/dj_pipeline/test_acquisition_environment_integration.py
@@ -28,7 +28,8 @@ class TestEnvironmentStreamTableDefinitions:
             "experiment_name",
             "chunk_start",
         }
-        assert "state" in attrs
+        assert "sample_count" in attrs
+        assert "timestamps" in attrs
         assert "stream_df" in attrs
         assert attrs["stream_df"].nullable
 
@@ -38,8 +39,8 @@ class TestEnvironmentStreamTableDefinitions:
             "experiment_name",
             "chunk_start",
         }
-        for col in ("priority", "type", "message"):
-            assert col in attrs
+        assert "sample_count" in attrs
+        assert "timestamps" in attrs
         assert attrs["stream_df"].nullable
 
     def test_light_events_table_exists(self, acquisition_module):
@@ -48,8 +49,8 @@ class TestEnvironmentStreamTableDefinitions:
             "experiment_name",
             "chunk_start",
         }
-        for col in ("channel", "value"):
-            assert col in attrs
+        assert "sample_count" in attrs
+        assert "timestamps" in attrs
         assert attrs["stream_df"].nullable
 
 

--- a/tests/dj_pipeline/test_acquisition_environment_integration.py
+++ b/tests/dj_pipeline/test_acquisition_environment_integration.py
@@ -9,49 +9,17 @@ import pytest
 pytestmark = pytest.mark.integration
 
 
-class TestEnvironmentStreamTableDefinitions:
-    """Confirm the three new tables are activated in the acquisition schema.
+@pytest.mark.parametrize("table_name", ["EnvironmentState", "MessageLog", "LightEvents"])
+def test_environment_table_schema(pipeline_integration, table_name):
+    """Confirm Environment table exists and has correct PK and nullable stream_df."""
+    from aeon.dj_pipeline import acquisition
 
-    Checks the expected primary key (-> Chunk only) and that stream_df is nullable.
-    """
-
-    @pytest.fixture
-    def acquisition_module(self, pipeline_integration):
-        from aeon.dj_pipeline import acquisition
-
-        return acquisition
-
-    def test_environment_state_table_exists(self, acquisition_module):
-        assert acquisition_module.EnvironmentState.full_table_name
-        attrs = acquisition_module.EnvironmentState.heading.attributes
-        assert set(acquisition_module.EnvironmentState.primary_key) == {
-            "experiment_name",
-            "chunk_start",
-        }
-        assert "sample_count" in attrs
-        assert "timestamps" in attrs
-        assert "stream_df" in attrs
-        assert attrs["stream_df"].nullable
-
-    def test_message_log_table_exists(self, acquisition_module):
-        attrs = acquisition_module.MessageLog.heading.attributes
-        assert set(acquisition_module.MessageLog.primary_key) == {
-            "experiment_name",
-            "chunk_start",
-        }
-        assert "sample_count" in attrs
-        assert "timestamps" in attrs
-        assert attrs["stream_df"].nullable
-
-    def test_light_events_table_exists(self, acquisition_module):
-        attrs = acquisition_module.LightEvents.heading.attributes
-        assert set(acquisition_module.LightEvents.primary_key) == {
-            "experiment_name",
-            "chunk_start",
-        }
-        assert "sample_count" in attrs
-        assert "timestamps" in attrs
-        assert attrs["stream_df"].nullable
+    table = getattr(acquisition, table_name)
+    attrs = table.heading.attributes
+    assert set(table.primary_key) == {"experiment_name", "chunk_start"}
+    assert "sample_count" in attrs
+    assert "timestamps" in attrs
+    assert attrs["stream_df"].nullable
 
 
 class TestEnvironmentStreamPopulate:

--- a/tests/dj_pipeline/test_acquisition_environment_integration.py
+++ b/tests/dj_pipeline/test_acquisition_environment_integration.py
@@ -69,28 +69,20 @@ class TestEnvironmentStreamPopulate:
             pytest.skip("No chunks ingested from golden dataset")
         return chunks
 
-    def test_environment_state_populates(self, full_pipeline, populated_chunks):
-        acquisition = full_pipeline["acquisition"]
-        acquisition.EnvironmentState.populate(populated_chunks[:1], display_progress=False)
-        assert len(acquisition.EnvironmentState & populated_chunks[0]) == 1
-        row = (acquisition.EnvironmentState & populated_chunks[0]).fetch1()
-        assert row["sample_count"] >= 0
-        assert isinstance(row["timestamps"], dict)
+    @pytest.mark.parametrize("table_name", ["EnvironmentState", "MessageLog", "LightEvents"])
+    def test_populates(self, full_pipeline, populated_chunks, table_name):
+        """Smoke test: populate the table for one chunk, confirm row exists with expected keys.
 
-    def test_message_log_populates(self, full_pipeline, populated_chunks):
-        acquisition = full_pipeline["acquisition"]
-        acquisition.MessageLog.populate(populated_chunks[:1], display_progress=False)
-        assert len(acquisition.MessageLog & populated_chunks[0]) == 1
-
-    def test_light_events_populates_foragingabc(self, full_pipeline, populated_chunks):
-        """ForagingABC golden dataset DOES have light_events.
-
-        Sample_count may be 0 for chunks where no light events fired, but the row must
+        LightEvents may not exist in all datasets but golden dataset (ForagingABC) HAS light_events.
+        Sample_count may be 0 for chunks where there are no events, but the row must
         exist and stream_df must NOT be null (reader was resolved).
         """
         acquisition = full_pipeline["acquisition"]
-        acquisition.LightEvents.populate(populated_chunks[:1], display_progress=False)
-        row = (acquisition.LightEvents & populated_chunks[0]).fetch1()
+        table = getattr(acquisition, table_name)
+        table.populate(populated_chunks[:1], display_progress=False)
+        row = (table & populated_chunks[0]).fetch1()
+        assert row["sample_count"] >= 0
+        assert isinstance(row["timestamps"], dict)
         assert row["stream_df"] is not None
-        assert row["stream_df"]["stream_type"] == "LightEvents"
+        assert row["stream_df"]["stream_type"] == table_name
         assert row["stream_df"]["device_name"] == "Environment"

--- a/tests/dj_pipeline/test_acquisition_environment_integration.py
+++ b/tests/dj_pipeline/test_acquisition_environment_integration.py
@@ -26,6 +26,7 @@ class TestEnvironmentStreamPopulate:
     """End-to-end populate against the foragingABC golden chunk.
 
     Skips when:
+      - swc.aeon_exp package is not installed, or
       - the golden dataset isn't on disk (require_golden_data fixture skips), or
       - the Pydantic Environment device doesn't expose @data_reader methods yet
         (upstream PR not merged).

--- a/tests/dj_pipeline/test_acquisition_environment_unit.py
+++ b/tests/dj_pipeline/test_acquisition_environment_unit.py
@@ -1,0 +1,110 @@
+"""Unit tests for Environment stream row building in acquisition.py.
+
+Tests target the pure `_environment_row` builder. The thin DB-coupled
+`_make_environment_stream` wrapper is exercised by integration tests.
+"""
+
+import pandas as pd
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def chunk_window():
+    """(chunk_start, chunk_end, epoch_start) -- the same triple Chunk.fetch1 returns."""
+    return (
+        pd.Timestamp("2025-01-01 00:00:00"),
+        pd.Timestamp("2025-01-01 01:00:00"),
+        pd.Timestamp("2025-01-01 00:00:00"),
+    )
+
+
+@pytest.fixture
+def chunk_key():
+    return {"experiment_name": "exp", "chunk_start": pd.Timestamp("2025-01-01 00:00:00")}
+
+
+class TestEnvironmentRow:
+    def test_builds_full_row_when_dataframe_has_data(self, chunk_key, chunk_window):
+        import aeon.dj_pipeline.acquisition as acquisition  # noqa: PLR0402
+
+        df = pd.DataFrame(
+            {"state": ["A", "B"]},
+            index=pd.DatetimeIndex(["2025-01-01 00:00:01", "2025-01-01 00:30:00"]),
+        )
+        row = acquisition._environment_row(
+            df,
+            key=chunk_key,
+            chunk_window=chunk_window,
+            stream_type="EnvironmentState",
+            columns=["state"],
+        )
+        assert row["sample_count"] == 2
+        # timestamp_stats / column_stats yield real dicts; we just assert non-empty
+        assert isinstance(row["timestamps"], dict)
+        assert row["timestamps"].get("count") == 2
+        assert isinstance(row["state"], dict)
+        assert row["state"].get("count") == 2
+        assert row["stream_df"] == {
+            "stream_type": "EnvironmentState",
+            "experiment_name": "exp",
+            "device_name": "Environment",
+            "chunk_start": "2025-01-01 00:00:00",
+            "chunk_end": "2025-01-01 01:00:00",
+            "epoch_start": "2025-01-01 00:00:00",
+        }
+
+    def test_builds_empty_stats_when_df_is_none(self, chunk_key, chunk_window):
+        """df=None means no reader was resolved (e.g., LightEvents on non-foragingABC).
+
+        The row carries sample_count=0, empty stats, AND stream_df=None.
+        """
+        import aeon.dj_pipeline.acquisition as acquisition  # noqa: PLR0402
+
+        row = acquisition._environment_row(
+            None,
+            key=chunk_key,
+            chunk_window=chunk_window,
+            stream_type="LightEvents",
+            columns=["channel", "value"],
+        )
+        assert row["sample_count"] == 0
+        assert row["timestamps"] == {}
+        assert row["channel"] == {}
+        assert row["value"] == {}
+        assert row["stream_df"] is None
+
+    def test_builds_empty_stats_when_df_is_empty(self, chunk_key, chunk_window):
+        """Reader resolved but the chunk window contains no rows -> sample_count=0.
+
+        Empty stats dicts, but stream_df IS populated (decode will yield empty DataFrame).
+        """
+        import aeon.dj_pipeline.acquisition as acquisition  # noqa: PLR0402
+
+        empty_df = pd.DataFrame({"state": []}, index=pd.DatetimeIndex([]))
+        row = acquisition._environment_row(
+            empty_df,
+            key=chunk_key,
+            chunk_window=chunk_window,
+            stream_type="EnvironmentState",
+            columns=["state"],
+        )
+        assert row["sample_count"] == 0
+        assert row["timestamps"] == {}
+        assert row["state"] == {}
+        assert row["stream_df"]["stream_type"] == "EnvironmentState"
+        assert row["stream_df"]["device_name"] == "Environment"
+
+    def test_includes_pk_fields_from_key(self, chunk_key, chunk_window):
+        import aeon.dj_pipeline.acquisition as acquisition  # noqa: PLR0402
+
+        row = acquisition._environment_row(
+            None,
+            key=chunk_key,
+            chunk_window=chunk_window,
+            stream_type="MessageLog",
+            columns=["priority", "type", "message"],
+        )
+        assert row["experiment_name"] == "exp"
+        assert row["chunk_start"] == chunk_key["chunk_start"]

--- a/tests/dj_pipeline/test_acquisition_environment_unit.py
+++ b/tests/dj_pipeline/test_acquisition_environment_unit.py
@@ -38,14 +38,10 @@ class TestEnvironmentRow:
             key=chunk_key,
             chunk_window=chunk_window,
             stream_type="EnvironmentState",
-            columns=["state"],
         )
         assert row["sample_count"] == 2
-        # timestamp_stats / column_stats yield real dicts; we just assert non-empty
         assert isinstance(row["timestamps"], dict)
         assert row["timestamps"].get("count") == 2
-        assert isinstance(row["state"], dict)
-        assert row["state"].get("count") == 2
         assert row["stream_df"] == {
             "stream_type": "EnvironmentState",
             "experiment_name": "exp",
@@ -58,7 +54,7 @@ class TestEnvironmentRow:
     def test_builds_empty_stats_when_df_is_none(self, chunk_key, chunk_window):
         """df=None means no reader was resolved (e.g., LightEvents on non-foragingABC).
 
-        The row carries sample_count=0, empty stats, AND stream_df=None.
+        The row carries sample_count=0, empty timestamps, AND stream_df=None.
         """
         import aeon.dj_pipeline.acquisition as acquisition  # noqa: PLR0402
 
@@ -67,18 +63,15 @@ class TestEnvironmentRow:
             key=chunk_key,
             chunk_window=chunk_window,
             stream_type="LightEvents",
-            columns=["channel", "value"],
         )
         assert row["sample_count"] == 0
         assert row["timestamps"] == {}
-        assert row["channel"] == {}
-        assert row["value"] == {}
         assert row["stream_df"] is None
 
     def test_builds_empty_stats_when_df_is_empty(self, chunk_key, chunk_window):
         """Reader resolved but the chunk window contains no rows -> sample_count=0.
 
-        Empty stats dicts, but stream_df IS populated (decode will yield empty DataFrame).
+        Empty timestamps dict, but stream_df IS populated (decode will yield empty DataFrame).
         """
         import aeon.dj_pipeline.acquisition as acquisition  # noqa: PLR0402
 
@@ -88,11 +81,9 @@ class TestEnvironmentRow:
             key=chunk_key,
             chunk_window=chunk_window,
             stream_type="EnvironmentState",
-            columns=["state"],
         )
         assert row["sample_count"] == 0
         assert row["timestamps"] == {}
-        assert row["state"] == {}
         assert row["stream_df"]["stream_type"] == "EnvironmentState"
         assert row["stream_df"]["device_name"] == "Environment"
 
@@ -104,7 +95,6 @@ class TestEnvironmentRow:
             key=chunk_key,
             chunk_window=chunk_window,
             stream_type="MessageLog",
-            columns=["priority", "type", "message"],
         )
         assert row["experiment_name"] == "exp"
         assert row["chunk_start"] == chunk_key["chunk_start"]

--- a/tests/dj_pipeline/utils/test_load_metadata_unit.py
+++ b/tests/dj_pipeline/utils/test_load_metadata_unit.py
@@ -252,17 +252,20 @@ class TestExtractActiveRegionsWithForagingABC:
 class TestGetStreamReaderForEpochDefault:
     """Test that get_stream_reader_for_epoch supports a default for missing readers."""
 
+    @staticmethod
+    def _fake_find_raises(_rig, device_name):
+        """Simulate _find_device_in_rig raising ValueError for missing device."""
+        raise ValueError(f"Device '{device_name}' not found in Rig")
+
+    class _DeviceWithoutMethod:
+        """Simulate a Device class that has no @data_reader methods."""
+
     def test_returns_default_when_device_not_in_rig(self, monkeypatch):
         """Device lookup raises ValueError -> return default sentinel."""
         import aeon.dj_pipeline.utils.load_metadata as load_metadata  # noqa: PLR0402
 
         sentinel = object()
-
-        def fake_find(rig, device_name):
-            raise ValueError(f"Device '{device_name}' not found in Rig")
-
-        # Short-circuit DB-touching parts so the unit test stays DB-free.
-        monkeypatch.setattr(load_metadata, "_find_device_in_rig", fake_find)
+        monkeypatch.setattr(load_metadata, "_find_device_in_rig", self._fake_find_raises)
         monkeypatch.setattr(load_metadata, "_load_rig_for_epoch", lambda *a, **kw: object())
 
         result = load_metadata.get_stream_reader_for_epoch(
@@ -274,10 +277,8 @@ class TestGetStreamReaderForEpochDefault:
         """Device exists but lacks the @data_reader -> return default sentinel."""
         import aeon.dj_pipeline.utils.load_metadata as load_metadata  # noqa: PLR0402
 
-        class DeviceWithoutMethod:
-            pass
-
-        monkeypatch.setattr(load_metadata, "_find_device_in_rig", lambda rig, name: DeviceWithoutMethod())
+        device_factory = self._DeviceWithoutMethod
+        monkeypatch.setattr(load_metadata, "_find_device_in_rig", lambda rig, name: device_factory())
         monkeypatch.setattr(load_metadata, "_load_rig_for_epoch", lambda *a, **kw: object())
 
         result = load_metadata.get_stream_reader_for_epoch(
@@ -289,10 +290,7 @@ class TestGetStreamReaderForEpochDefault:
         """Backward-compatible behavior: no default -> propagate the original error."""
         import aeon.dj_pipeline.utils.load_metadata as load_metadata  # noqa: PLR0402
 
-        def fake_find(rig, device_name):
-            raise ValueError("not found")
-
-        monkeypatch.setattr(load_metadata, "_find_device_in_rig", fake_find)
+        monkeypatch.setattr(load_metadata, "_find_device_in_rig", self._fake_find_raises)
         monkeypatch.setattr(load_metadata, "_load_rig_for_epoch", lambda *a, **kw: object())
 
         with pytest.raises(ValueError, match="not found"):
@@ -304,10 +302,8 @@ class TestGetStreamReaderForEpochDefault:
         """Backward-compatible behavior: no default -> propagate AttributeError."""
         import aeon.dj_pipeline.utils.load_metadata as load_metadata  # noqa: PLR0402
 
-        class DeviceWithoutMethod:
-            pass
-
-        monkeypatch.setattr(load_metadata, "_find_device_in_rig", lambda rig, name: DeviceWithoutMethod())
+        device_factory = self._DeviceWithoutMethod
+        monkeypatch.setattr(load_metadata, "_find_device_in_rig", lambda rig, name: device_factory())
         monkeypatch.setattr(load_metadata, "_load_rig_for_epoch", lambda *a, **kw: object())
 
         with pytest.raises(AttributeError):

--- a/tests/dj_pipeline/utils/test_load_metadata_unit.py
+++ b/tests/dj_pipeline/utils/test_load_metadata_unit.py
@@ -247,3 +247,70 @@ class TestExtractActiveRegionsWithForagingABC:
         regions = extract_active_regions(foraging_abc_rig_config)
         # CameraNest has cameraTracking: null, should not appear
         assert "CameraNest_Arena" not in regions
+
+
+class TestGetStreamReaderForEpochDefault:
+    """Test that get_stream_reader_for_epoch supports a default for missing readers."""
+
+    def test_returns_default_when_device_not_in_rig(self, monkeypatch):
+        """Device lookup raises ValueError -> return default sentinel."""
+        import aeon.dj_pipeline.utils.load_metadata as load_metadata  # noqa: PLR0402
+
+        sentinel = object()
+
+        def fake_find(rig, device_name):
+            raise ValueError(f"Device '{device_name}' not found in Rig")
+
+        # Short-circuit DB-touching parts so the unit test stays DB-free.
+        monkeypatch.setattr(load_metadata, "_find_device_in_rig", fake_find)
+        monkeypatch.setattr(load_metadata, "_load_rig_for_epoch", lambda *a, **kw: object())
+
+        result = load_metadata.get_stream_reader_for_epoch(
+            "exp", "MissingDevice", "Anything", "2025-01-01 00:00:00", default=sentinel
+        )
+        assert result is sentinel
+
+    def test_returns_default_when_method_missing_on_device(self, monkeypatch):
+        """Device exists but lacks the @data_reader -> return default sentinel."""
+        import aeon.dj_pipeline.utils.load_metadata as load_metadata  # noqa: PLR0402
+
+        class DeviceWithoutMethod:
+            pass
+
+        monkeypatch.setattr(load_metadata, "_find_device_in_rig", lambda rig, name: DeviceWithoutMethod())
+        monkeypatch.setattr(load_metadata, "_load_rig_for_epoch", lambda *a, **kw: object())
+
+        result = load_metadata.get_stream_reader_for_epoch(
+            "exp", "Environment", "LightEvents", "2025-01-01 00:00:00", default=None
+        )
+        assert result is None
+
+    def test_raises_when_no_default_provided_and_device_missing(self, monkeypatch):
+        """Backward-compatible behavior: no default -> propagate the original error."""
+        import aeon.dj_pipeline.utils.load_metadata as load_metadata  # noqa: PLR0402
+
+        def fake_find(rig, device_name):
+            raise ValueError("not found")
+
+        monkeypatch.setattr(load_metadata, "_find_device_in_rig", fake_find)
+        monkeypatch.setattr(load_metadata, "_load_rig_for_epoch", lambda *a, **kw: object())
+
+        with pytest.raises(ValueError, match="not found"):
+            load_metadata.get_stream_reader_for_epoch(
+                "exp", "MissingDevice", "Anything", "2025-01-01 00:00:00"
+            )
+
+    def test_raises_when_no_default_provided_and_method_missing(self, monkeypatch):
+        """Backward-compatible behavior: no default -> propagate AttributeError."""
+        import aeon.dj_pipeline.utils.load_metadata as load_metadata  # noqa: PLR0402
+
+        class DeviceWithoutMethod:
+            pass
+
+        monkeypatch.setattr(load_metadata, "_find_device_in_rig", lambda rig, name: DeviceWithoutMethod())
+        monkeypatch.setattr(load_metadata, "_load_rig_for_epoch", lambda *a, **kw: object())
+
+        with pytest.raises(AttributeError):
+            load_metadata.get_stream_reader_for_epoch(
+                "exp", "Environment", "LightEvents", "2025-01-01 00:00:00"
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "aeon-mecha"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "bottleneck" },


### PR DESCRIPTION
## Summary
- Adds three `dj.Imported` tables in `acquisition.py` — `EnvironmentState`, `MessageLog`, `LightEvents` — keyed `-> Chunk`. Each row carries `sample_count`, `timestamps` stats, and an `<aeon_stream>` codec ref for lazy DataFrame loading. 
- Bumps version 0.4.1 → 0.4.2.

## Design notes
- Two helpers in the HELPERS section: pure `_environment_row(df, key, chunk_window, stream_type)` builds the insert dict; `_make_environment_stream(table, key, stream_type)` does the DJ I/O and delegates.
- `device_name="Environment"` is the global file prefix, not a discoverable rig device — so each table is keyed by `Chunk` only, no device dimension.
- Per-column stats columns (`state`, `priority`, `type`, `message`, `channel`, `value`) were intentionally **not** included — the full data is already lazily decodable from `stream_df`, and `column_stats()` on string columns reduces to `{dtype, count}` which adds nothing over `sample_count`.

## Upstream dependency
Activation of the populate path requires `swc-aeon` (and `swc-aeon-foragingABC`) to expose a Pydantic `Environment` device with `@data_reader` methods `environment_state`, `message_log`, and (foragingABC-only) `light_events`. Table activation, schema, and helper logic are fully verified independently of upstream.

## Test plan
- all tests passed (integration tests with golden dataset)