### PR TITLE
Fix C1/C3/C4 from PR #564 review: raw-ephys in OnixImuChunk.make + narrow exception + get_probe_id tests

### DIFF
--- a/aeon/dj_pipeline/ephys.py
+++ b/aeon/dj_pipeline/ephys.py
@@ -794,11 +794,11 @@ class OnixImuChunk(dj.Imported):
         onix_ts_start = (EphysSyncModel & key).fetch1("onix_ts_start")
         epoch_dir = (acquisition.Epoch & key).fetch1("epoch_dir")
         raw_dir_result = acquisition.Experiment.get_data_directory(
-            {"experiment_name": key["experiment_name"]}, "raw"
+            {"experiment_name": key["experiment_name"]}, "raw-ephys"
         )
         if raw_dir_result is None:
             raise FileNotFoundError(
-                f"No raw data directory registered for experiment {key['experiment_name']!r}"
+                f"No raw-ephys data directory registered for experiment {key['experiment_name']!r}"
             )
         raw_dir = Path(raw_dir_result)
         epoch_path = raw_dir / epoch_dir

--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -706,8 +706,9 @@ class SortedSpikes(dj.Imported):
                 )
             else:
                 logger.info("Using raw analyzer (no official curation found)")
-        except Exception as e:
-            # If curation module not available or no official curation, use raw analyzer
+        except (dj.errors.DataJointError, ImportError, AttributeError) as e:
+            # Curation module not available, table mis-named, or no official curation — use raw analyzer.
+            # Narrow scope: other exceptions (network, permission, etc.) should propagate.
             logger.info(f"Using raw analyzer (curation check failed: {e})")
 
         sorting_file = output_dir / "spike_sorting" / "si_sorting.pkl"

--- a/tests/dj_pipeline/utils/test_ephys_utils_unit.py
+++ b/tests/dj_pipeline/utils/test_ephys_utils_unit.py
@@ -179,3 +179,83 @@ class TestResolveHarp:
         resolve_harp(sync_row, onix_ts=6000, _model_cache=cache)
 
         assert load_calls["count"] == expected_loads
+
+
+class TestGetProbeId:
+    """Regression tests for get_probe_id — covers bugs 1, 2, 3 from bugs_found.md."""
+
+    def test_v2_extracts_serial_from_windows_path(self):
+        """V2 hardware: parses the Bonsai-written Windows path and returns the serial directory name.
+
+        Covers bug 1 (correct metadata path: Devices.NeuropixelsV2e.ConfigurationA/B) AND
+        bug 3 (PureWindowsPath correctly parses backslash separators on Linux).
+        """
+        from aeon.dj_pipeline.utils.ephys_utils import get_probe_id
+
+        metadata = {
+            "Devices": {
+                "ProbeA": "true",
+                "NeuropixelsV2e": {
+                    "ConfigurationA": {
+                        "GainCalibrationFileName": r"Z:\aeon\code\23299108854\file.csv",
+                    },
+                },
+            },
+        }
+        assert get_probe_id(metadata, "NeuropixelsV2", "ProbeA") == "23299108854"
+
+    def test_v2_returns_none_for_disabled_probe(self):
+        """V2 hardware: Devices.ProbeA = "false" signals a disabled/dummy probe → return None.
+
+        Covers bug 2 (downstream EphysEpoch.make filters None-returning probes).
+        """
+        from aeon.dj_pipeline.utils.ephys_utils import get_probe_id
+
+        metadata = {
+            "Devices": {
+                "ProbeA": "false",
+                "NeuropixelsV2e": {
+                    "ConfigurationA": {
+                        "GainCalibrationFileName": r"Z:\aeon\code\12345678\file.csv",
+                    },
+                },
+            },
+        }
+        assert get_probe_id(metadata, "NeuropixelsV2", "ProbeA") is None
+
+    def test_v2_falls_back_to_default_when_metadata_missing(self):
+        """V2 hardware with metadata=None: fall back to "{device_name}_{probe_label}"."""
+        from aeon.dj_pipeline.utils.ephys_utils import get_probe_id
+
+        assert get_probe_id(None, "NeuropixelsV2", "ProbeA") == "NeuropixelsV2_ProbeA"
+
+    def test_v2_falls_back_to_default_when_calibration_missing(self):
+        """V2 hardware where GainCalibrationFileName is absent: fall back to default ID."""
+        from aeon.dj_pipeline.utils.ephys_utils import get_probe_id
+
+        metadata = {
+            "Devices": {
+                "ProbeA": "true",
+                "NeuropixelsV2e": {
+                    "ConfigurationA": {},  # no GainCalibrationFileName
+                },
+            },
+        }
+        assert get_probe_id(metadata, "NeuropixelsV2", "ProbeA") == "NeuropixelsV2_ProbeA"
+
+    def test_v2beta_uses_default_id(self):
+        """V2Beta hardware has no per-probe serial; always returns the default ID."""
+        from aeon.dj_pipeline.utils.ephys_utils import get_probe_id
+
+        # Even with metadata present, V2Beta path is not exercised — default returned.
+        metadata = {
+            "Devices": {
+                "ProbeA": "true",
+                "NeuropixelsV2e": {
+                    "ConfigurationA": {
+                        "GainCalibrationFileName": r"Z:\aeon\code\99999999\file.csv",
+                    },
+                },
+            },
+        }
+        assert get_probe_id(metadata, "NeuropixelsV2Beta", "ProbeA") == "NeuropixelsV2Beta_ProbeA"


