### PR TITLE
Add ephys integration tests and golden baseline

### DIFF
--- a/docs/specs/SPEC_EPHYS_TESTING.md
+++ b/docs/specs/SPEC_EPHYS_TESTING.md
@@ -1,0 +1,272 @@
+# Ephys Pipeline Testing Specification
+
+Testing strategy for the electrophysiology (spike sorting) pipeline, covering epoch discovery through synced spike times.
+
+**Last Updated:** 2026-05-26
+
+---
+
+## Overview
+
+The ephys test suite parallels the existing behavior tests in `test_full_ingestion.py`. It exercises the full ephys ingestion pipeline from epoch discovery through spike time synchronization, using a golden dataset — a reduced 8-channel extract of real NeuropixelsV2 data.
+
+Tests are integration tests that require a database and golden dataset files. They gracefully skip when the data is unavailable.
+
+---
+
+## Golden Dataset
+
+### What it is
+
+An 8-channel subset of a real NeuropixelsV2 ProbeB recording from the `social-ephys0.1-aeon3` experiment, plus pre-computed KS4 sorting output. The reduction from 384 to 8 channels makes the data small enough for fast test runs (~2 min) while still exercising every pipeline stage.
+
+### Contents
+
+| Component | Size | Description |
+|-----------|------|-------------|
+| `AmplifierData_0.bin` | 1,008 MB | 63M samples × 8 channels × uint16 |
+| `Clock_0.bin` | 504 MB | 63M samples × int64 (ONIX timestamps) |
+| `HarpSync_*.csv` (3) | ~KB | ONIX↔HARP clock regression data |
+| `Metadata.yml` | ~KB | Epoch metadata (device config, gains) |
+| `M81_ProbeB_*.json` | ~KB | Probeinterface channel map (remapped to 0-7) |
+| `golden_test_sorting/` | ~50 MB | Pre-computed KS4 output (14 units) |
+
+**Source recording:** `social-ephys0.1-aeon3`, epoch `2026-05-11T07-50-11`, subject `IAA-1147881`, electrodes 3982–3989 on shank 3. Duration: 35 minutes continuous.
+
+**Sorting details:** Kilosort4 with modified parameters for small channel count (`nblocks=0`, `Th_universal=8`, `Th_learned=7`). Produced 14 units (7 good, 7 MUA), 357,480 total spikes.
+
+### Storage locations
+
+**Source of truth (Ceph on HPC):**
+```
+/ceph/aeon/aeon/data/golden_tests/AEONX1/abcGolden01/
+├── 2026-05-11T07-50-11/          # epoch data
+│   ├── Metadata.yml
+│   ├── M81_ProbeB_4Shanks_1000_to_1700_um.json
+│   └── NeuropixelsV2/
+│       ├── NeuropixelsV2_ProbeB_AmplifierData_0.bin
+│       ├── NeuropixelsV2_ProbeB_Clock_0.bin
+│       └── NeuropixelsV2_HarpSync_*.csv (3 files)
+└── golden_test_sorting/          # pre-computed KS4 output
+    ├── recording/recording.dat
+    └── sorting_output/
+        ├── si_sorting.pkl
+        ├── in_container_sorting/
+        └── sorter_output/
+```
+
+**Local test copy (per-user):**
+```
+~/sciops-data/project_aeon/aeon/data/raw/AEONX1/abcGolden01/
+```
+
+Note: the local path uses `raw/` while Ceph uses `golden_tests/`. This is because the test code expects data under `DEFAULT_GOLDEN_DATA_ROOT / "raw"`, and the golden data is a modified extract (not production data) so it lives in a separate Ceph directory.
+
+---
+
+## Setup Instructions
+
+### 1. Get the golden data
+
+From the HPC (or any machine with Ceph access), rsync the golden dataset to your local home directory:
+
+```bash
+mkdir -p ~/sciops-data/project_aeon/aeon/data/raw/AEONX1/abcGolden01
+rsync -avP /ceph/aeon/aeon/data/golden_tests/AEONX1/abcGolden01/ \
+    ~/sciops-data/project_aeon/aeon/data/raw/AEONX1/abcGolden01/
+```
+
+If running from outside the HPC (e.g., your local machine):
+```bash
+rsync -avP aeon-hpc:/ceph/aeon/aeon/data/golden_tests/AEONX1/abcGolden01/ \
+    ~/sciops-data/project_aeon/aeon/data/raw/AEONX1/abcGolden01/
+```
+
+### 2. Clone the branch
+
+```bash
+git clone -b es/ephys-tests https://github.com/SainsburyWellcomeCentre/aeon_mecha.git aeon_mecha_ephys-tests
+cd aeon_mecha_ephys-tests
+```
+
+### 3. Install dependencies
+
+```bash
+module load uv
+uv sync --all-extras
+```
+
+### 4. Database configuration
+
+The tests need access to a DataJoint-compatible database. Set the `TEST_DB_PREFIX` environment variable to use an existing database connection (via `datajoint.json` + `.secrets/`):
+
+```bash
+export TEST_DB_PREFIX=u_<username>_golden_tests_
+```
+
+This creates test schemas prefixed with that string (e.g., `u_thinh_golden_tests_ephys`). Schemas are dropped automatically after the test session.
+
+If `TEST_DB_PREFIX` is not set, the tests attempt to use testcontainers (Docker-based ephemeral MySQL). This works locally but not on HPC where Docker is unavailable.
+
+**DataJoint config files:** If your clone doesn't have `datajoint.json` and `.secrets/`, symlink from an existing working directory:
+
+```bash
+ln -s ~/ProjectAeon/foragingABC_analysis/datajoint.json .
+ln -s ~/ProjectAeon/foragingABC_analysis/.secrets .
+```
+
+### 5. Run tests
+
+```bash
+# Get onto a compute node (Ceph is not visible from the gateway)
+srun --cpus-per-task=2 --mem=8G --time=2:00:00 --pty bash
+
+cd ~/ProjectAeon/aeon_mecha_ephys-tests
+export TEST_DB_PREFIX=u_<username>_golden_tests_
+module load uv
+
+# Run all ephys integration tests
+uv run pytest -m integration tests/dj_pipeline/test_ephys_ingestion.py -v --tb=short
+
+# Run a single test class
+uv run pytest -m integration tests/dj_pipeline/test_ephys_ingestion.py::TestPreProcessing -v --tb=short
+```
+
+Tests take approximately 2 minutes for the full suite.
+
+---
+
+## Test Coverage
+
+### Pipeline stages tested
+
+The tests follow the ephys pipeline cascade in order. Each stage depends on the previous.
+
+| Test Class | Pipeline Stage | What it verifies |
+|------------|---------------|------------------|
+| `TestEphysEpochDiscovery` | EphysEpoch, ProbeInsertion | Epoch creation, probe discovery, subject linking |
+| `TestEphysChunkIngestion` | EphysChunk | Chunk file registration, timestamp validity |
+| `TestEphysBlockInfo` | EphysBlockInfo | Block timing, chunk association, channel mappings |
+| `TestPreProcessing` | PreProcessing | Binary recording creation, file registration |
+| `TestPostProcessing` | PostProcessing | Sorting analyzer creation from golden KS4 output |
+| `TestSortedSpikes` | SortedSpikes | Unit extraction, spike counts, quality labels |
+| `TestSyncedSpikes` | SyncedSpikes | ONIX→HARP timestamp synchronization |
+
+### Test list (25 tests)
+
+**TestEphysEpochDiscovery** (6 tests):
+- Epoch entry exists in DB
+- `has_ephys` flag is set
+- Correct number of probes discovered (1 — ProbeB only)
+- ProbeInsertion entries created
+- ProbeInsertion links to correct subject
+- `discover_epoch_probes()` returns expected probe labels
+
+**TestEphysChunkIngestion** (3 tests):
+- Chunks ingested for the experiment
+- Chunk timestamps are valid datetimes
+- Chunk files registered in DB
+
+**TestEphysBlockInfo** (4 tests):
+- Block info populated
+- Block duration matches expected value
+- Block-chunk associations exist
+- Channel mappings created (8 channels)
+
+**TestPreProcessing** (3 tests):
+- PreProcessing entry populated (runs `write_binary_recording`)
+- Recording files registered in DB
+- `recording.dat` binary file exists on disk
+
+**TestPostProcessing** (2 tests):
+- PostProcessing entry populated (runs quality metrics)
+- Sorting analyzer artifact created
+
+**TestSortedSpikes** (4 tests):
+- Sorted spikes populated
+- Unit count matches expected (14 units)
+- Spike counts are reasonable (> 0 for each unit)
+- Quality labels assigned (good/mua/noise)
+
+**TestSyncedSpikes** (3 tests):
+- Synced spikes populated
+- Spike times have datetime64 dtype (confirms sync model ran)
+- All spike times fall within the sync model's calibrated HARP time range
+
+### How SpikeSorting is handled
+
+The tests do NOT run Kilosort4 (requires GPU + Singularity container). Instead, the `ephys_sorting_injected` fixture:
+
+1. Runs PreProcessing.populate() normally (creates `recording.dat`)
+2. Copies the pre-computed golden sorting output into the pipeline's expected directory
+3. Force-inserts a SpikeSorting entry with `allow_direct_insert=True`
+4. PostProcessing, SortedSpikes, and SyncedSpikes then populate normally through the real pipeline code
+
+---
+
+## Key Design Decisions
+
+### External DB support (`TEST_DB_PREFIX`)
+
+HPC has no Docker, so testcontainers can't run there. When `TEST_DB_PREFIX` is set, the tests use the host's `datajoint.json` configuration and prefix all schema names with the given string. This isolates test schemas from production data.
+
+### Golden data is modified, not production
+
+Unlike the behavior golden dataset (which is unmodified production data rsynced directly from `/ceph/aeon/aeon/data/raw/`), the ephys golden dataset is a modified extract:
+
+- 8 channels extracted from 384 (reduces data from ~50 GB to ~1.5 GB)
+- Probeinterface JSON `device_channel_indices` remapped from 384-channel positions to 0-7
+- ProbeA stub files removed (only ProbeB retained)
+
+This is why it lives in `/ceph/aeon/aeon/data/golden_tests/` rather than `/ceph/aeon/aeon/data/raw/`.
+
+### No `specialized` test tier
+
+All ephys tests are marked `integration`. The `specialized` tier (for GPU-dependent tests) was considered but deferred — KS4 sorting is injected from pre-computed output rather than run live.
+
+---
+
+## File Structure
+
+```
+tests/
+├── conftest.py                              # Root: testcontainers, markers, TEST_DB_PREFIX
+├── dj_pipeline/
+│   ├── conftest.py                          # Golden dataset registry + ephys fixtures
+│   ├── test_ephys_ingestion.py              # Ephys integration tests (25 tests)
+│   ├── test_full_ingestion.py               # Behavior integration tests (existing)
+│   └── utils/
+│       └── test_ephys_utils_unit.py         # Ephys utility unit tests
+└── fixtures/
+    └── ephys/
+        └── probe_assignments/               # Test fixture for read_probe_assignments()
+```
+
+---
+
+## Troubleshooting
+
+**Tests skip with "Golden data root not found":**
+Run the rsync command from the setup instructions. The tests expect data at `~/sciops-data/project_aeon/aeon/data/raw/AEONX1/abcGolden01/`.
+
+**Tests skip with "Golden sorting output not found":**
+Make sure you rsynced the full `golden_tests/` directory, including `golden_test_sorting/`.
+
+**"Cannot touch /ceph/..." or Ceph not visible:**
+You're on the gateway (`hpc-gw2`). Ceph is only accessible from compute nodes. Use `srun` to get onto one first.
+
+**Schema drop warnings in teardown:**
+The teardown drops schemas in arbitrary order, which can hit foreign key constraints. These warnings are cosmetic — the schemas get cleaned up on the next test run.
+
+**Stale test schemas from a crashed run:**
+If a previous run crashed without cleanup, manually drop the schemas:
+```bash
+.venv/bin/python << 'EOF'
+import datajoint as dj
+dj.config.safemode = False
+for s in dj.list_schemas():
+    if s.startswith('u_<username>_golden_tests_'):
+        print(f'Dropping {s}')
+        dj.Schema(s).drop()
+EOF
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,16 +15,18 @@ import pytest
 
 logger = logging.getLogger(__name__)
 
-# Set default DataJoint connection env vars (for imports to work)
-# These will be overridden by mysql_container fixture for integration tests
-if "DJ_HOST" not in os.environ:
-    os.environ["DJ_HOST"] = "localhost"
-if "DJ_USER" not in os.environ:
-    os.environ["DJ_USER"] = "root"
-if "DJ_PASS" not in os.environ:
-    os.environ["DJ_PASS"] = "test_password"
-if "DJ_PORT" not in os.environ:
-    os.environ["DJ_PORT"] = "3306"
+# Set default DataJoint connection env vars for testcontainers mode.
+# Skipped when TEST_DB_PREFIX is set (external DB — credentials come from
+# datajoint.json + .secrets/).
+if not os.environ.get("TEST_DB_PREFIX"):
+    if "DJ_HOST" not in os.environ:
+        os.environ["DJ_HOST"] = "localhost"
+    if "DJ_USER" not in os.environ:
+        os.environ["DJ_USER"] = "root"
+    if "DJ_PASS" not in os.environ:
+        os.environ["DJ_PASS"] = "test_password"
+    if "DJ_PORT" not in os.environ:
+        os.environ["DJ_PORT"] = "3306"
 
 
 def _make_mock_dj():
@@ -99,20 +101,38 @@ def pytest_collection_modifyitems(items):
 
 @pytest.fixture(scope="session")
 def mysql_container():
-    """Auto-provision MySQL via testcontainers.
+    """Provide a MySQL backend for integration tests.
 
-    Session-scoped to share container across all integration tests.
-    Container is automatically cleaned up when session ends.
+    When TEST_DB_PREFIX is set in the environment, uses the pre-configured
+    external DB (connection details from datajoint.json + .secrets/).
+    Otherwise, auto-provisions a MySQL 8.0 container via testcontainers.
     """
-    from testcontainers.mysql import MySqlContainer
+    if os.environ.get("TEST_DB_PREFIX"):
+        logger.info(
+            f"Using external DB with prefix {os.environ['TEST_DB_PREFIX']}"
+        )
+        yield None
+        return
 
-    container = MySqlContainer(
-        image="mysql:8.0",
-        username="root",
-        password="test_password",
-        dbname="test_db",
-    )
-    container.start()
+    try:
+        from testcontainers.mysql import MySqlContainer
+
+        container = MySqlContainer(
+            image="mysql:8.0",
+            username="root",
+            password="test_password",
+            dbname="test_db",
+        )
+        container.start()
+    except Exception as e:
+        pytest.exit(
+            f"Could not start MySQL container: {e}\n\n"
+            "If Docker is not available (e.g. on HPC), set TEST_DB_PREFIX to\n"
+            "use an external database with your datajoint.json credentials:\n\n"
+            "    export TEST_DB_PREFIX=u_<username>_golden_tests_\n"
+            "    pytest -m integration tests/dj_pipeline/ -v\n",
+            returncode=1,
+        )
 
     # Update environment variables with container details
     host = container.get_container_host_ip()

--- a/tests/dj_pipeline/conftest.py
+++ b/tests/dj_pipeline/conftest.py
@@ -631,6 +631,9 @@ def ephys_test_epochs(
     finally:
         ephys.EphysEpoch.probe_assignments_override_dir = None
 
+    # Ingest sync models from HarpSync CSVs — required before EphysChunk.ingest_chunks()
+    ephys.EphysSyncModel.ingest(exp_name)
+
     return (acquisition.Epoch & {"experiment_name": exp_name}).to_dicts()
 
 

--- a/tests/dj_pipeline/conftest.py
+++ b/tests/dj_pipeline/conftest.py
@@ -33,8 +33,9 @@ def dj_download_to_tmp(request):
         yield
 
 
-# Single test prefix for ALL integration tests
-TEST_DB_PREFIX = "test_aeon_"
+# Single test prefix for ALL integration tests.
+# Override via env var on systems where the DB user can only create specific prefixes.
+TEST_DB_PREFIX = os.environ.get("TEST_DB_PREFIX", "test_aeon_")
 
 # ============================================================================
 # Golden Dataset Registry
@@ -107,11 +108,15 @@ def dj_config_integration(mysql_container):
 
     # Set config BEFORE any pipeline imports
     dj.config.safemode = False
-    dj.config.database.host = os.environ.get("DJ_HOST", "localhost")
-    dj.config.database.port = int(os.environ.get("DJ_PORT", "3306"))
-    dj.config.database.user = os.environ.get("DJ_USER", "root")
-    dj.config.database.password = os.environ.get("DJ_PASS", "test_password")
     dj.config.database.database_prefix = TEST_DB_PREFIX
+
+    if mysql_container is not None:
+        # Testcontainers: use the container's connection details
+        dj.config.database.host = os.environ["DJ_HOST"]
+        dj.config.database.port = int(os.environ["DJ_PORT"])
+        dj.config.database.user = os.environ["DJ_USER"]
+        dj.config.database.password = os.environ["DJ_PASS"]
+    # External DB: connection details already loaded from datajoint.json
 
     # Now import pipeline — all module-level schema activations use test prefix
 

--- a/tests/dj_pipeline/conftest.py
+++ b/tests/dj_pipeline/conftest.py
@@ -90,6 +90,56 @@ DEFAULT_GOLDEN_DATA_ROOT = Path.home() / "sciops-data/project_aeon/aeon/data"
 # (which mock datajoint) to run without triggering DB connections
 
 
+def _check_golden_data(dataset_config: dict) -> Path:
+    """Validate golden dataset files are present; call pytest.skip if not.
+
+    Returns the epoch path on success.
+    """
+    import aeon.dj_pipeline as pipeline
+
+    if "DJ_REPOSITORY_CONFIG" not in os.environ:
+        pipeline.repository_config = {"ceph_aeon": str(DEFAULT_GOLDEN_DATA_ROOT)}
+
+    if not Path(pipeline.repository_config["ceph_aeon"]).exists():
+        pytest.skip(f"Golden data root not found: {pipeline.repository_config['ceph_aeon']}")
+
+    from aeon.dj_pipeline.utils.paths import get_repository_path
+
+    repo_path = get_repository_path("ceph_aeon")
+    epoch_path = repo_path / "raw" / dataset_config["experiment_path"] / dataset_config["epoch_dir"]
+
+    if not epoch_path.exists():
+        pytest.skip(f"Golden dataset not found: {epoch_path}")
+
+    for f in dataset_config["required_files"]:
+        if not (epoch_path / f).exists():
+            pytest.skip(f"Missing required file: {f}")
+
+    return epoch_path
+
+
+def _drop_test_schemas() -> None:
+    """Drop all test-prefixed schemas, retrying to handle FK dependencies."""
+    import datajoint as dj
+
+    prefix = dj.config.database.database_prefix
+    schemas_to_drop = [s for s in dj.list_schemas() if s.startswith(prefix)]
+    max_attempts = len(schemas_to_drop) + 1
+    for _ in range(max_attempts):
+        if not schemas_to_drop:
+            break
+        remaining = []
+        for schema_name in schemas_to_drop:
+            try:
+                dj.Schema(schema_name).drop()
+            except Exception as e:
+                logger.warning(f"Failed to drop schema {schema_name}: {e}")
+                remaining.append(schema_name)
+        schemas_to_drop = remaining
+    if schemas_to_drop:
+        logger.error(f"Could not drop schemas after {max_attempts} attempts: {schemas_to_drop}")
+
+
 # ============================================================================
 # Integration Test Fixtures (testcontainers MySQL)
 # ============================================================================
@@ -229,30 +279,7 @@ def golden_dataset_config():
 @pytest.fixture(scope="session")
 def require_golden_data(dj_config_integration, golden_dataset_config):
     """Skip tests if golden dataset is unavailable. Returns epoch path."""
-    import aeon.dj_pipeline as pipeline
-
-    # If DJ_REPOSITORY_CONFIG env var is not set, use default golden data root
-    if "DJ_REPOSITORY_CONFIG" not in os.environ:
-        pipeline.repository_config = {"ceph_aeon": str(DEFAULT_GOLDEN_DATA_ROOT)}
-
-    if not Path(pipeline.repository_config["ceph_aeon"]).exists():
-        pytest.skip(f"Golden data root not found: {pipeline.repository_config['ceph_aeon']}")
-
-    from aeon.dj_pipeline.utils.paths import get_repository_path
-
-    repo_path = get_repository_path("ceph_aeon")
-    epoch_path = (
-        repo_path / "raw" / golden_dataset_config["experiment_path"] / golden_dataset_config["epoch_dir"]
-    )
-
-    if not epoch_path.exists():
-        pytest.skip(f"Golden dataset not found: {epoch_path}")
-
-    for f in golden_dataset_config["required_files"]:
-        if not (epoch_path / f).exists():
-            pytest.skip(f"Missing required file: {f}")
-
-    return epoch_path
+    return _check_golden_data(golden_dataset_config)
 
 
 @pytest.fixture(scope="session")
@@ -271,7 +298,6 @@ def full_pipeline(dj_config_integration, streams_schema, golden_dataset_config):
     3. Tests can then call EpochConfig.make() for DML
     """
     pytest.importorskip("swc.aeon_exp", reason="requires swc.aeon_exp package")
-    import datajoint as dj
 
     from aeon.dj_pipeline import acquisition, lab, subject
     from aeon.dj_pipeline.utils import streams_maker
@@ -294,23 +320,7 @@ def full_pipeline(dj_config_integration, streams_schema, golden_dataset_config):
     }
 
     # Teardown - drop all test schemas
-    prefix = dj.config.database.database_prefix
-    schemas_to_drop = [s for s in dj.list_schemas() if s.startswith(prefix)]
-    # Try multiple passes to handle foreign key dependencies
-    max_attempts = len(schemas_to_drop) + 1
-    for _ in range(max_attempts):
-        if not schemas_to_drop:
-            break
-        remaining = []
-        for schema_name in schemas_to_drop:
-            try:
-                dj.Schema(schema_name).drop()
-            except Exception as e:
-                logger.warning(f"Failed to drop schema {schema_name}: {e}")
-                remaining.append(schema_name)
-        schemas_to_drop = remaining
-    if schemas_to_drop:
-        logger.error(f"Could not drop schemas after {max_attempts} attempts: {schemas_to_drop}")
+    _drop_test_schemas()
 
 
 @pytest.fixture(scope="session")
@@ -408,30 +418,7 @@ def ephys_golden_dataset_config():
 @pytest.fixture(scope="session")
 def require_ephys_golden_data(dj_config_integration, ephys_golden_dataset_config):
     """Skip tests if ephys golden dataset is unavailable. Returns epoch path."""
-    import aeon.dj_pipeline as pipeline
-
-    if "DJ_REPOSITORY_CONFIG" not in os.environ:
-        pipeline.repository_config = {"ceph_aeon": str(DEFAULT_GOLDEN_DATA_ROOT)}
-
-    if not Path(pipeline.repository_config["ceph_aeon"]).exists():
-        pytest.skip(
-            f"Golden data root not found: {pipeline.repository_config['ceph_aeon']}"
-        )
-
-    from aeon.dj_pipeline.utils.paths import get_repository_path
-
-    repo_path = get_repository_path("ceph_aeon")
-    cfg = ephys_golden_dataset_config
-    epoch_path = repo_path / "raw" / cfg["experiment_path"] / cfg["epoch_dir"]
-
-    if not epoch_path.exists():
-        pytest.skip(f"Ephys golden dataset not found: {epoch_path}")
-
-    for f in cfg["required_files"]:
-        if not (epoch_path / f).exists():
-            pytest.skip(f"Missing required ephys file: {f}")
-
-    return epoch_path
+    return _check_golden_data(ephys_golden_dataset_config)
 
 
 @pytest.fixture(scope="session")
@@ -450,13 +437,9 @@ def ephys_full_pipeline(dj_config_integration, tmp_path_factory):
 
     sorting_root = tmp_path_factory.mktemp("sorting_root")
 
-    from aeon.dj_pipeline import acquisition, lab, subject
-    from aeon.dj_pipeline import ephys
-    from aeon.dj_pipeline import spike_sorting
-    from aeon.dj_pipeline import spike_sorting_curation
-
     # Patch get_sorting_root_dir to return our temp directory
     import aeon.dj_pipeline.spike_sorting as ss_module
+    from aeon.dj_pipeline import acquisition, ephys, lab, spike_sorting, spike_sorting_curation, subject
 
     _original_get_sorting_root = ss_module.get_sorting_root_dir
     ss_module.get_sorting_root_dir = lambda: sorting_root
@@ -485,10 +468,7 @@ def ephys_full_pipeline(dj_config_integration, tmp_path_factory):
         skip_duplicates=True,
     )
     ephys.ElectrodeConfig.Electrode.insert(
-        (
-            {**electrode_config_key, "electrode": e}
-            for e in golden_electrodes
-        ),
+        ({**electrode_config_key, "electrode": e} for e in golden_electrodes),
         skip_duplicates=True,
     )
 
@@ -505,21 +485,7 @@ def ephys_full_pipeline(dj_config_integration, tmp_path_factory):
 
     # Teardown
     ss_module.get_sorting_root_dir = _original_get_sorting_root
-
-    prefix = dj.config.database.database_prefix
-    schemas_to_drop = [s for s in dj.list_schemas() if s.startswith(prefix)]
-    max_attempts = len(schemas_to_drop) + 1
-    for _ in range(max_attempts):
-        if not schemas_to_drop:
-            break
-        remaining = []
-        for schema_name in schemas_to_drop:
-            try:
-                dj.Schema(schema_name).drop()
-            except Exception as e:
-                logger.warning(f"Failed to drop schema {schema_name}: {e}")
-                remaining.append(schema_name)
-        schemas_to_drop = remaining
+    _drop_test_schemas()
 
 
 @pytest.fixture(scope="session")
@@ -578,8 +544,11 @@ def ephys_test_experiment(ephys_full_pipeline, require_ephys_golden_data, ephys_
 
 @pytest.fixture(scope="session")
 def ephys_test_epochs(
-    ephys_test_experiment, ephys_full_pipeline, ephys_golden_dataset_config,
-    require_ephys_golden_data, tmp_path_factory,
+    ephys_test_experiment,
+    ephys_full_pipeline,
+    ephys_golden_dataset_config,
+    require_ephys_golden_data,
+    tmp_path_factory,
 ):
     """Insert epoch and populate EphysEpoch using the real pipeline code.
 
@@ -765,7 +734,7 @@ def ephys_sorting_injected(
     (PostProcessing, SortedSpikes, SyncedSpikes) can then populate normally.
     """
     import shutil
-    from datetime import datetime, UTC
+    from datetime import UTC, datetime
 
     spike_sorting = ephys_full_pipeline["spike_sorting"]
     ephys = ephys_full_pipeline["ephys"]
@@ -777,9 +746,7 @@ def ephys_sorting_injected(
     spike_sorting.PreProcessing.populate(display_progress=True, suppress_errors=False)
 
     # Find the output_dir that PreProcessing created
-    sorting_task_keys = (
-        spike_sorting.SortingTask & {"experiment_name": cfg["experiment_name"]}
-    ).to_dicts()
+    sorting_task_keys = (spike_sorting.SortingTask & {"experiment_name": cfg["experiment_name"]}).to_dicts()
     assert len(sorting_task_keys) >= 1, "No SortingTask entries found"
 
     key = sorting_task_keys[0]
@@ -802,9 +769,7 @@ def ephys_sorting_injected(
 
     si_native_dir = test_sorting_dir / "in_container_sorting"
     sorting = si.load(si_native_dir)
-    sorting.dump_to_pickle(
-        test_sorting_dir / "si_sorting.pkl", relative_to=output_dir
-    )
+    sorting.dump_to_pickle(test_sorting_dir / "si_sorting.pkl", relative_to=output_dir)
 
     # Force-inject SpikeSorting entry
     if not (spike_sorting.SpikeSorting & key):

--- a/tests/dj_pipeline/conftest.py
+++ b/tests/dj_pipeline/conftest.py
@@ -58,7 +58,28 @@ GOLDEN_DATASETS = {
         "expected_camera_count": 13,
         "expected_feeder_count": 6,
     },
-    # Future datasets can be added here
+    # Ephys golden dataset — 8-channel subset of abcGolden01 (NeuropixelsV2 ProbeB)
+    # Electrodes 3982-3989 on shank3, 35 min continuous recording
+    "foraging_abc_ephys_2026_05_11": {
+        "experiment_name": "abcGolden01-aeonx1",
+        "experiment_path": "AEONX1/abcGolden01",
+        "epoch_dir": "2026-05-11T07-50-11",
+        "subject": "IAA-1147881",
+        "device_name": "NeuropixelsV2",
+        "probe_type": "neuropixels2.0",
+        "probe_serial": "23299108854",
+        "n_channels": 8,
+        "electrodes": list(range(3982, 3990)),
+        "required_files": [
+            "Metadata.yml",
+            "NeuropixelsV2/NeuropixelsV2_ProbeB_AmplifierData_0.bin",
+            "NeuropixelsV2/NeuropixelsV2_ProbeB_Clock_0.bin",
+        ],
+        "expected_probe_count": 1,  # ProbeB only; ProbeA is disabled/spoofed
+        "golden_sorting_dir": "golden_test_sorting",
+        "expected_unit_count": 14,
+        "expected_total_spikes": 357_480,
+    },
 }
 
 # Default golden data root (can be overridden via DJ_REPOSITORY_CONFIG env var)
@@ -366,3 +387,429 @@ def test_epochs(test_experiment, full_pipeline, golden_dataset_config):
     # Return list of ingested epoch keys
     epochs = (acquisition.Epoch & {"experiment_name": cfg["experiment_name"]}).keys()
     return epochs
+
+
+# ============================================================================
+# Ephys Golden Dataset Fixtures
+# ============================================================================
+
+
+@pytest.fixture(scope="session")
+def ephys_golden_dataset_config():
+    """Get the ephys golden dataset configuration. No DB needed."""
+    return GOLDEN_DATASETS["foraging_abc_ephys_2026_05_11"]
+
+
+@pytest.fixture(scope="session")
+def require_ephys_golden_data(dj_config_integration, ephys_golden_dataset_config):
+    """Skip tests if ephys golden dataset is unavailable. Returns epoch path."""
+    import aeon.dj_pipeline as pipeline
+
+    if "DJ_REPOSITORY_CONFIG" not in os.environ:
+        pipeline.repository_config = {"ceph_aeon": str(DEFAULT_GOLDEN_DATA_ROOT)}
+
+    if not Path(pipeline.repository_config["ceph_aeon"]).exists():
+        pytest.skip(
+            f"Golden data root not found: {pipeline.repository_config['ceph_aeon']}"
+        )
+
+    from aeon.dj_pipeline.utils.paths import get_repository_path
+
+    repo_path = get_repository_path("ceph_aeon")
+    cfg = ephys_golden_dataset_config
+    epoch_path = repo_path / "raw" / cfg["experiment_path"] / cfg["epoch_dir"]
+
+    if not epoch_path.exists():
+        pytest.skip(f"Ephys golden dataset not found: {epoch_path}")
+
+    for f in cfg["required_files"]:
+        if not (epoch_path / f).exists():
+            pytest.skip(f"Missing required ephys file: {f}")
+
+    return epoch_path
+
+
+@pytest.fixture(scope="session")
+def ephys_full_pipeline(dj_config_integration, tmp_path_factory):
+    """Full ephys pipeline setup: imports modules, configures stores, creates probe types."""
+    import datajoint as dj
+
+    store_dir = tmp_path_factory.mktemp("dj_store")
+    dj.config.stores = {
+        "dj_store": {
+            "protocol": "file",
+            "location": str(store_dir),
+            "stage": str(store_dir),
+        },
+    }
+
+    sorting_root = tmp_path_factory.mktemp("sorting_root")
+
+    from aeon.dj_pipeline import acquisition, lab, subject
+    from aeon.dj_pipeline import ephys
+    from aeon.dj_pipeline import spike_sorting
+    from aeon.dj_pipeline import spike_sorting_curation
+
+    # Patch get_sorting_root_dir to return our temp directory
+    import aeon.dj_pipeline.spike_sorting as ss_module
+
+    _original_get_sorting_root = ss_module.get_sorting_root_dir
+    ss_module.get_sorting_root_dir = lambda: sorting_root
+
+    # Create ProbeType with electrode geometry via probeinterface
+    ephys.create_probe_type(
+        probe_type="neuropixels2.0",
+        manufacturer="imec",
+        probe_name="NP2014",
+    )
+
+    # Create ElectrodeConfig for golden dataset's 8 electrodes (3982-3989)
+    import uuid
+
+    golden_electrodes = list(range(3982, 3990))
+    electrode_config_key = {
+        "probe_type": "neuropixels2.0",
+        "electrode_config_name": "3982-3989",
+    }
+    ephys.ElectrodeConfig.insert1(
+        {
+            **electrode_config_key,
+            "electrode_config_description": "8 electrodes on shank3 (golden dataset)",
+            "electrode_config_hash": uuid.uuid4(),
+        },
+        skip_duplicates=True,
+    )
+    ephys.ElectrodeConfig.Electrode.insert(
+        (
+            {**electrode_config_key, "electrode": e}
+            for e in golden_electrodes
+        ),
+        skip_duplicates=True,
+    )
+
+    yield {
+        "lab": lab,
+        "subject": subject,
+        "acquisition": acquisition,
+        "ephys": ephys,
+        "spike_sorting": spike_sorting,
+        "spike_sorting_curation": spike_sorting_curation,
+        "store_dir": store_dir,
+        "sorting_root": sorting_root,
+    }
+
+    # Teardown
+    ss_module.get_sorting_root_dir = _original_get_sorting_root
+
+    prefix = dj.config.database.database_prefix
+    schemas_to_drop = [s for s in dj.list_schemas() if s.startswith(prefix)]
+    max_attempts = len(schemas_to_drop) + 1
+    for _ in range(max_attempts):
+        if not schemas_to_drop:
+            break
+        remaining = []
+        for schema_name in schemas_to_drop:
+            try:
+                dj.Schema(schema_name).drop()
+            except Exception as e:
+                logger.warning(f"Failed to drop schema {schema_name}: {e}")
+                remaining.append(schema_name)
+        schemas_to_drop = remaining
+
+
+@pytest.fixture(scope="session")
+def ephys_test_experiment(ephys_full_pipeline, require_ephys_golden_data, ephys_golden_dataset_config):
+    """Create experiment, subject, and directory for ephys golden dataset."""
+    from aeon.dj_pipeline import subject as subject_module
+
+    acquisition = ephys_full_pipeline["acquisition"]
+    cfg = ephys_golden_dataset_config
+
+    subject_module.Subject.insert1(
+        {
+            "subject": cfg["subject"],
+            "sex": "U",
+            "subject_birth_date": "2024-01-01",
+            "subject_description": "Golden dataset subject for ephys tests",
+        },
+        skip_duplicates=True,
+    )
+
+    from aeon.dj_pipeline.utils.time_utils import parse_epoch_timestamp
+
+    epoch_dt = parse_epoch_timestamp(cfg["epoch_dir"])
+
+    acquisition.Experiment.insert1(
+        {
+            "experiment_name": cfg["experiment_name"],
+            "experiment_start_time": epoch_dt,
+            "experiment_description": "Ephys golden dataset test",
+            "arena_name": "circle-2m",
+            "lab": "SWC",
+            "location": "AEON3",
+            "experiment_type": "foraging",
+        },
+        skip_duplicates=True,
+    )
+
+    acquisition.Experiment.Subject.insert1(
+        {"experiment_name": cfg["experiment_name"], "subject": cfg["subject"]},
+        skip_duplicates=True,
+    )
+
+    # Split raw: "raw-ephys" for AEONX1 ephys data
+    acquisition.Experiment.Directory.insert1(
+        {
+            "experiment_name": cfg["experiment_name"],
+            "directory_type": "raw-ephys",
+            "repository_name": "ceph_aeon",
+            "directory_path": f"raw/{cfg['experiment_path']}",
+        },
+        skip_duplicates=True,
+    )
+
+    return {"experiment_name": cfg["experiment_name"], "epoch_start": epoch_dt}
+
+
+@pytest.fixture(scope="session")
+def ephys_test_epochs(
+    ephys_test_experiment, ephys_full_pipeline, ephys_golden_dataset_config,
+    require_ephys_golden_data, tmp_path_factory,
+):
+    """Ingest epochs and populate EphysEpoch using the real pipeline code.
+
+    Creates a probe_assignments.json in a temp dir and sets
+    EphysEpoch.probe_assignments_override_dir so that populate() can
+    read the subject-probe mapping without the file existing on Ceph.
+    """
+    import json
+
+    acquisition = ephys_full_pipeline["acquisition"]
+    ephys = ephys_full_pipeline["ephys"]
+    cfg = ephys_golden_dataset_config
+    exp_name = cfg["experiment_name"]
+
+    # Discover epochs from filesystem
+    acquisition.Epoch.ingest_epochs(exp_name)
+
+    epochs = (acquisition.Epoch & {"experiment_name": exp_name}).to_dicts()
+    assert len(epochs) >= 1, f"No epochs discovered for {exp_name}"
+
+    # Write probe_assignments.json to temp dir for EphysEpoch.populate()
+    override_dir = tmp_path_factory.mktemp("probe_assignments")
+    assignments = {
+        "version": 1,
+        "probe_assignments": {
+            cfg["probe_serial"]: {"subject": cfg["subject"]},
+        },
+    }
+    (override_dir / "probe_assignments.json").write_text(json.dumps(assignments))
+
+    # Set override dir and populate — this runs the full EphysEpoch.make() pipeline:
+    # discover probes, parse metadata, get probe IDs, read assignments, create ProbeInsertions
+    ephys.EphysEpoch.probe_assignments_override_dir = override_dir
+    try:
+        ephys.EphysEpoch.populate(suppress_errors=False)
+    finally:
+        ephys.EphysEpoch.probe_assignments_override_dir = None
+
+    return (acquisition.Epoch & {"experiment_name": exp_name}).to_dicts()
+
+
+@pytest.fixture(scope="session")
+def ephys_test_blocks(ephys_test_epochs, ephys_full_pipeline, ephys_golden_dataset_config):
+    """Create EphysBlock entry for the golden dataset — single 35-minute block."""
+    from datetime import timedelta
+
+    from aeon.dj_pipeline.utils.time_utils import parse_epoch_timestamp
+
+    ephys = ephys_full_pipeline["ephys"]
+    cfg = ephys_golden_dataset_config
+    exp_name = cfg["experiment_name"]
+
+    probe_insertions = (ephys.ProbeInsertion & {"experiment_name": exp_name}).to_dicts()
+    epoch_start = parse_epoch_timestamp(cfg["epoch_dir"])
+
+    for pi in probe_insertions:
+        ephys.EphysBlock.insert1(
+            {
+                "experiment_name": exp_name,
+                "subject": pi["subject"],
+                "insertion_number": pi["insertion_number"],
+                "block_start": epoch_start,
+                "block_end": epoch_start + timedelta(minutes=35),
+            },
+            skip_duplicates=True,
+        )
+
+    return (ephys.EphysBlock & {"experiment_name": exp_name}).to_dicts()
+
+
+@pytest.fixture(scope="session")
+def ephys_sorting_setup(ephys_test_blocks, ephys_full_pipeline, ephys_golden_dataset_config):
+    """Set up sorting prerequisites: ElectrodeGroup, SortingParamSet, SortingTask."""
+    spike_sorting = ephys_full_pipeline["spike_sorting"]
+    ephys = ephys_full_pipeline["ephys"]
+    cfg = ephys_golden_dataset_config
+    exp_name = cfg["experiment_name"]
+
+    electrode_config_key = {
+        "probe_type": "neuropixels2.0",
+        "electrode_config_name": "3982-3989",
+    }
+    spike_sorting.ElectrodeGroup.insert1(
+        {
+            **electrode_config_key,
+            "electrode_group": "shank3",
+            "electrode_group_description": "8 electrodes on shank3 (golden dataset)",
+            "electrode_count": 8,
+        },
+        skip_duplicates=True,
+    )
+    golden_electrodes = (ephys.ElectrodeConfig.Electrode & electrode_config_key).to_dicts()
+    spike_sorting.ElectrodeGroup.Electrode.insert(
+        (
+            {**electrode_config_key, "electrode_group": "shank3", "electrode": e["electrode"]}
+            for e in golden_electrodes
+        ),
+        skip_duplicates=True,
+    )
+
+    spike_sorting.SortingParamSet.insert1(
+        {
+            "paramset_id": "400",
+            "sorting_method": "kilosort4",
+            "paramset_description": "KS4 golden dataset (8-ch, no drift correction)",
+            "params": {
+                "SI_SORTING_PARAMS": {
+                    "nblocks": 0,
+                    "Th_universal": 8,
+                    "Th_learned": 7,
+                    "do_CAR": False,
+                    "skip_kilosort_preprocessing": False,
+                    "clear_cache": True,
+                },
+                "SI_POSTPROCESSING_PARAMS": {
+                    "extensions": {
+                        "random_spikes": {},
+                        "waveforms": {},
+                        "templates": {},
+                        "noise_levels": {},
+                        "spike_amplitudes": {},
+                        "spike_locations": {},
+                        "quality_metrics": {},
+                    },
+                    "job_kwargs": {"n_jobs": 1, "chunk_duration": "1s"},
+                },
+            },
+        },
+        skip_duplicates=True,
+    )
+
+    blocks = (ephys.EphysBlock & {"experiment_name": exp_name}).to_dicts()
+    for block in blocks:
+        spike_sorting.SortingTask.insert1(
+            {
+                "experiment_name": block["experiment_name"],
+                "subject": block["subject"],
+                "insertion_number": block["insertion_number"],
+                "block_start": block["block_start"],
+                "block_end": block["block_end"],
+                **electrode_config_key,
+                "electrode_group": "shank3",
+                "paramset_id": "400",
+            },
+            skip_duplicates=True,
+        )
+
+    return {
+        "electrode_config_key": electrode_config_key,
+        "electrode_group": "shank3",
+        "paramset_id": "400",
+    }
+
+
+@pytest.fixture(scope="session")
+def ephys_sorting_injected(
+    ephys_sorting_setup,
+    ephys_full_pipeline,
+    ephys_golden_dataset_config,
+    require_ephys_golden_data,
+):
+    """Run PreProcessing.populate() and force-inject SpikeSorting from golden data.
+
+    Runs the full cascade up through PreProcessing, then copies
+    pre-computed KS4 sorting output into the test's output directory and
+    inserts SpikeSorting + SpikeSorting.File entries. Downstream tables
+    (PostProcessing, SortedSpikes, SyncedSpikes) can then populate normally.
+    """
+    import shutil
+    from datetime import datetime, UTC
+
+    spike_sorting = ephys_full_pipeline["spike_sorting"]
+    ephys = ephys_full_pipeline["ephys"]
+    cfg = ephys_golden_dataset_config
+
+    # Run prerequisite populates
+    ephys.EphysChunk.ingest_chunks(cfg["experiment_name"])
+    ephys.EphysBlockInfo.populate(display_progress=True, suppress_errors=False)
+    spike_sorting.PreProcessing.populate(display_progress=True, suppress_errors=False)
+
+    # Find the output_dir that PreProcessing created
+    sorting_task_keys = (
+        spike_sorting.SortingTask & {"experiment_name": cfg["experiment_name"]}
+    ).to_dicts()
+    assert len(sorting_task_keys) >= 1, "No SortingTask entries found"
+
+    key = sorting_task_keys[0]
+    output_dir = spike_sorting.PreProcessing.infer_output_dir(key)
+
+    # Locate golden sorting output
+    epoch_path = require_ephys_golden_data
+    golden_sorting_dir = epoch_path.parent / cfg["golden_sorting_dir"]
+    golden_sorting_output = golden_sorting_dir / "sorting_output"
+    if not golden_sorting_output.exists():
+        pytest.skip(f"Golden sorting output not found: {golden_sorting_output}")
+
+    # Copy golden sorting output into the pipeline's expected location
+    test_sorting_dir = output_dir / "spike_sorting"
+    if not test_sorting_dir.exists():
+        shutil.copytree(golden_sorting_output, test_sorting_dir)
+
+    # Re-save si_sorting.pkl with correct relative_to for this output_dir
+    import spikeinterface as si
+
+    si_native_dir = test_sorting_dir / "in_container_sorting"
+    sorting = si.load(si_native_dir)
+    sorting.dump_to_pickle(
+        test_sorting_dir / "si_sorting.pkl", relative_to=output_dir
+    )
+
+    # Force-inject SpikeSorting entry
+    if not (spike_sorting.SpikeSorting & key):
+        spike_sorting.SpikeSorting.insert1(
+            {
+                **key,
+                "execution_time": datetime.now(UTC),
+                "execution_duration": 0.0,
+            },
+            allow_direct_insert=True,
+        )
+        spike_sorting.SpikeSorting.File.insert(
+            [
+                {
+                    **key,
+                    "file_name": f.relative_to(test_sorting_dir).as_posix(),
+                    "file": f,
+                }
+                for f in test_sorting_dir.rglob("*")
+                if f.is_file()
+            ],
+            allow_direct_insert=True,
+        )
+
+    return {
+        "output_dir": output_dir,
+        "sorting_dir": test_sorting_dir,
+        "sorting_task_key": key,
+    }

--- a/tests/dj_pipeline/conftest.py
+++ b/tests/dj_pipeline/conftest.py
@@ -608,7 +608,6 @@ def ephys_test_epochs(
             "experiment_name": exp_name,
             "epoch_start": epoch_start,
             "directory_type": "raw-ephys",
-            "repository_name": "ceph_aeon",
             "epoch_dir": cfg["epoch_dir"],
         },
         skip_duplicates=True,

--- a/tests/dj_pipeline/conftest.py
+++ b/tests/dj_pipeline/conftest.py
@@ -581,7 +581,12 @@ def ephys_test_epochs(
     ephys_test_experiment, ephys_full_pipeline, ephys_golden_dataset_config,
     require_ephys_golden_data, tmp_path_factory,
 ):
-    """Ingest epochs and populate EphysEpoch using the real pipeline code.
+    """Insert epoch and populate EphysEpoch using the real pipeline code.
+
+    Directly inserts the Epoch entry rather than calling ingest_epochs(),
+    which requires a "raw" behavior directory that ephys-only experiments
+    don't have. The ephys pipeline from EphysEpoch.populate() onward is
+    what these tests exercise.
 
     Creates a probe_assignments.json in a temp dir and sets
     EphysEpoch.probe_assignments_override_dir so that populate() can
@@ -589,16 +594,25 @@ def ephys_test_epochs(
     """
     import json
 
+    from aeon.dj_pipeline.utils.time_utils import parse_epoch_timestamp
+
     acquisition = ephys_full_pipeline["acquisition"]
     ephys = ephys_full_pipeline["ephys"]
     cfg = ephys_golden_dataset_config
     exp_name = cfg["experiment_name"]
+    epoch_start = parse_epoch_timestamp(cfg["epoch_dir"])
 
-    # Discover epochs from filesystem
-    acquisition.Epoch.ingest_epochs(exp_name)
-
-    epochs = (acquisition.Epoch & {"experiment_name": exp_name}).to_dicts()
-    assert len(epochs) >= 1, f"No epochs discovered for {exp_name}"
+    # Directly insert the epoch (ingest_epochs requires a "raw" directory)
+    acquisition.Epoch.insert1(
+        {
+            "experiment_name": exp_name,
+            "epoch_start": epoch_start,
+            "directory_type": "raw-ephys",
+            "repository_name": "ceph_aeon",
+            "epoch_dir": cfg["epoch_dir"],
+        },
+        skip_duplicates=True,
+    )
 
     # Write probe_assignments.json to temp dir for EphysEpoch.populate()
     override_dir = tmp_path_factory.mktemp("probe_assignments")

--- a/tests/dj_pipeline/test_ephys_ingestion.py
+++ b/tests/dj_pipeline/test_ephys_ingestion.py
@@ -329,9 +329,10 @@ class TestSyncedSpikes:
         spike_sorting = ephys_full_pipeline["spike_sorting"]
         cfg = ephys_golden_dataset_config
 
+        import numpy as np
         from aeon.dj_pipeline.utils.time_utils import parse_epoch_timestamp
 
-        epoch_start = parse_epoch_timestamp(cfg["epoch_dir"])
+        epoch_start = np.datetime64(parse_epoch_timestamp(cfg["epoch_dir"]))
 
         units = (spike_sorting.SyncedSpikes.Unit & {"experiment_name": cfg["experiment_name"]}).to_dicts()
         for unit in units:

--- a/tests/dj_pipeline/test_ephys_ingestion.py
+++ b/tests/dj_pipeline/test_ephys_ingestion.py
@@ -322,20 +322,21 @@ class TestSyncedSpikes:
         assert len(units) >= 1
         assert np.issubdtype(units[0]["spike_times"].dtype, np.datetime64)
 
-    def test_spike_times_within_epoch_range(
+    def test_spike_times_within_sync_range(
         self, ephys_sorting_injected, ephys_full_pipeline, ephys_golden_dataset_config
     ):
         self._ensure_prerequisites(ephys_full_pipeline, ephys_golden_dataset_config)
         spike_sorting = ephys_full_pipeline["spike_sorting"]
+        ephys = ephys_full_pipeline["ephys"]
         cfg = ephys_golden_dataset_config
 
         import numpy as np
-        from aeon.dj_pipeline.utils.time_utils import parse_epoch_timestamp
 
-        epoch_start = np.datetime64(parse_epoch_timestamp(cfg["epoch_dir"]))
-        # Recording can start slightly before the epoch directory timestamp
-        tolerance = np.timedelta64(60, "s")
+        sync_rows = (ephys.EphysSyncModel & {"experiment_name": cfg["experiment_name"]}).to_dicts()
+        sync_start = np.datetime64(min(r["sync_start"] for r in sync_rows))
+        sync_end = np.datetime64(max(r["sync_end"] for r in sync_rows))
 
         units = (spike_sorting.SyncedSpikes.Unit & {"experiment_name": cfg["experiment_name"]}).to_dicts()
         for unit in units:
-            assert unit["spike_times"].min() >= epoch_start - tolerance
+            assert unit["spike_times"].min() >= sync_start
+            assert unit["spike_times"].max() <= sync_end

--- a/tests/dj_pipeline/test_ephys_ingestion.py
+++ b/tests/dj_pipeline/test_ephys_ingestion.py
@@ -35,7 +35,7 @@ class TestEphysEpochDiscovery:
         ephys = ephys_full_pipeline["ephys"]
         cfg = ephys_golden_dataset_config
         epochs = (ephys.EphysEpoch & {"experiment_name": cfg["experiment_name"]}).to_dicts()
-        assert any(e["has_ephys"] for e in epochs)
+        assert all(e["has_ephys"] for e in epochs)
 
     def test_probe_count(self, ephys_test_epochs, ephys_full_pipeline, ephys_golden_dataset_config):
         ephys = ephys_full_pipeline["ephys"]
@@ -128,8 +128,7 @@ class TestEphysBlockInfo:
         cfg = ephys_golden_dataset_config
         infos = (ephys.EphysBlockInfo & {"experiment_name": cfg["experiment_name"]}).to_dicts()
         for info in infos:
-            expected_hours = (info["block_end"] - info["block_start"]).total_seconds() / 3600
-            assert abs(info["block_duration"] - expected_hours) < 0.01
+            assert abs(info["block_duration"] - 35 / 60) < 0.01
 
     def test_block_chunks_associated(self, ephys_test_blocks, ephys_full_pipeline, ephys_golden_dataset_config):
         self._ensure_prerequisites(ephys_full_pipeline, ephys_golden_dataset_config)
@@ -142,8 +141,12 @@ class TestEphysBlockInfo:
         self._ensure_prerequisites(ephys_full_pipeline, ephys_golden_dataset_config)
         ephys = ephys_full_pipeline["ephys"]
         cfg = ephys_golden_dataset_config
-        channels = len(ephys.EphysBlockInfo.Channel & {"experiment_name": cfg["experiment_name"]})
-        assert channels == cfg["n_channels"]
+        channel_rows = (
+            ephys.EphysBlockInfo.Channel & {"experiment_name": cfg["experiment_name"]}
+        ).to_dicts()
+        assert len(channel_rows) == cfg["n_channels"]
+        channel_indices = sorted(r["channel_idx"] for r in channel_rows)
+        assert channel_indices == list(range(cfg["n_channels"]))
 
 
 class TestPreProcessing:
@@ -195,7 +198,11 @@ class TestPreProcessing:
         output_dir = spike_sorting.PreProcessing.infer_output_dir(key)
         recording_dat = output_dir.parent / "recording" / "recording.dat"
         assert recording_dat.exists()
-        assert recording_dat.stat().st_size > 0
+        file_size = recording_dat.stat().st_size
+        assert file_size > 0
+        expected_size = cfg["n_channels"] * 2  # int16 per sample per channel
+        assert file_size % expected_size == 0, f"File size {file_size} not divisible by frame size {expected_size}"
+        assert file_size >= 500_000_000, f"recording.dat too small ({file_size} bytes), expected ~1 GB"
 
 
 class TestPostProcessing:
@@ -269,9 +276,9 @@ class TestSortedSpikes:
             spike_sorting.SortedSpikes.Unit & {"experiment_name": cfg["experiment_name"]}
         ).to_dicts()
         for u in units:
-            assert u["spike_count"] >= 100
+            assert u["spike_count"] > 0
         total = sum(u["spike_count"] for u in units)
-        assert total > 300_000
+        assert total == cfg["expected_total_spikes"]
 
     def test_quality_labels_assigned(
         self, ephys_sorting_injected, ephys_full_pipeline, ephys_golden_dataset_config
@@ -282,9 +289,10 @@ class TestSortedSpikes:
         units = (
             spike_sorting.SortedSpikes.Unit & {"experiment_name": cfg["experiment_name"]}
         ).to_dicts()
-        qualities = {u["unit_quality"] for u in units}
-        assert qualities <= {"good", "mua", "noise", "ok", "n.a."}
-        assert len(qualities) >= 1
+        qualities = [u["unit_quality"] for u in units]
+        assert set(qualities) <= {"good", "mua", "noise"}
+        assert qualities.count("good") == 7
+        assert qualities.count("mua") == 7
 
 
 class TestSyncedSpikes:
@@ -320,7 +328,8 @@ class TestSyncedSpikes:
 
         units = (spike_sorting.SyncedSpikes.Unit & {"experiment_name": cfg["experiment_name"]}).to_dicts()
         assert len(units) >= 1
-        assert np.issubdtype(units[0]["spike_times"].dtype, np.datetime64)
+        for unit in units:
+            assert np.issubdtype(unit["spike_times"].dtype, np.datetime64)
 
     def test_spike_times_within_sync_range(
         self, ephys_sorting_injected, ephys_full_pipeline, ephys_golden_dataset_config

--- a/tests/dj_pipeline/test_ephys_ingestion.py
+++ b/tests/dj_pipeline/test_ephys_ingestion.py
@@ -1,0 +1,338 @@
+"""Golden baseline and integration tests for the ephys pipeline.
+
+Tests the ephys ingestion pipeline using a known dataset (8-channel
+subset of abcGolden01 NeuropixelsV2 recording). Tests gracefully skip
+if data unavailable.
+
+Requirements:
+1. Ephys golden dataset at ~/sciops-data/project_aeon/aeon/data/raw/AEONX1/...
+2. probeinterface package installed
+3. aeon.schema.ephys available (from swc-aeon package)
+
+Pipeline cascade tested (all live except SpikeSorting):
+    EphysChunk.ingest_chunks → EphysBlockInfo.populate → PreProcessing.populate
+    → [SpikeSorting: force-injected from golden KS4 output]
+    → PostProcessing.populate → SortedSpikes.populate → SyncedSpikes.populate
+"""
+
+import pytest
+
+pytestmark = pytest.mark.integration
+pytest.importorskip("probeinterface", reason="Ephys tests require probeinterface")
+pytest.importorskip("aeon.schema.ephys", reason="Ephys tests require aeon.schema.ephys (from swc-aeon)")
+
+
+class TestEphysEpochDiscovery:
+    """Verify ephys epoch and probe discovery setup."""
+
+    def test_ephys_epoch_exists(self, ephys_test_epochs, ephys_full_pipeline, ephys_golden_dataset_config):
+        ephys = ephys_full_pipeline["ephys"]
+        cfg = ephys_golden_dataset_config
+        count = len(ephys.EphysEpoch & {"experiment_name": cfg["experiment_name"]})
+        assert count >= 1
+
+    def test_has_ephys_flag(self, ephys_test_epochs, ephys_full_pipeline, ephys_golden_dataset_config):
+        ephys = ephys_full_pipeline["ephys"]
+        cfg = ephys_golden_dataset_config
+        epochs = (ephys.EphysEpoch & {"experiment_name": cfg["experiment_name"]}).to_dicts()
+        assert any(e["has_ephys"] for e in epochs)
+
+    def test_probe_count(self, ephys_test_epochs, ephys_full_pipeline, ephys_golden_dataset_config):
+        ephys = ephys_full_pipeline["ephys"]
+        cfg = ephys_golden_dataset_config
+        ephys_epochs = (
+            ephys.EphysEpoch & {"experiment_name": cfg["experiment_name"], "has_ephys": True}
+        ).to_dicts()
+        assert len(ephys_epochs) >= 1
+        assert ephys_epochs[0]["n_probes"] == cfg["expected_probe_count"]
+
+    def test_probe_insertions_created(self, ephys_test_epochs, ephys_full_pipeline, ephys_golden_dataset_config):
+        ephys = ephys_full_pipeline["ephys"]
+        cfg = ephys_golden_dataset_config
+        insertions = (
+            ephys.EphysEpoch.Insertion & {"experiment_name": cfg["experiment_name"]}
+        ).to_dicts()
+        assert len(insertions) == cfg["expected_probe_count"]
+
+    def test_probe_insertion_links_correct_subject(
+        self, ephys_test_epochs, ephys_full_pipeline, ephys_golden_dataset_config
+    ):
+        ephys = ephys_full_pipeline["ephys"]
+        cfg = ephys_golden_dataset_config
+        pis = (
+            ephys.ProbeInsertion & {"experiment_name": cfg["experiment_name"]}
+        ).to_dicts()
+        assert len(pis) >= 1
+        assert all(pi["subject"] == cfg["subject"] for pi in pis)
+
+    def test_discover_epoch_probes_on_golden_data(
+        self, require_ephys_golden_data, ephys_golden_dataset_config
+    ):
+        from aeon.dj_pipeline.utils.ephys_utils import discover_epoch_probes
+
+        epoch_path = require_ephys_golden_data
+        device_name, _, labels = discover_epoch_probes(epoch_path)
+        assert device_name is not None
+        assert len(labels) == ephys_golden_dataset_config["expected_probe_count"]
+
+
+class TestEphysChunkIngestion:
+    """Verify EphysChunk.ingest_chunks() output."""
+
+    def _ensure_chunks_ingested(self, ephys_full_pipeline, cfg):
+        ephys = ephys_full_pipeline["ephys"]
+        ephys.EphysChunk.ingest_chunks(cfg["experiment_name"])
+
+    def test_chunks_ingested(self, ephys_test_epochs, ephys_full_pipeline, ephys_golden_dataset_config):
+        self._ensure_chunks_ingested(ephys_full_pipeline, ephys_golden_dataset_config)
+        ephys = ephys_full_pipeline["ephys"]
+        cfg = ephys_golden_dataset_config
+        count = len(ephys.EphysChunk & {"experiment_name": cfg["experiment_name"]})
+        assert count >= 1
+
+    def test_chunk_timestamps_valid(self, ephys_test_epochs, ephys_full_pipeline, ephys_golden_dataset_config):
+        self._ensure_chunks_ingested(ephys_full_pipeline, ephys_golden_dataset_config)
+        ephys = ephys_full_pipeline["ephys"]
+        cfg = ephys_golden_dataset_config
+        chunks = (ephys.EphysChunk & {"experiment_name": cfg["experiment_name"]}).to_dicts()
+        for chunk in chunks:
+            assert chunk["chunk_start"] < chunk["chunk_end"]
+
+    def test_chunk_files_registered(self, ephys_test_epochs, ephys_full_pipeline, ephys_golden_dataset_config):
+        self._ensure_chunks_ingested(ephys_full_pipeline, ephys_golden_dataset_config)
+        ephys = ephys_full_pipeline["ephys"]
+        cfg = ephys_golden_dataset_config
+        files = (ephys.EphysChunk.File & {"experiment_name": cfg["experiment_name"]}).to_dicts()
+        assert len(files) >= 2
+
+
+class TestEphysBlockInfo:
+    """Verify EphysBlockInfo.populate() output."""
+
+    def _ensure_prerequisites(self, ephys_full_pipeline, cfg):
+        ephys = ephys_full_pipeline["ephys"]
+        ephys.EphysChunk.ingest_chunks(cfg["experiment_name"])
+        ephys.EphysBlockInfo.populate()
+
+    def test_block_info_populated(self, ephys_test_blocks, ephys_full_pipeline, ephys_golden_dataset_config):
+        self._ensure_prerequisites(ephys_full_pipeline, ephys_golden_dataset_config)
+        ephys = ephys_full_pipeline["ephys"]
+        cfg = ephys_golden_dataset_config
+        blocks = len(ephys.EphysBlock & {"experiment_name": cfg["experiment_name"]})
+        infos = len(ephys.EphysBlockInfo & {"experiment_name": cfg["experiment_name"]})
+        assert infos == blocks
+
+    def test_block_duration_correct(self, ephys_test_blocks, ephys_full_pipeline, ephys_golden_dataset_config):
+        self._ensure_prerequisites(ephys_full_pipeline, ephys_golden_dataset_config)
+        ephys = ephys_full_pipeline["ephys"]
+        cfg = ephys_golden_dataset_config
+        infos = (ephys.EphysBlockInfo & {"experiment_name": cfg["experiment_name"]}).to_dicts()
+        for info in infos:
+            expected_hours = (info["block_end"] - info["block_start"]).total_seconds() / 3600
+            assert abs(info["block_duration"] - expected_hours) < 0.01
+
+    def test_block_chunks_associated(self, ephys_test_blocks, ephys_full_pipeline, ephys_golden_dataset_config):
+        self._ensure_prerequisites(ephys_full_pipeline, ephys_golden_dataset_config)
+        ephys = ephys_full_pipeline["ephys"]
+        cfg = ephys_golden_dataset_config
+        chunk_links = len(ephys.EphysBlockInfo.Chunk & {"experiment_name": cfg["experiment_name"]})
+        assert chunk_links >= 1
+
+    def test_channel_mappings_created(self, ephys_test_blocks, ephys_full_pipeline, ephys_golden_dataset_config):
+        self._ensure_prerequisites(ephys_full_pipeline, ephys_golden_dataset_config)
+        ephys = ephys_full_pipeline["ephys"]
+        cfg = ephys_golden_dataset_config
+        channels = len(ephys.EphysBlockInfo.Channel & {"experiment_name": cfg["experiment_name"]})
+        assert channels == cfg["n_channels"]
+
+
+class TestPreProcessing:
+    """Verify PreProcessing.populate() output.
+
+    PreProcessing reads raw ephys binary, selects electrode group channels,
+    applies bandpass filter + common average reference, and writes
+    recording.dat + si_recording.pkl.
+    """
+
+    def _ensure_prerequisites(self, ephys_full_pipeline, cfg):
+        ephys = ephys_full_pipeline["ephys"]
+        spike_sorting = ephys_full_pipeline["spike_sorting"]
+        ephys.EphysChunk.ingest_chunks(cfg["experiment_name"])
+        ephys.EphysBlockInfo.populate()
+        spike_sorting.PreProcessing.populate(display_progress=True, suppress_errors=False)
+
+    def test_preprocessing_populated(
+        self, ephys_sorting_setup, ephys_full_pipeline, ephys_golden_dataset_config, require_ephys_golden_data
+    ):
+        self._ensure_prerequisites(ephys_full_pipeline, ephys_golden_dataset_config)
+        spike_sorting = ephys_full_pipeline["spike_sorting"]
+        cfg = ephys_golden_dataset_config
+        count = len(spike_sorting.PreProcessing & {"experiment_name": cfg["experiment_name"]})
+        assert count >= 1
+
+    def test_recording_files_registered(
+        self, ephys_sorting_setup, ephys_full_pipeline, ephys_golden_dataset_config, require_ephys_golden_data
+    ):
+        self._ensure_prerequisites(ephys_full_pipeline, ephys_golden_dataset_config)
+        spike_sorting = ephys_full_pipeline["spike_sorting"]
+        cfg = ephys_golden_dataset_config
+        files = (
+            spike_sorting.PreProcessing.File
+            & {"experiment_name": cfg["experiment_name"]}
+        ).to_dicts()
+        file_names = [f["file_name"] for f in files]
+        assert any("si_recording.pkl" in fn for fn in file_names)
+
+    def test_recording_binary_exists(
+        self, ephys_sorting_setup, ephys_full_pipeline, ephys_golden_dataset_config, require_ephys_golden_data
+    ):
+        self._ensure_prerequisites(ephys_full_pipeline, ephys_golden_dataset_config)
+        spike_sorting = ephys_full_pipeline["spike_sorting"]
+        cfg = ephys_golden_dataset_config
+        key = (
+            spike_sorting.SortingTask & {"experiment_name": cfg["experiment_name"]}
+        ).to_dicts()[0]
+        output_dir = spike_sorting.PreProcessing.infer_output_dir(key)
+        recording_dat = output_dir.parent / "recording" / "recording.dat"
+        assert recording_dat.exists()
+        assert recording_dat.stat().st_size > 0
+
+
+class TestPostProcessing:
+    """Verify PostProcessing.populate() output.
+
+    PostProcessing creates a SpikeInterface sorting_analyzer with computed
+    extensions (waveforms, templates, spike_locations, quality_metrics).
+    Depends on SpikeSorting being force-injected from golden data.
+    """
+
+    def _ensure_prerequisites(self, ephys_full_pipeline, cfg):
+        spike_sorting = ephys_full_pipeline["spike_sorting"]
+        spike_sorting.PostProcessing.populate(display_progress=True, suppress_errors=False)
+
+    def test_postprocessing_populated(
+        self, ephys_sorting_injected, ephys_full_pipeline, ephys_golden_dataset_config
+    ):
+        self._ensure_prerequisites(ephys_full_pipeline, ephys_golden_dataset_config)
+        spike_sorting = ephys_full_pipeline["spike_sorting"]
+        cfg = ephys_golden_dataset_config
+        count = len(spike_sorting.PostProcessing & {"experiment_name": cfg["experiment_name"]})
+        assert count >= 1
+
+    def test_sorting_analyzer_created(
+        self, ephys_sorting_injected, ephys_full_pipeline, ephys_golden_dataset_config
+    ):
+        self._ensure_prerequisites(ephys_full_pipeline, ephys_golden_dataset_config)
+        output_dir = ephys_sorting_injected["output_dir"]
+        analyzer_dir = output_dir / "sorting_analyzer"
+        assert analyzer_dir.exists()
+        assert any(analyzer_dir.iterdir())
+
+
+class TestSortedSpikes:
+    """Verify SortedSpikes.populate() output.
+
+    SortedSpikes extracts unit info from the sorting_analyzer: spike counts,
+    spike indices, electrode assignments, quality labels.
+    """
+
+    def _ensure_prerequisites(self, ephys_full_pipeline, cfg):
+        spike_sorting = ephys_full_pipeline["spike_sorting"]
+        spike_sorting.PostProcessing.populate(display_progress=True, suppress_errors=False)
+        spike_sorting.SortedSpikes.populate(display_progress=True, suppress_errors=False)
+
+    def test_sorted_spikes_populated(
+        self, ephys_sorting_injected, ephys_full_pipeline, ephys_golden_dataset_config
+    ):
+        self._ensure_prerequisites(ephys_full_pipeline, ephys_golden_dataset_config)
+        spike_sorting = ephys_full_pipeline["spike_sorting"]
+        cfg = ephys_golden_dataset_config
+        count = len(spike_sorting.SortedSpikes & {"experiment_name": cfg["experiment_name"]})
+        assert count >= 1
+
+    def test_unit_count(
+        self, ephys_sorting_injected, ephys_full_pipeline, ephys_golden_dataset_config
+    ):
+        self._ensure_prerequisites(ephys_full_pipeline, ephys_golden_dataset_config)
+        spike_sorting = ephys_full_pipeline["spike_sorting"]
+        cfg = ephys_golden_dataset_config
+        units = len(spike_sorting.SortedSpikes.Unit & {"experiment_name": cfg["experiment_name"]})
+        assert units == cfg["expected_unit_count"]
+
+    def test_spike_counts_reasonable(
+        self, ephys_sorting_injected, ephys_full_pipeline, ephys_golden_dataset_config
+    ):
+        self._ensure_prerequisites(ephys_full_pipeline, ephys_golden_dataset_config)
+        spike_sorting = ephys_full_pipeline["spike_sorting"]
+        cfg = ephys_golden_dataset_config
+        units = (
+            spike_sorting.SortedSpikes.Unit & {"experiment_name": cfg["experiment_name"]}
+        ).to_dicts()
+        for u in units:
+            assert u["spike_count"] >= 100
+        total = sum(u["spike_count"] for u in units)
+        assert total > 300_000
+
+    def test_quality_labels_assigned(
+        self, ephys_sorting_injected, ephys_full_pipeline, ephys_golden_dataset_config
+    ):
+        self._ensure_prerequisites(ephys_full_pipeline, ephys_golden_dataset_config)
+        spike_sorting = ephys_full_pipeline["spike_sorting"]
+        cfg = ephys_golden_dataset_config
+        units = (
+            spike_sorting.SortedSpikes.Unit & {"experiment_name": cfg["experiment_name"]}
+        ).to_dicts()
+        qualities = {u["unit_quality"] for u in units}
+        assert qualities <= {"good", "mua", "noise", "ok", "n.a."}
+        assert len(qualities) >= 1
+
+
+class TestSyncedSpikes:
+    """Verify clock-synchronized spike times.
+
+    SyncedSpikes reads binary Clock files and HarpSync models to convert
+    spike sample indices to absolute datetime timestamps.
+    """
+
+    def _ensure_prerequisites(self, ephys_full_pipeline, cfg):
+        spike_sorting = ephys_full_pipeline["spike_sorting"]
+        spike_sorting.PostProcessing.populate(display_progress=True, suppress_errors=False)
+        spike_sorting.SortedSpikes.populate(display_progress=True, suppress_errors=False)
+        spike_sorting.SyncedSpikes.populate(display_progress=True, suppress_errors=False)
+
+    def test_synced_spikes_populated(
+        self, ephys_sorting_injected, ephys_full_pipeline, ephys_golden_dataset_config
+    ):
+        self._ensure_prerequisites(ephys_full_pipeline, ephys_golden_dataset_config)
+        spike_sorting = ephys_full_pipeline["spike_sorting"]
+        cfg = ephys_golden_dataset_config
+        count = len(spike_sorting.SyncedSpikes & {"experiment_name": cfg["experiment_name"]})
+        assert count >= 1
+
+    def test_spike_times_are_datetimes(
+        self, ephys_sorting_injected, ephys_full_pipeline, ephys_golden_dataset_config
+    ):
+        self._ensure_prerequisites(ephys_full_pipeline, ephys_golden_dataset_config)
+        spike_sorting = ephys_full_pipeline["spike_sorting"]
+        cfg = ephys_golden_dataset_config
+
+        import numpy as np
+
+        units = (spike_sorting.SyncedSpikes.Unit & {"experiment_name": cfg["experiment_name"]}).to_dicts()
+        assert len(units) >= 1
+        assert np.issubdtype(units[0]["spike_times"].dtype, np.datetime64)
+
+    def test_spike_times_within_epoch_range(
+        self, ephys_sorting_injected, ephys_full_pipeline, ephys_golden_dataset_config
+    ):
+        self._ensure_prerequisites(ephys_full_pipeline, ephys_golden_dataset_config)
+        spike_sorting = ephys_full_pipeline["spike_sorting"]
+        cfg = ephys_golden_dataset_config
+
+        from aeon.dj_pipeline.utils.time_utils import parse_epoch_timestamp
+
+        epoch_start = parse_epoch_timestamp(cfg["epoch_dir"])
+
+        units = (spike_sorting.SyncedSpikes.Unit & {"experiment_name": cfg["experiment_name"]}).to_dicts()
+        for unit in units:
+            assert unit["spike_times"].min() >= epoch_start

--- a/tests/dj_pipeline/test_ephys_ingestion.py
+++ b/tests/dj_pipeline/test_ephys_ingestion.py
@@ -333,7 +333,9 @@ class TestSyncedSpikes:
         from aeon.dj_pipeline.utils.time_utils import parse_epoch_timestamp
 
         epoch_start = np.datetime64(parse_epoch_timestamp(cfg["epoch_dir"]))
+        # Recording can start slightly before the epoch directory timestamp
+        tolerance = np.timedelta64(60, "s")
 
         units = (spike_sorting.SyncedSpikes.Unit & {"experiment_name": cfg["experiment_name"]}).to_dicts()
         for unit in units:
-            assert unit["spike_times"].min() >= epoch_start
+            assert unit["spike_times"].min() >= epoch_start - tolerance

--- a/tests/dj_pipeline/utils/test_ephys_utils_unit.py
+++ b/tests/dj_pipeline/utils/test_ephys_utils_unit.py
@@ -259,3 +259,108 @@ class TestGetProbeId:
             },
         }
         assert get_probe_id(metadata, "NeuropixelsV2Beta", "ProbeA") == "NeuropixelsV2Beta_ProbeA"
+
+
+class TestDiscoverEpochProbes:
+    """Tests for discover_epoch_probes(epoch_path)."""
+
+    def test_single_probe(self, tmp_path):
+        from aeon.dj_pipeline.utils.ephys_utils import discover_epoch_probes
+
+        device_dir = tmp_path / "NeuropixelsV2Beta"
+        device_dir.mkdir()
+        (device_dir / "NeuropixelsV2Beta_ProbeA_AmplifierData_0.bin").touch()
+
+        device_name, device_path, labels = discover_epoch_probes(tmp_path)
+
+        assert device_name == "NeuropixelsV2Beta"
+        assert device_path == device_dir
+        assert labels == ["ProbeA"]
+
+    def test_two_probes(self, tmp_path):
+        from aeon.dj_pipeline.utils.ephys_utils import discover_epoch_probes
+
+        device_dir = tmp_path / "NeuropixelsV2Beta"
+        device_dir.mkdir()
+        (device_dir / "NeuropixelsV2Beta_ProbeA_AmplifierData_0.bin").touch()
+        (device_dir / "NeuropixelsV2Beta_ProbeB_AmplifierData_0.bin").touch()
+
+        device_name, _, labels = discover_epoch_probes(tmp_path)
+
+        assert device_name == "NeuropixelsV2Beta"
+        assert labels == ["ProbeA", "ProbeB"]
+
+    def test_no_device_directory(self, tmp_path):
+        from aeon.dj_pipeline.utils.ephys_utils import discover_epoch_probes
+
+        device_name, device_path, labels = discover_epoch_probes(tmp_path)
+
+        assert device_name is None
+        assert device_path is None
+        assert labels == []
+
+    def test_v2beta_preferred_over_v2(self, tmp_path):
+        from aeon.dj_pipeline.utils.ephys_utils import discover_epoch_probes
+
+        (tmp_path / "NeuropixelsV2Beta").mkdir()
+        (tmp_path / "NeuropixelsV2Beta" / "NeuropixelsV2Beta_ProbeA_AmplifierData_0.bin").touch()
+        (tmp_path / "NeuropixelsV2").mkdir()
+        (tmp_path / "NeuropixelsV2" / "NeuropixelsV2_ProbeA_AmplifierData_0.bin").touch()
+
+        device_name, _, _ = discover_epoch_probes(tmp_path)
+
+        assert device_name == "NeuropixelsV2Beta"
+
+    def test_no_amplifier_files(self, tmp_path):
+        from aeon.dj_pipeline.utils.ephys_utils import discover_epoch_probes
+
+        (tmp_path / "NeuropixelsV2Beta").mkdir()
+
+        device_name, _, labels = discover_epoch_probes(tmp_path)
+
+        assert device_name == "NeuropixelsV2Beta"
+        assert labels == []
+
+    def test_unexpected_filenames_ignored(self, tmp_path):
+        from aeon.dj_pipeline.utils.ephys_utils import discover_epoch_probes
+
+        device_dir = tmp_path / "NeuropixelsV2Beta"
+        device_dir.mkdir()
+        (device_dir / "NeuropixelsV2Beta_ProbeA_AmplifierData_0.bin").touch()
+        (device_dir / "NeuropixelsV2Beta_Clock_0.bin").touch()
+        (device_dir / "random_file.txt").touch()
+
+        _, _, labels = discover_epoch_probes(tmp_path)
+
+        assert labels == ["ProbeA"]
+
+
+class TestParseEpochMetadata:
+    """Tests for parse_epoch_metadata(epoch_path)."""
+
+    def test_valid_metadata(self, tmp_path):
+        import json
+
+        from aeon.dj_pipeline.utils.ephys_utils import parse_epoch_metadata
+
+        metadata = {"Devices": {"NeuropixelsV2e": {"ConfigurationA": {}}}}
+        (tmp_path / "Metadata.yml").write_text(json.dumps(metadata))
+        result = parse_epoch_metadata(tmp_path)
+
+        assert result is not None
+        assert "Devices" in result
+
+    def test_missing_metadata(self, tmp_path):
+        from aeon.dj_pipeline.utils.ephys_utils import parse_epoch_metadata
+
+        result = parse_epoch_metadata(tmp_path)
+
+        assert result is None
+
+    def test_malformed_metadata(self, tmp_path):
+        from aeon.dj_pipeline.utils.ephys_utils import parse_epoch_metadata
+
+        (tmp_path / "Metadata.yml").write_text("not: valid: json: {{}")
+        result = parse_epoch_metadata(tmp_path)
+
+        assert result is None


### PR DESCRIPTION
## Summary

- Add 25 integration tests covering the full ephys pipeline cascade: epoch discovery → chunk ingestion → block info → preprocessing → post-processing → sorted spikes → synced spikes
- Add 9 unit tests for ephys utility functions (discover_epoch_probes, parse_epoch_metadata)
- Add `TEST_DB_PREFIX` support for running integration tests on HPC without Docker/testcontainers
- Add ephys testing specification (`docs/specs/SPEC_EPHYS_TESTING.md`)

Tests use an 8-channel golden dataset (NeuropixelsV2 ProbeB extract) with pre-computed KS4 sorting output. SpikeSorting is injected from the golden output; all other pipeline stages run through real `populate()` calls.

See `docs/specs/SPEC_EPHYS_TESTING.md` for full details on the golden dataset, setup instructions, and test coverage.