### PR TITLE
test(behavior): parametrize behavior golden over both abcBehav0 + abcGolden01

### DIFF
--- a/aeon/dj_pipeline/acquisition.py
+++ b/aeon/dj_pipeline/acquisition.py
@@ -24,6 +24,9 @@ _ref_device_mapping = {
     "exp0.1-r0": "FrameTop",
     "social0-r1": "FrameTop",
     "exp0.2-r0": "CameraTop",
+    # abcGolden01 behavior arm: CameraTop isn't part of this rig's active set,
+    # so use CameraNest as the chunk-discovery reference.
+    "abcGolden01-aeon3": "CameraNest",
 }
 
 

--- a/docs/specs/SPEC_TESTING.md
+++ b/docs/specs/SPEC_TESTING.md
@@ -95,21 +95,28 @@ Override the root with the `DJ_REPOSITORY_CONFIG` env var (used on HPC). The `_c
 
 ---
 
-## Behavior golden dataset
+## Behavior golden datasets
 
-**Active dataset:** `foraging_abc_2026_05_11` — ~2 hours of `abcGolden01-aeon3`,
-13 cameras + 6 feeders declared, 5 cameras + 4 feeders writing data to disk.
-Paired with the ephys golden (`foraging_abc_ephys_2026_05_11`): same experiment,
-same wall-clock window, AEON3 acquires behavior while AEONX1 acquires ephys.
+Tests parametrize the `golden_dataset_config` fixture over both registered
+datasets — every behavior test runs once per dataset:
 
-**Location:** `~/sciops-data/project_aeon/aeon/data/raw/AEON3/abcGolden01/2026-05-11T075134Z/`
+| Key | Experiment | Duration | On-disk profile | Pair |
+|---|---|---|---|---|
+| `foraging_abc_2025_11_18` | `abcBehav0-aeon3` | ~1 hour | Full 13 cameras + 6 feeders writing data; rich stream samples (`FeederEncoder` 848k, `CameraPosition` 12k) | Behavior only |
+| `foraging_abc_2026_05_11` | `abcGolden01-aeon3` | ~2 hours | 5 cameras + 4 feeders writing data; sparser samples; paired with the ephys golden | Paired with `foraging_abc_ephys_2026_05_11` |
 
-**Test module:** `tests/dj_pipeline/test_full_ingestion.py`
+**Locations:**
+- `~/sciops-data/project_aeon/aeon/data/raw/AEON3/abcBehav0/2025-11-18T10-13-15/`
+- `~/sciops-data/project_aeon/aeon/data/raw/AEON3/abcGolden01/2026-05-11T075134Z/`
 
-**Reference device:** `CameraNest` (set via `_ref_device_mapping` in
-`acquisition.py`). This rig doesn't have CameraTop on-disk.
+**Test modules:** `tests/dj_pipeline/test_full_ingestion.py`,
+`tests/dj_pipeline/test_acquisition_environment_integration.py`
 
-**Mixed file-name formats** within the epoch dir — CSVs use `T07-00-00`, newer
+**Reference device:** `CameraTop` by default; `abcGolden01-aeon3` overrides
+to `CameraNest` via `_ref_device_mapping` in `acquisition.py` (that rig has
+no `CameraTop` on disk).
+
+**Mixed file-name formats** in abcGolden01 — CSVs use `T07-00-00`, newer
 bins use `T070000Z`. Both parse via `swc.aeon.io.api.chunk_key`.
 
 **Covers:**
@@ -117,9 +124,8 @@ bins use `T070000Z`. Both parse via `swc.aeon.io.api.chunk_key`.
 - `EpochConfig.populate()` — Metadata.json parsing via foragingABC Pydantic schema
 - `Chunk.ingest_chunks()` — chunk file detection
 - All `DeviceDataStream` tables — `populate(max_calls=10)` per stream
-
-**Deprecated:** `foraging_abc_2025_11_18` (`abcBehav0-aeon3`, 1 hour, retained
-as a rollback fallback for one release; removal in a follow-up PR).
+- The 3 `acquisition.Environment*` tables (`EnvironmentState`, `MessageLog`, `LightEvents`)
+- `TestStreamPopulationInventory` — diagnostic inventory of which streams populate
 
 **Run:**
 ```bash

