### PR TITLE
Redirect DataJoint attach downloads to tmp dir in tests and restrict populate calls to experiment being tested

### DIFF
--- a/tests/dj_pipeline/conftest.py
+++ b/tests/dj_pipeline/conftest.py
@@ -8,11 +8,30 @@ Test commands:
 
 import logging
 import os
+import tempfile
 from pathlib import Path
 
 import pytest
 
 logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(autouse=True)
+def dj_download_to_tmp(request):
+    """Redirect DataJoint attach downloads to a per-test tmpdir.
+
+    DataJoint extracts <attach> columns to `dj.config["download_path"]` (cwd by
+    default). Without this fixture, fetching sync_model rows leaves .joblib files
+    in the repo root. Skipped for unit tests which mock datajoint entirely.
+    """
+    if request.node.get_closest_marker("unit"):
+        yield
+        return
+    import datajoint as dj
+
+    with tempfile.TemporaryDirectory() as tmpdir, dj.config.override(download_path=tmpdir):
+        yield
+
 
 # Single test prefix for ALL integration tests
 TEST_DB_PREFIX = "test_aeon_"

--- a/tests/dj_pipeline/test_full_ingestion.py
+++ b/tests/dj_pipeline/test_full_ingestion.py
@@ -111,7 +111,7 @@ class TestEpochConfigMake:
         acquisition = full_pipeline["acquisition"]
         cfg = golden_dataset_config
 
-        acquisition.EpochConfig.populate()
+        acquisition.EpochConfig.populate({"experiment_name": cfg["experiment_name"]})
 
         assert len(acquisition.EpochConfig & {"experiment_name": cfg["experiment_name"]}) >= 1
 
@@ -122,7 +122,7 @@ class TestEpochConfigMake:
         acquisition = full_pipeline["acquisition"]
         cfg = golden_dataset_config
 
-        acquisition.EpochConfig.populate()
+        acquisition.EpochConfig.populate({"experiment_name": cfg["experiment_name"]})
 
         meta = (acquisition.EpochConfig.Meta & {"experiment_name": cfg["experiment_name"]}).fetch1()
 
@@ -178,7 +178,7 @@ class TestStreamDataIngestion:
         cfg = golden_dataset_config
 
         # Ensure prerequisites
-        acquisition.EpochConfig.populate()
+        acquisition.EpochConfig.populate({"experiment_name": cfg["experiment_name"]})
         acquisition.Chunk.ingest_chunks(cfg["experiment_name"])
 
         # Get all Computed tables in streams module (these are DeviceDataStream tables)
@@ -216,7 +216,7 @@ class TestStreamDataIngestion:
         cfg = golden_dataset_config
 
         # Ensure prerequisites
-        acquisition.EpochConfig.populate()
+        acquisition.EpochConfig.populate({"experiment_name": cfg["experiment_name"]})
         acquisition.Chunk.ingest_chunks(cfg["experiment_name"])
 
         # Find video tables
@@ -250,7 +250,7 @@ class TestStreamDataIngestion:
         cfg = golden_dataset_config
 
         # Ensure prerequisites
-        acquisition.EpochConfig.populate()
+        acquisition.EpochConfig.populate({"experiment_name": cfg["experiment_name"]})
         acquisition.Chunk.ingest_chunks(cfg["experiment_name"])
 
         # Find Harp-based tables (BeamBreak, Encoder, Weight, Pellet, etc.)
@@ -299,7 +299,7 @@ class TestFetchStream:
         streams = full_pipeline["streams"]
         cfg = golden_dataset_config
 
-        acquisition.EpochConfig.populate()
+        acquisition.EpochConfig.populate({"experiment_name": cfg["experiment_name"]})
         acquisition.Chunk.ingest_chunks(cfg["experiment_name"])
 
         # Populate all stream tables
@@ -449,7 +449,7 @@ class TestCodecStreamData:
         streams = full_pipeline["streams"]
         cfg = golden_dataset_config
 
-        acquisition.EpochConfig.populate()
+        acquisition.EpochConfig.populate({"experiment_name": cfg["experiment_name"]})
         acquisition.Chunk.ingest_chunks(cfg["experiment_name"])
 
         for name in dir(streams):

