### PR TITLE
Fix C2/C3 from PR #564 review: OnixStreamCodec raw-ephys + 4-col HarpSync fixtures

### DIFF
--- a/aeon/dj_pipeline/utils/codec.py
+++ b/aeon/dj_pipeline/utils/codec.py
@@ -152,11 +152,11 @@ class OnixStreamCodec(dj.Codec):
 
         epoch_dir = (acquisition.Epoch & sm_key).fetch1("epoch_dir")
         raw_dir = acquisition.Experiment.get_data_directory(
-            {"experiment_name": stored["experiment_name"]}, "raw"
+            {"experiment_name": stored["experiment_name"]}, "raw-ephys"
         )
         if raw_dir is None:
             raise FileNotFoundError(
-                f"No raw data directory registered for experiment {stored['experiment_name']!r}"
+                f"No raw-ephys data directory registered for experiment {stored['experiment_name']!r}"
             )
         device_dir = raw_dir / epoch_dir / stored["device_name"]
 

--- a/tests/dj_pipeline/_synthetic_ephys_fixtures.py
+++ b/tests/dj_pipeline/_synthetic_ephys_fixtures.py
@@ -31,20 +31,28 @@ def _make_synthetic_ephys_epoch(
     # HARP epoch base: arbitrary seconds-since-1904 for plausible wall-clock times.
     harp_base = 3000.0
 
+    # Aeon CSV convention: the first column is the Aeon timestamp (in seconds),
+    # promoted to the DataFrame index via ``index_col=0`` in ``Csv.read``. The
+    # remaining columns are named per ``HarpSync.Reader``'s ``columns=`` list.
+    # So real CSVs have 4 columns total even though only 3 are named.
     for n in range(n_chunks):
         ts_str = f"2024-06-04T1{n}-00-00"
         csv_path = device_dir / f"{device_name}_HarpSync_{ts_str}.csv"
         rows = []
         for s in range(60):
+            harp = harp_base + n * 60 + s
             rows.append(
                 {
+                    "aeon_time": harp,
                     "clock": 1000 * (n * 60 + s) + 1,
                     "hub_clock": s,
-                    "harp_time": harp_base + n * 60 + s,
+                    "harp_time": harp,
                 }
             )
         with open(csv_path, "w", newline="") as f:
-            writer = csv.DictWriter(f, fieldnames=["clock", "hub_clock", "harp_time"])
+            writer = csv.DictWriter(
+                f, fieldnames=["aeon_time", "clock", "hub_clock", "harp_time"]
+            )
             writer.writeheader()
             writer.writerows(rows)
 
@@ -120,22 +128,27 @@ def _register_synthetic_experiment(
 
     # Directory: directory_path is "raw" (relative to tmp_path), so
     # get_data_directory resolves to tmp_path / "raw" = raw_dir.
-    acquisition.Experiment.Directory.insert1(
-        {
-            "experiment_name": experiment_name,
-            "directory_type": "raw",
-            "repository_name": repo_key,
-            "directory_path": "raw",
-        },
-        skip_duplicates=True,
-    )
+    # Register the same path under both "raw" and "raw-ephys" — the ephys
+    # downstream (resolve_raw_dir_and_epochs) looks up "raw-ephys".
+    for dir_type in ("raw", "raw-ephys"):
+        acquisition.Experiment.Directory.insert1(
+            {
+                "experiment_name": experiment_name,
+                "directory_type": dir_type,
+                "repository_name": repo_key,
+                "directory_path": "raw",
+            },
+            skip_duplicates=True,
+        )
 
-    # Epoch — insert directly (skip ingest_epochs which scans camera files)
+    # Epoch — insert directly (skip ingest_epochs which scans camera files).
+    # Use "raw-ephys" since ephys downstream filters Epoch by EphysEpoch.has_ephys
+    # via resolve_raw_dir_and_epochs.
     acquisition.Epoch.insert1(
         {
             "experiment_name": experiment_name,
             "epoch_start": epoch_dt,
-            "directory_type": "raw",
+            "directory_type": "raw-ephys",
             "repository_name": repo_key,
             "epoch_dir": epoch_dir_name,
         },

--- a/tests/dj_pipeline/utils/test_onix_imu_unit.py
+++ b/tests/dj_pipeline/utils/test_onix_imu_unit.py
@@ -25,7 +25,9 @@ def _write_bno_chunk(tmp_path, device_name, n, n_samples, seed=0):
     device_dir.mkdir(parents=True, exist_ok=True)
     rng = np.random.default_rng(seed)
 
-    clock = ((np.arange(n_samples) + 1) * 100).astype(np.uint64)
+    # Offset clocks by chunk index so each chunk has a distinct first sample
+    # (required by tests that locate a chunk by its starting ONIX timestamp).
+    clock = (((np.arange(n_samples) + 1) * 100) + n * 1_000_000).astype(np.uint64)
     (device_dir / f"{device_name}_Bno055_Clock_{n}.bin").write_bytes(clock.tobytes())
 
     payloads = {}

--- a/tests/schema/test_ephys_reader_unit.py
+++ b/tests/schema/test_ephys_reader_unit.py
@@ -11,15 +11,21 @@ pytestmark = pytest.mark.unit
 
 @pytest.fixture
 def synthetic_harp_csv(tmp_path):
-    """Write a HarpSync CSV with three known sync samples and return its path."""
+    """Write a HarpSync CSV with three known sync samples and return its path.
+
+    Aeon CSV convention: the first column is the Aeon timestamp (in seconds),
+    which the Csv reader promotes to the DataFrame index via ``index_col=0``.
+    The remaining columns are named per ``HarpSync.Reader``'s ``columns=``.
+    Real CSVs therefore have 4 columns total even though only 3 are named.
+    """
     csv_path = tmp_path / "NeuropixelsV2Beta_HarpSync_2024-06-04T11-00-00.csv"
     rows = [
-        {"clock": 1000, "hub_clock": 0, "harp_time": 3000.5},
-        {"clock": 2000, "hub_clock": 1, "harp_time": 3001.5},
-        {"clock": 3000, "hub_clock": 2, "harp_time": 3002.5},
+        {"aeon_time": 3000.5, "clock": 1000, "hub_clock": 0, "harp_time": 3000.5},
+        {"aeon_time": 3001.5, "clock": 2000, "hub_clock": 1, "harp_time": 3001.5},
+        {"aeon_time": 3002.5, "clock": 3000, "hub_clock": 2, "harp_time": 3002.5},
     ]
     with open(csv_path, "w", newline="") as f:
-        writer = csv.DictWriter(f, fieldnames=["clock", "hub_clock", "harp_time"])
+        writer = csv.DictWriter(f, fieldnames=["aeon_time", "clock", "hub_clock", "harp_time"])
         writer.writeheader()
         writer.writerows(rows)
     return csv_path
@@ -46,7 +52,8 @@ def test_read_drops_na_rows_before_counting(synthetic_harp_csv, tmp_path):
     with open(synthetic_harp_csv) as src, open(csv_path, "w") as dst:
         dst.write(src.read())
         # Append a row with empty harp_time → NaN after parse
-        dst.write("4000,3,\n")
+        # (aeon_time, clock, hub_clock, harp_time) — 4 columns to match real format
+        dst.write("3003.5,4000,3,\n")
 
     reader = HarpSyncModel.Reader(pattern="NeuropixelsV2Beta")
     df = reader.read(csv_path)


### PR DESCRIPTION
Addresses the two open items from my [PR #564 review comment](https://github.com/SainsburyWellcomeCentre/aeon_mecha/pull/564#issuecomment-4451331515):

## Changes

**1. `OnixStreamCodec.decode` directory_type: `"raw"` → `"raw-ephys"`** (`aeon/dj_pipeline/utils/codec.py`)

The codec was the odd one out — `EphysSyncModel.ingest`, `EphysChunk.ingest_chunks`, and `OnixImuChunk.make` all use `raw-ephys` (via `resolve_raw_dir_and_epochs`), but the codec was still looking under `raw`. For split-rig experiments (AEON3 behavior + AEONX1 ephys), this meant any `stream_df` fetch silently returned an empty DataFrame because the device dir doesn't exist under the behavior path. Now consistent with the rest of the pipeline.

**2. 4-column HarpSync CSV test fixtures** (`tests/schema/test_ephys_reader_unit.py`, `tests/dj_pipeline/_synthetic_ephys_fixtures.py`)

The HarpSync reader fix in `dc4188f` (use `data.clock.values` not `data.index.values`) is correct, but two synthetic test fixtures still wrote 3-column CSVs. Real Aeon CSVs have 4 columns: the first is the Aeon timestamp (promoted to the DataFrame index via `Csv.read`'s `index_col=0`), and `HarpSync.Reader`'s `columns=` names the remaining 3. Updated both fixtures to write the 4-column layout.

## Test results

- Unit suite: **80 passed** (was 78 passed, 2 failed before this branch).
- Ruff clean on all changed files.

## Notes

- Branch is rebased on top of current `es/ephys-guide` (`f18c39a`). Conflict on the codec error message resolved by taking the `"raw-ephys"` wording with the single-line f-string formatting from `f18c39a`.
- Single commit, ready to squash-merge or cherry-pick.