--- a/docs/specs/SPEC_TESTING.md
+++ b/docs/specs/SPEC_TESTING.md
@@ -97,11 +97,20 @@ Override the root with the `DJ_REPOSITORY_CONFIG` env var (used on HPC). The `_c
 
 ## Behavior golden dataset
 
-**Active dataset:** `foraging_abc_2025_11_18` — 1 hour of `abcBehav0-aeon3`, 13 cameras + 6 feeders.
+**Active dataset:** `foraging_abc_2026_05_11` — ~2 hours of `abcGolden01-aeon3`,
+13 cameras + 6 feeders declared, 5 cameras + 4 feeders writing data to disk.
+Paired with the ephys golden (`foraging_abc_ephys_2026_05_11`): same experiment,
+same wall-clock window, AEON3 acquires behavior while AEONX1 acquires ephys.
 
-**Location:** `~/sciops-data/project_aeon/aeon/data/raw/AEON3/abcBehav0/2025-11-18T10-13-15/`
+**Location:** `~/sciops-data/project_aeon/aeon/data/raw/AEON3/abcGolden01/2026-05-11T075134Z/`
 
 **Test module:** `tests/dj_pipeline/test_full_ingestion.py`
+
+**Reference device:** `CameraNest` (set via `_ref_device_mapping` in
+`acquisition.py`). This rig doesn't have CameraTop on-disk.
+
+**Mixed file-name formats** within the epoch dir — CSVs use `T07-00-00`, newer
+bins use `T070000Z`. Both parse via `swc.aeon.io.api.chunk_key`.
 
 **Covers:**
 - `Epoch.ingest_epochs()` — filesystem detection of epoch directories
@@ -109,10 +118,16 @@ Override the root with the `DJ_REPOSITORY_CONFIG` env var (used on HPC). The `_c
 - `Chunk.ingest_chunks()` — chunk file detection
 - All `DeviceDataStream` tables — `populate(max_calls=10)` per stream
 
+**Deprecated:** `foraging_abc_2025_11_18` (`abcBehav0-aeon3`, 1 hour, retained
+as a rollback fallback for one release; removal in a follow-up PR).
+
 **Run:**
 ```bash
 uv run pytest -m integration tests/dj_pipeline/test_full_ingestion.py -v
 ```
+
+**Required deps:** `uv sync --group test-golden` (installs `swc-aeon-rigs-foragingabc`).
+Without it, the test module skips at import time via `pytest.importorskip`.
 
 ---
 

--- a/docs/specs/SPEC_TESTING.md
+++ b/docs/specs/SPEC_TESTING.md
@@ -105,9 +105,9 @@ datasets — every behavior test runs once per dataset:
 | `foraging_abc_2025_11_18` | `abcBehav0-aeon3` | ~1 hour | Full 13 cameras + 6 feeders writing data; rich stream samples (`FeederEncoder` 848k, `CameraPosition` 12k) | Behavior only |
 | `foraging_abc_2026_05_11` | `abcGolden01-aeon3` | ~2 hours | 5 cameras + 4 feeders writing data; sparser samples; paired with the ephys golden | Paired with `foraging_abc_ephys_2026_05_11` |
 