### PR DESCRIPTION
Addresses 3 issues from my [PR #564 review](https://github.com/SainsburyWellcomeCentre/aeon_mecha/pull/564#issuecomment-4451331515) (post-review iteration).

## Changes

**C1 (critical) — `OnixImuChunk.make()` directory_type** (`aeon/dj_pipeline/ephys.py:797`)

Same class as bug 6 (`EphysChunk.File.directory_type` was wrong, fixed earlier). `OnixImuChunk.make` was still using `directory_type="raw"` to locate the device dir while everything else (`EphysChunk.ingest_chunks`, `EphysSyncModel.ingest`, `OnixStreamCodec.decode`) uses `"raw-ephys"`. On split-rig experiments (AEON3 behavior + AEONX1 ephys), `populate()` would fail with `FileNotFoundError` because the AEON3 directory has no NeuropixelsV2 subdirectory. One-line fix: `"raw"` → `"raw-ephys"` (and matching error message).

I missed this when I fixed the codec in #565 — same bug class, parallel call site.

**C3 (important) — Narrow `except Exception` in `SortedSpikes.make_compute`** (`aeon/dj_pipeline/spike_sorting.py:709`)

The applied-curation lookup caught bare `Exception`, silently downgrading any failure (network, permission, attribute error) to "use raw analyzer". Narrowed to `(dj.errors.DataJointError, ImportError, AttributeError)` to match the pattern used by `make_fetch` fallbacks elsewhere in the same file.

**C4 (important) — Unit tests for `get_probe_id`** (`tests/dj_pipeline/utils/test_ephys_utils_unit.py`)

Three of the 14 bugs in `bugs_found.md` (#1 wrong metadata path, #2 disabled-probe detection, #3 Windows path on Linux) lived in `get_probe_id` and had zero unit coverage. Added a `TestGetProbeId` class with 5 regression tests:

- `test_v2_extracts_serial_from_windows_path` — covers bugs #1 and #3 (correct `Devices.NeuropixelsV2e.ConfigurationA/B.GainCalibrationFileName` path + `PureWindowsPath` parsing of backslash separators on Linux)
- `test_v2_returns_none_for_disabled_probe` — covers bug #2 (`Devices.ProbeA = "false"` → None)
- `test_v2_falls_back_to_default_when_metadata_missing` — V2 + `metadata=None` → default ID
- `test_v2_falls_back_to_default_when_calibration_missing` — V2 with no `GainCalibrationFileName` → default ID
- `test_v2beta_uses_default_id` — V2Beta backward compat

## Test results

- Unit: **85 passed** (was 80 on `es/ephys-guide`, +5 new)
- Integration: 68 passed, 3 skipped
- Ruff: no new errors introduced (`spike_sorting.py`'s pre-existing lint debt unchanged)

## Notes

Single commit, single concern per fix. Ready to squash-merge or cherry-pick.