--- a/tests/dj_pipeline/test_onix_imu_pipeline_integration.py
+++ b/tests/dj_pipeline/test_onix_imu_pipeline_integration.py
@@ -57,7 +57,7 @@ def test_ephys_sync_model_ingest_inserts_one_row_per_csv(dj_config_integration, 
 
     ephys.EphysSyncModel.ingest(experiment_name)
 
-    # Project only non-attach columns to avoid triggering attachment extraction to cwd
+    # Project only non-attach columns
     query = (ephys.EphysSyncModel & {"experiment_name": experiment_name}).proj(
         "n_samples", "r2", "onix_ts_start", "onix_ts_end", "sync_start", "sync_end"
     )

--- a/tests/dj_pipeline/test_onix_imu_pipeline_integration.py
+++ b/tests/dj_pipeline/test_onix_imu_pipeline_integration.py
@@ -227,7 +227,7 @@ def test_onix_imu_chunk_populate_with_data(dj_config_integration, tmp_path):
     _register_synthetic_experiment(tmp_path, raw_dir, experiment_name, epoch_dir_name)
 
     ephys.EphysSyncModel.ingest(experiment_name)
-    ephys.OnixImuChunk.populate()
+    ephys.OnixImuChunk.populate({"experiment_name": experiment_name})
 
     rows = (ephys.OnixImuChunk & {"experiment_name": experiment_name}).proj().to_dicts()
     assert len(rows) == 2
@@ -260,7 +260,7 @@ def test_onix_imu_chunk_populate_no_imu_rig(dj_config_integration, tmp_path):
     _register_synthetic_experiment(tmp_path, raw_dir, experiment_name, epoch_dir_name)
 
     ephys.EphysSyncModel.ingest(experiment_name)
-    ephys.OnixImuChunk.populate()
+    ephys.OnixImuChunk.populate({"experiment_name": experiment_name})
 
     full_rows = (
         (ephys.OnixImuChunk & {"experiment_name": experiment_name})
@@ -296,7 +296,7 @@ def test_synced_df_returns_harp_indexed_dataframe(dj_config_integration, tmp_pat
     _register_synthetic_experiment(tmp_path, raw_dir, experiment_name, epoch_dir_name)
 
     ephys.EphysSyncModel.ingest(experiment_name)
-    ephys.OnixImuChunk.populate()
+    ephys.OnixImuChunk.populate({"experiment_name": experiment_name})
 
     key = (ephys.OnixImuChunk & {"experiment_name": experiment_name}).fetch1("KEY")
     df = ephys.OnixImuChunk.synced_df(key)
@@ -326,7 +326,7 @@ def test_synced_df_raises_on_ambiguous_key(dj_config_integration, tmp_path):
     _register_synthetic_experiment(tmp_path, raw_dir, experiment_name, epoch_dir_name)
 
     ephys.EphysSyncModel.ingest(experiment_name)
-    ephys.OnixImuChunk.populate()
+    ephys.OnixImuChunk.populate({"experiment_name": experiment_name})
 
     # Ambiguous key — matches 2 rows
     with pytest.raises(dj.errors.DataJointError):

--- a/tests/dj_pipeline/utils/test_onix_codec_integration.py
+++ b/tests/dj_pipeline/utils/test_onix_codec_integration.py
@@ -32,7 +32,7 @@ def test_round_trip_returns_onix_indexed_dataframe(dj_config_integration, tmp_pa
     _register_synthetic_experiment(tmp_path, raw_dir, experiment_name, epoch_dir_name)
 
     ephys.EphysSyncModel.ingest(experiment_name)
-    ephys.OnixImuChunk.populate()
+    ephys.OnixImuChunk.populate({"experiment_name": experiment_name})
 
     key = (ephys.OnixImuChunk & {"experiment_name": experiment_name}).fetch1("KEY")
     df = (ephys.OnixImuChunk & key).fetch1("stream_df")
@@ -59,7 +59,7 @@ def test_round_trip_no_data_returns_empty_dataframe(dj_config_integration, tmp_p
     _register_synthetic_experiment(tmp_path, raw_dir, experiment_name, epoch_dir_name)
 
     ephys.EphysSyncModel.ingest(experiment_name)
-    ephys.OnixImuChunk.populate()
+    ephys.OnixImuChunk.populate({"experiment_name": experiment_name})
 
     key = (ephys.OnixImuChunk & {"experiment_name": experiment_name}).fetch1("KEY")
     df = (ephys.OnixImuChunk & key).fetch1("stream_df")


### PR DESCRIPTION
When running integration tests for OnixImuChunk, two related issues cause .joblib files to accumulate in cwd:
- OnixImuChunk.make() calls fetch1("sync_model"), which extracts .joblib files to dj.config["download_path"] (default is cwd) and these are never cleaned up after running the test suite
- All populate() calls are unrestricted. Since MySQL container is session-scoped, EphysSyncModel rows inserted by one test are visible to populate() calls in other tests, causing make() to process rows from unrelated experiments (created in other tests). This causes unnecessary attachment extractions from other tests' data.

This PR adds 2 fixes:
- the `dj_download_to_tmp` autouse fixture that overrides dj.config["download_path"], redirecting all attachment extractions to a per-test temporary directory that is cleaned up automatically
- restrict populate() calls to the experiment within the test, to ensure test isolation