### PR TITLE
Mock DJ for all tests marked "unit"

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,31 +27,66 @@ if "DJ_PORT" not in os.environ:
     os.environ["DJ_PORT"] = "3306"
 
 
-def pytest_configure(config):
-    """Called before test collection begins.
+def _make_mock_dj():
+    from unittest.mock import MagicMock
 
-    For unit tests, mock datajoint to prevent DB connection attempts
-    during import of aeon.dj_pipeline modules.
+    mock_dj = MagicMock()
+    mock_dj.logger = MagicMock()
+    mock_dj.config = MagicMock()
+    mock_dj.config.database.database_prefix = ""
+    mock_dj.VirtualModule = MagicMock()
+    mock_dj.Schema = MagicMock()
+    mock_dj.DataJointError = Exception
+    # Codec must be a real class so subclasses (AeonStreamCodec, OnixStreamCodec)
+    # can be instantiated without turning into MagicMock objects.
+    mock_dj.Codec = type("Codec", (), {})
+    return mock_dj
+
+
+@pytest.fixture(autouse=True)
+def mock_dj_for_unit(request):
+    """Auto-mock datajoint for unit tests.
+
+    This prevents DB connection attempts when importing
+    aeon.dj_pipeline modules in unit tests. Integration tests
+    will use the real DJ with testcontainers MySQL.
     """
-    # Check if we're running unit tests only
-    markers = config.getoption("-m", default="")
+    if not request.node.get_closest_marker("unit"):
+        yield
+        return
 
-    if "unit" in markers:
-        from unittest.mock import MagicMock
+    # Save and evict all datajoint + pipeline modules so the test gets a
+    # fresh import with the mock; not a cached real-DJ module from a prior
+    # integration test in the same session.
+    evict_prefixes = ("datajoint", "aeon.dj_pipeline")
+    saved = {
+        k: v for k, v in sys.modules.items() if any(k == p or k.startswith(p + ".") for p in evict_prefixes)
+    }
+    for k in saved:
+        sys.modules.pop(k)
 
-        # Create a mock datajoint module
-        mock_dj = MagicMock()
-        mock_dj.logger = MagicMock()
-        mock_dj.config = MagicMock()
-        mock_dj.config.database.database_prefix = ""
-        mock_dj.VirtualModule = MagicMock()
-        mock_dj.Schema = MagicMock()
-        mock_dj.DataJointError = Exception
-        # Codec must be a real class so subclasses (AeonStreamCodec, OnixStreamCodec)
-        # can be instantiated without turning into MagicMock objects.
-        mock_dj.Codec = type("Codec", (), {})
+    sys.modules["datajoint"] = _make_mock_dj()
 
-        sys.modules["datajoint"] = mock_dj
+    yield
+
+    # Restore original modules (real DJ for integration tests that follow)
+    for k in list(sys.modules):
+        if any(k == p or k.startswith(p + ".") for p in evict_prefixes):
+            sys.modules.pop(k)
+    sys.modules.update(saved)
+
+    # Clear (or restore) the `dj_pipeline` attribute on the `aeon` package so that
+    # subsequent `import aeon.dj_pipeline as _pipeline` (IMPORT_FROM bytecode) reads
+    # the correct module rather than the stale mock left on the parent package object.
+    aeon_pkg = sys.modules.get("aeon")
+    if aeon_pkg is not None:
+        if "aeon.dj_pipeline" in saved:
+            aeon_pkg.dj_pipeline = saved["aeon.dj_pipeline"]  # type: ignore[attr-defined]
+        else:
+            try:
+                delattr(aeon_pkg, "dj_pipeline")
+            except AttributeError:
+                pass
 
 
 def pytest_collection_modifyitems(items):


### PR DESCRIPTION
The current setup will only mock DataJoint when the tests are run with `-m unit`. 

Running `uv run pytest tests/dj_pipeline/utils/test_stats_unit.py` for instance will result in the following error:
> FAILED tests/dj_pipeline/utils/test_stats_unit.py::TestColumnStats::test_column_stats[numeric array] - pymysql.err.OperationalError: (2003, "Can't connect to MySQL server on 'localhost' ([WinError 10061] No connection could be made because the targ...

Instead of checking for the `-m` marker, this PR adds the `mock_dj_for_unit` fixture that auto-runs on every test. 
For non-unit tests: no-op, yield, done. 
For unit tests:
1. save datajoint and aeon.dj_pipeline from sys.modules (module cache) before removing them
2. mock datajoint so we don't attempt to connect to the DB
3. yield (test runs with mock DJ)
4. during teardown, restore the saved modules (from step 1) to sys.modules["aeon.dj_pipeline"] and any sys.modules["aeon"].dj_pipeline) - this keeps integration tests from seeing the stale mock