-**Locations:**
-- `~/sciops-data/project_aeon/aeon/data/raw/AEON3/abcBehav0/2025-11-18T10-13-15/`
-- `~/sciops-data/project_aeon/aeon/data/raw/AEON3/abcGolden01/2026-05-11T075134Z/`
+**Locations** (relative to `DEFAULT_GOLDEN_DATA_ROOT`):
+- `<data-root>/raw/AEON3/abcBehav0/2025-11-18T10-13-15/`
+- `<data-root>/raw/AEON3/abcGolden01/2026-05-11T075134Z/`
 
 **Test modules:** `tests/dj_pipeline/test_full_ingestion.py`,
 `tests/dj_pipeline/test_acquisition_environment_integration.py`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,4 +190,4 @@ markers = [
 
 [tool.uv.sources]
 swc-aeon = { git = "https://github.com/SainsburyWellcomeCentre/aeon_api.git", branch = "main" }
-swc-aeon-rigs-foragingabc = { git = "https://github.com/SainsburyWellcomeCentre/aeon_exp_foragingABC.git", branch = "main" }
+swc-aeon-rigs-foragingabc = { git = "https://github.com/SainsburyWellcomeCentre/aeon_exp_foragingABC.git", branch = "tn/env-data-readers" }

--- a/tests/dj_pipeline/conftest.py
+++ b/tests/dj_pipeline/conftest.py
@@ -42,6 +42,10 @@ TEST_DB_PREFIX = os.environ.get("TEST_DB_PREFIX", "test_aeon_")
 # ============================================================================
 
 GOLDEN_DATASETS = {
+    # DEPRECATED: kept for one release as a rollback fallback. Superseded by
+    # foraging_abc_2026_05_11, which is the behavior arm of the same experiment
+    # as the ephys golden dataset (abcGolden01). Scheduled for removal in a
+    # follow-up PR once the new dataset has stabilized.
     "foraging_abc_2025_11_18": {
         "experiment_name": "abcBehav0-aeon3",
         "experiment_path": "AEON3/abcBehav0",
@@ -55,6 +59,28 @@ GOLDEN_DATASETS = {
             "Metadata.json",
             "CameraTop/CameraTop_2025-11-18T10-00-00.csv",
             "Feeder1/Feeder1_32_2025-11-18T10-00-00.bin",
+        ],
+        "expected_camera_count": 13,
+        "expected_feeder_count": 6,
+    },
+    # Behavior arm of abcGolden01 — paired with foraging_abc_ephys_2026_05_11
+    # (same experiment, same wall-clock window, AEON3 acquires behavior while
+    # AEONX1 acquires ephys). Mixed file-name formats within the epoch dir
+    # (T07-00-00 for CSVs, T070000Z for newer bins) — both parse cleanly via
+    # swc.aeon.io.api.chunk_key.
+    "foraging_abc_2026_05_11": {
+        "experiment_name": "abcGolden01-aeon3",
+        "experiment_path": "AEON3/abcGolden01",
+        "epoch_dir": "2026-05-11T075134Z",
+        "devices_schema": "swc.aeon_exp.foragingABC.experiment:Experiment",
+        "arena_name": "circle-2m",
+        "lab": "SWC",
+        "location": "AEON3",
+        "experiment_type": "foraging",
+        "required_files": [
+            "Metadata.json",
+            "CameraNest/CameraNest_2026-05-11T07-00-00.csv",
+            "Feeder3/Feeder3_32_2026-05-11T070000Z.bin",
         ],
         "expected_camera_count": 13,
         "expected_feeder_count": 6,
@@ -286,8 +312,8 @@ def clean_streams_tables(pipeline_integration):
 
 @pytest.fixture(scope="session")
 def golden_dataset_config():
-    """Get the active golden dataset configuration."""
-    return GOLDEN_DATASETS["foraging_abc_2025_11_18"]
+    """Get the active behavior golden dataset configuration."""
+    return GOLDEN_DATASETS["foraging_abc_2026_05_11"]
 
 
 @pytest.fixture(scope="session")

--- a/tests/dj_pipeline/conftest.py
+++ b/tests/dj_pipeline/conftest.py
@@ -42,10 +42,9 @@ TEST_DB_PREFIX = os.environ.get("TEST_DB_PREFIX", "test_aeon_")
 # ============================================================================
 
 GOLDEN_DATASETS = {
-    # DEPRECATED: kept for one release as a rollback fallback. Superseded by
-    # foraging_abc_2026_05_11, which is the behavior arm of the same experiment
-    # as the ephys golden dataset (abcGolden01). Scheduled for removal in a
-    # follow-up PR once the new dataset has stabilized.
+    # Original behavior golden: ~1h of abcBehav0 on AEON3, full 13 cameras + 6
+    # feeders writing data to disk. Richest stream coverage (FeederEncoder
+    # 848k samples, CameraPosition 12k samples). No paired ephys.
     "foraging_abc_2025_11_18": {
         "experiment_name": "abcBehav0-aeon3",
         "experiment_path": "AEON3/abcBehav0",
@@ -65,9 +64,10 @@ GOLDEN_DATASETS = {
     },
     # Behavior arm of abcGolden01 — paired with foraging_abc_ephys_2026_05_11
     # (same experiment, same wall-clock window, AEON3 acquires behavior while
-    # AEONX1 acquires ephys). Mixed file-name formats within the epoch dir
-    # (T07-00-00 for CSVs, T070000Z for newer bins) — both parse cleanly via
-    # swc.aeon.io.api.chunk_key.
+    # AEONX1 acquires ephys). Sparser on-disk data than abcBehav0 (5 cameras,
+    # 4 feeders writing data) but exercises the newer file-name conventions:
+    # mixed T07-00-00 for CSVs and T070000Z for bins (both parse cleanly via
+    # swc.aeon.io.api.chunk_key).
     "foraging_abc_2026_05_11": {
         "experiment_name": "abcGolden01-aeon3",
         "experiment_path": "AEON3/abcGolden01",
@@ -310,10 +310,21 @@ def clean_streams_tables(pipeline_integration):
 # ============================================================================
 
 
-@pytest.fixture(scope="session")
-def golden_dataset_config():
-    """Get the active behavior golden dataset configuration."""
-    return GOLDEN_DATASETS["foraging_abc_2026_05_11"]
+@pytest.fixture(
+    scope="session",
+    params=[
+        pytest.param("foraging_abc_2025_11_18", id="abcBehav0_2025-11-18"),
+        pytest.param("foraging_abc_2026_05_11", id="abcGolden01_2026-05-11"),
+    ],
+)
+def golden_dataset_config(request):
+    """Behavior golden dataset configuration.
+
+    Parametrized over both registered behavior goldens — every test consuming
+    this fixture (and its session-scoped dependents like ``full_pipeline``,
+    ``test_experiment``, ``test_epochs``) runs once per dataset.
+    """
+    return GOLDEN_DATASETS[request.param]
 
 
 @pytest.fixture(scope="session")
@@ -359,8 +370,10 @@ def full_pipeline(dj_config_integration, streams_schema, golden_dataset_config):
         "streams": streams_module,
     }
 
-    # Teardown - drop all test schemas
-    _drop_test_schemas()
+    # No per-iteration teardown — golden_dataset_config is parametrized, so
+    # this fixture runs once per dataset. Dropping schemas between iterations
+    # would invalidate the cached streams_schema fixture. Final cleanup
+    # happens when the MySQL testcontainer shuts down at session end.
 
 
 @pytest.fixture(scope="session")

--- a/tests/dj_pipeline/test_acquisition_environment_integration.py
+++ b/tests/dj_pipeline/test_acquisition_environment_integration.py
@@ -72,18 +72,23 @@ class TestEnvironmentStreamPopulate:
 
     @pytest.mark.parametrize("table_name", ["EnvironmentState", "MessageLog", "LightEvents"])
     def test_populates(self, full_pipeline, populated_chunks, table_name):
-        """Smoke test: populate the table for one chunk, confirm row exists with expected keys.
+        """Smoke test: populate the table for one chunk, confirm row exists.
 
-        LightEvents may not exist in all datasets but golden dataset (ForagingABC) HAS light_events.
-        Sample_count may be 0 for chunks where there are no events, but the row must
-        exist and stream_df must NOT be null (reader was resolved).
+        Sample_count may be 0 (no events in chunk, or no source file on disk);
+        stream_df is the codec-decoded DataFrame (or None when the reader was
+        not resolved for this rig).
         """
+        import pandas as pd
+
         acquisition = full_pipeline["acquisition"]
         table = getattr(acquisition, table_name)
         table.populate(populated_chunks[:1], display_progress=False)
         row = (table & populated_chunks[0]).fetch1()
         assert row["sample_count"] >= 0
         assert isinstance(row["timestamps"], dict)
-        assert row["stream_df"] is not None
-        assert row["stream_df"]["stream_type"] == table_name
-        assert row["stream_df"]["device_name"] == "Environment"
+        # When the reader was resolved, stream_df decodes to a DataFrame whose
+        # length matches sample_count. None is acceptable when no reader exists
+        # (e.g. legacy rigs that don't expose the @data_reader method).
+        if row["stream_df"] is not None:
+            assert isinstance(row["stream_df"], pd.DataFrame)
+            assert len(row["stream_df"]) == row["sample_count"]

--- a/tests/dj_pipeline/test_full_ingestion.py
+++ b/tests/dj_pipeline/test_full_ingestion.py
@@ -462,6 +462,10 @@ class TestCodecStreamData:
                 obj.populate(max_calls=self.POPULATE_LIMIT, display_progress=False, suppress_errors=True)
                 query = obj & {"experiment_name": cfg["experiment_name"]} & "sample_count > 0"
                 if len(query):
+                    # Restrict to a single row — datasets may span multiple chunks
+                    # per (epoch, device); these tests only check codec correctness
+                    # on any one row.
+                    query = query & dj.Top(limit=1, order_by="chunk_start")
                     return name, obj, query
         return None
 
@@ -542,3 +546,66 @@ class TestCodecStreamData:
                     assert not attr.is_blob, (
                         f"{name}.{attr_name} is still a blob column — expected json or codec"
                     )
+
+
+class TestStreamPopulationInventory:
+    """Inventory which stream tables actually populate from the golden dataset.
+
+    Diagnostic — run with `-s` to see the printed inventory:
+
+        uv run pytest -m integration tests/dj_pipeline/test_full_ingestion.py::TestStreamPopulationInventory -s
+    """
+
+    POPULATE_LIMIT = 50
+
+    def test_inventory(self, test_epochs, full_pipeline, golden_dataset_config):
+        """Populate every stream table and report row + sample counts."""
+        import datajoint as dj
+
+        acquisition = full_pipeline["acquisition"]
+        streams = full_pipeline["streams"]
+        cfg = golden_dataset_config
+
+        acquisition.EpochConfig.populate({"experiment_name": cfg["experiment_name"]})
+        acquisition.Chunk.ingest_chunks(cfg["experiment_name"])
+
+        # Acquisition-module Environment streams (hand-written, not auto-generated)
+        acq_tables = {
+            "acquisition.EnvironmentState": acquisition.EnvironmentState,
+            "acquisition.MessageLog": acquisition.MessageLog,
+            "acquisition.LightEvents": acquisition.LightEvents,
+        }
+        # Dynamic streams tables (auto-generated from Pydantic schema)
+        stream_tables = {}
+        for name in dir(streams):
+            if name.startswith("_"):
+                continue
+            obj = getattr(streams, name, None)
+            if isinstance(obj, type) and issubclass(obj, dj.Imported) and obj is not dj.Imported:
+                stream_tables[f"streams.{name}"] = obj
+
+        all_tables = {**acq_tables, **stream_tables}
+        results: list[tuple[str, int, int]] = []
+        for label, tbl in all_tables.items():
+            tbl.populate(
+                max_calls=self.POPULATE_LIMIT, display_progress=False, suppress_errors=True
+            )
+            q = tbl & {"experiment_name": cfg["experiment_name"]}
+            row_count = len(q)
+            sample_total = 0
+            if row_count > 0 and "sample_count" in tbl.heading.attributes:
+                sample_total = sum(q.to_arrays("sample_count"))
+            results.append((label, row_count, sample_total))
+
+        # Print human-readable inventory
+        results.sort(key=lambda r: (-r[2], -r[1], r[0]))
+        print(f"\n=== Stream population inventory: {cfg['experiment_name']} ===")
+        print(f"{'table':<60} {'rows':>6} {'samples':>12}")
+        print("-" * 80)
+        for label, rows, samples in results:
+            print(f"{label:<60} {rows:>6} {samples:>12}")
+
+        # Only MessageLog is common to both old and new golden datasets;
+        # EnvironmentState exists in abcBehav0 only, LightEvents in neither.
+        msg_rows = next(r for n, r, _ in results if n == "acquisition.MessageLog")
+        assert msg_rows > 0, "acquisition.MessageLog did not populate from golden dataset"

--- a/uv.lock
+++ b/uv.lock
@@ -136,7 +136,7 @@ test = [
 test-golden = [
     { name = "pytest", specifier = ">=7.0" },
     { name = "pytest-cov" },
-    { name = "swc-aeon-rigs-foragingabc", git = "https://github.com/SainsburyWellcomeCentre/aeon_exp_foragingABC.git?branch=main" },
+    { name = "swc-aeon-rigs-foragingabc", git = "https://github.com/SainsburyWellcomeCentre/aeon_exp_foragingABC.git?branch=tn%2Fenv-data-readers" },
     { name = "testcontainers", extras = ["mysql"], specifier = ">=3.7" },
 ]
 
@@ -3335,7 +3335,7 @@ dependencies = [
 [[package]]
 name = "swc-aeon-rigs-foragingabc"
 version = "0.0.1"
-source = { git = "https://github.com/SainsburyWellcomeCentre/aeon_exp_foragingABC.git?branch=main#d75a553ad90b06f2206415760e0d9c917c51faa1" }
+source = { git = "https://github.com/SainsburyWellcomeCentre/aeon_exp_foragingABC.git?branch=tn%2Fenv-data-readers#d1e612d81766c9460127e4f3e645066349147726" }
 dependencies = [
     { name = "dotmap" },
     { name = "gitpython" },


### PR DESCRIPTION
## Summary
Parametrize the `golden_dataset_config` fixture over **both** behavior golden datasets so every behavior test runs once per dataset — true complement rather than a swap:

| Key | Experiment | Duration | On-disk profile |
|---|---|---|---|
| `foraging_abc_2025_11_18` (kept) | `abcBehav0-aeon3` | ~1h | Full 13 cameras + 6 feeders writing data; richest stream samples |
| `foraging_abc_2026_05_11` (new) | `abcGolden01-aeon3` | ~2h | 5 cameras + 4 feeders writing data; paired with the ephys golden |

The rich abcBehav0 dataset (FeederEncoder 848k samples, CameraPosition 12k) keeps full regression coverage; abcGolden01 adds coverage of the newer file-name conventions, the paired ephys+behavior wall-clock window, and exercises the 3 acquisition Environment stream tables that were previously dormant.

While migrating, surfaced and fixed three latent gaps:
1. The 3 `acquisition.Environment*` tables (`EnvironmentState`, `MessageLog`, `LightEvents`) had no active test coverage — `test_acquisition_environment_integration.py` was silently skipping because the upstream `Environment` device was missing `environment_state` and `message_log` data readers. Companion fix: SainsburyWellcomeCentre/aeon_exp_foragingABC#83.
2. `test_acquisition_environment_integration.py::test_populates` had a broken assertion that treated the codec-decoded `stream_df` DataFrame as a dict. Fixed to assert `DataFrame` + length matches `sample_count`.
3. New `TestStreamPopulationInventory` diagnostic test inventories every stream table after a full pipeline run, so future migrations can see at a glance which streams populate.

## Changes
- `tests/dj_pipeline/conftest.py`:
  - Add `foraging_abc_2026_05_11` registry entry (new behavior golden).
  - Parametrize `golden_dataset_config` over both datasets.
  - Drop the per-iteration `_drop_test_schemas()` in `full_pipeline` teardown (would invalidate the cached `streams_schema` between iterations). Cleanup happens at session end via `streams_schema` teardown + container shutdown.
- `aeon/dj_pipeline/acquisition.py`: add `abcGolden01-aeon3 -> CameraNest` to `_ref_device_mapping` (this rig has no `CameraTop` on disk).
- `tests/dj_pipeline/test_full_ingestion.py`: `_ensure_and_find` restricts query to one row via `dj.Top(limit=1, order_by="chunk_start")` (dataset-agnostic — abcGolden01 has multi-chunk epochs); add `TestStreamPopulationInventory`.
- `tests/dj_pipeline/test_acquisition_environment_integration.py`: fix the broken `stream_df` codec assertion.
- `docs/specs/SPEC_TESTING.md`: comparison table covering both datasets.
- `pyproject.toml` / `uv.lock`: temporarily point `swc-aeon-rigs-foragingabc` at `tn/env-data-readers` for validation; **revert back to `main` once #83 merges**.

## Test plan
- Integration suite: 99 passed, 3 skipped, 0 failed (was 65/15/0 on `--group test`; +34 invocations).
- `test_full_ingestion.py`: 23 passed + 1 graceful skip per dataset (= 48 invocations total).
- `test_acquisition_environment_integration.py`: 12 passed (was silently skipping all 6).
- Stream inventory confirms real ingestion: abcBehav0 → FeederEncoder 848k samples, CameraVideo 189k; abcGolden01 → CameraVideo 47k.
- Re-point `swc-aeon-rigs-foragingabc` to `main` once #83 merges (separate small commit).

## Stacked on
PR #585 (`tn/ephys-pipeline-restructure`). Merge order: #585 first, then this one. Re-targets to `main` once #585 merges.