### PR TITLE
Make zarr the default format for spike sorting intermediates

### DIFF
--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -565,28 +565,22 @@ class PostProcessing(dj.Computed):
 
         job_kwargs = postprocessing_params.get("job_kwargs", {"n_jobs": -1, "chunk_duration": "1s"})
 
-        analyzer_output_dir = output_dir / "sorting_analyzer"
-        for check_dir in [analyzer_output_dir, output_dir / "sorting_analyzer.zarr"]:
-            if check_dir.exists() and any(check_dir.iterdir()):
-                raise FileExistsError(
-                    f"Sorting analyzer directory already contains data: {check_dir}. "
-                    "Refusing to overwrite existing sorting data."
-                )
-
-        has_units = si_sorting.unit_ids.size > 0
-
-        # ---- run the analyzer extensions ----
-        if not has_units:
-            logger.info("No units found in sorting object. Skipping sorting analyzer.")
-            analyzer_output_dir.mkdir(
-                parents=True, exist_ok=True
-            )  # create empty directory anyway, for consistency
-            execution_duration = (datetime.now(UTC) - execution_time).total_seconds() / 3600
-            return analyzer_output_dir, execution_time, execution_duration
-
-        # Sorting Analyzer
         save_format = params.get("save_format", "zarr")
         analyzer_format = "zarr" if save_format == "zarr" else "binary_folder"
+        analyzer_name = "sorting_analyzer.zarr" if save_format == "zarr" else "sorting_analyzer"
+        analyzer_output_dir = output_dir / analyzer_name
+
+        if analyzer_output_dir.exists() and any(analyzer_output_dir.iterdir()):
+            raise FileExistsError(
+                f"Sorting analyzer directory already contains data: {analyzer_output_dir}. "
+                "Refusing to overwrite existing sorting data."
+            )
+
+        if si_sorting.unit_ids.size == 0:
+            logger.info("No units found in sorting object. Skipping sorting analyzer.")
+            analyzer_output_dir.mkdir(parents=True, exist_ok=True)
+            execution_duration = (datetime.now(UTC) - execution_time).total_seconds() / 3600
+            return analyzer_output_dir, execution_time, execution_duration
 
         sorting_analyzer = si.create_sorting_analyzer(
             sorting=si_sorting,
@@ -608,9 +602,6 @@ class PostProcessing(dj.Computed):
         }
 
         sorting_analyzer.compute(extensions_to_compute, **job_kwargs)
-
-        if analyzer_format == "zarr":
-            analyzer_output_dir = output_dir / "sorting_analyzer.zarr"
 
         execution_duration = (datetime.now(UTC) - execution_time).total_seconds() / 3600
 

--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -524,12 +524,12 @@ class PostProcessing(dj.Computed):
         )
 
         analyzer_output_dir = output_dir / "sorting_analyzer"
-        # Safety check: refuse to overwrite existing data on ceph
-        if analyzer_output_dir.exists() and any(analyzer_output_dir.iterdir()):
-            raise FileExistsError(
-                f"Sorting analyzer directory already contains data: {analyzer_output_dir}. "
-                "Refusing to overwrite existing sorting data."
-            )
+        for check_dir in [analyzer_output_dir, output_dir / "sorting_analyzer.zarr"]:
+            if check_dir.exists() and any(check_dir.iterdir()):
+                raise FileExistsError(
+                    f"Sorting analyzer directory already contains data: {check_dir}. "
+                    "Refusing to overwrite existing sorting data."
+                )
 
         has_units = si_sorting.unit_ids.size > 0
 
@@ -541,10 +541,13 @@ class PostProcessing(dj.Computed):
             return analyzer_output_dir, execution_time, execution_duration
 
         # Sorting Analyzer
+        save_format = params.get("save_format", "zarr")
+        analyzer_format = "zarr" if save_format == "zarr" else "binary_folder"
+
         sorting_analyzer = si.create_sorting_analyzer(
             sorting=si_sorting,
             recording=si_recording,
-            format="binary_folder",
+            format=analyzer_format,
             folder=analyzer_output_dir,
             sparse=True,
             overwrite=True,
@@ -560,6 +563,9 @@ class PostProcessing(dj.Computed):
         }
 
         sorting_analyzer.compute(extensions_to_compute, **job_kwargs)
+
+        if analyzer_format == "zarr":
+            analyzer_output_dir = output_dir / "sorting_analyzer.zarr"
 
         execution_duration = (datetime.now(UTC) - execution_time).total_seconds() / 3600
 

--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -446,16 +446,18 @@ class SpikeSorting(dj.Computed):
         if sorting_method == "kilosort4" and "clear_cache" not in sorting_params:
             sorting_params["clear_cache"] = True
 
+        # Prevent SpikeInterface from re-running write_binary_recording internally:
+        # https://github.com/SpikeInterface/spikeinterface/blob/705c932/src/spikeinterface/sorters/external/kilosortbase.py#L124
+        sorting_params["skip_kilosort_preprocessing"] = False
+
         if save_format == "zarr":
             zarr_path = Path(recording_file).parent / "recording.zarr"
             recording_for_sorting = si.load(zarr_path)
-            sorting_params["skip_kilosort_preprocessing"] = False
         else:
             binary_file_path = Path(recording_file).parent / "recording.dat"
             recording_for_sorting = load_and_verify_binary_file(
                 binary_file_path=binary_file_path, se_recording_obj=si_recording
             )
-            sorting_params["skip_kilosort_preprocessing"] = False
             if not recording_for_sorting.binary_compatible_with(
                 dtype="int16", time_axis=0, file_paths_length=1
             ):

--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -263,22 +263,38 @@ class PreProcessing(dj.Computed):
         si_recording = ephys_preproc(si_recording)
         si_recording.dump_to_pickle(file_path=recording_file, relative_to=output_dir)
 
-        # write binary into recording.dat
+        params = (SortingParamSet & key).fetch1("params")
+        save_format = params.get("save_format", "zarr")
+
         job_kwargs = {"n_jobs": -1, "chunk_duration": "2s"}
-        binary_file_path = recording_file.parent / "recording.dat"
-        if binary_file_path.exists():
-            load_and_verify_binary_file(
-                binary_file_path=binary_file_path,
-                se_recording_obj=si_recording)
-            logger.info(f"{binary_file_path} already exists. Skipping writing binary file.")
-        else:
-            logger.info(f"Writing binary recording to {binary_file_path}...")
-            si.core.write_binary_recording(
-                    recording=si_recording,
-                    file_paths=[binary_file_path],
-                    dtype="int16",
+
+        if save_format == "zarr":
+            zarr_path = recording_file.parent / "recording.zarr"
+            if zarr_path.exists():
+                logger.info(f"{zarr_path} already exists. Skipping zarr write.")
+            else:
+                _strip_non_numeric_properties(si_recording)
+                logger.info(f"Writing zarr recording to {zarr_path}...")
+                si_recording.save(
+                    format="zarr",
+                    folder=zarr_path,
                     **sorters.basesorter.get_job_kwargs(job_kwargs, True),
                 )
+        else:
+            binary_file_path = recording_file.parent / "recording.dat"
+            if binary_file_path.exists():
+                load_and_verify_binary_file(
+                    binary_file_path=binary_file_path,
+                    se_recording_obj=si_recording)
+                logger.info(f"{binary_file_path} already exists. Skipping writing binary file.")
+            else:
+                logger.info(f"Writing binary recording to {binary_file_path}...")
+                si.core.write_binary_recording(
+                        recording=si_recording,
+                        file_paths=[binary_file_path],
+                        dtype="int16",
+                        **sorters.basesorter.get_job_kwargs(job_kwargs, True),
+                    )
 
         return output_dir, execution_time, recording_dir
 
@@ -298,7 +314,9 @@ class PreProcessing(dj.Computed):
             [
                 {**key, "file_name": f.relative_to(output_dir.parent).as_posix(), "file": f}
                 for f in recording_dir.rglob("*")
-                if f.is_file() and f.name != "recording.dat"  # exclude the large binary file (too long for hashing)
+                if f.is_file()
+                and f.name != "recording.dat"
+                and not str(f).startswith(str(recording_dir / "recording.zarr"))
             ]
         )
 

--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -393,32 +393,30 @@ class SpikeSorting(dj.Computed):
         si_recording: si.BaseRecording = si.load(
             recording_file, base_folder=output_dir
         )
-        # load the pre-generated binary file - recording.dat
-        binary_file_path = Path(recording_file).parent / "recording.dat"
-        binary_rec = load_and_verify_binary_file(
-            binary_file_path=binary_file_path,
-            se_recording_obj=si_recording)
 
+        save_format = params.get("save_format", "zarr")
         sorting_params = params["SI_SORTING_PARAMS"].copy()
 
-        # explicitly set `skip_kilosort_preprocessing` to False
-        # to avoid SpikeInterface rerunning the `write_binary_recording` step
-        # https://github.com/SpikeInterface/spikeinterface/blob/705c9320c854f2a192fa200fe7866cec5a8ffca7/src/spikeinterface/sorters/external/kilosortbase.py#L124
-        sorting_params["skip_kilosort_preprocessing"] = False
-        
-        # Add Kilosort4 memory optimization parameters to reduce GPU memory usage
-        # clear_cache=True forces PyTorch to clear cached CUDA memory after memory-intensive steps,
-        # which helps free reserved but unallocated memory (like the 7.69 GiB in the error)
         if sorting_method == "kilosort4":
             if "clear_cache" not in sorting_params:
                 sorting_params["clear_cache"] = True
-                
-        if not binary_rec.binary_compatible_with(dtype="int16", time_axis=0, file_paths_length=1):
-            raise ValueError(f"Incompatible binary file for spike sorting: {binary_file_path}")
+
+        if save_format == "zarr":
+            zarr_path = Path(recording_file).parent / "recording.zarr"
+            recording_for_sorting = si.load(zarr_path)
+            sorting_params["skip_kilosort_preprocessing"] = False
+        else:
+            binary_file_path = Path(recording_file).parent / "recording.dat"
+            recording_for_sorting = load_and_verify_binary_file(
+                binary_file_path=binary_file_path,
+                se_recording_obj=si_recording)
+            sorting_params["skip_kilosort_preprocessing"] = False
+            if not recording_for_sorting.binary_compatible_with(dtype="int16", time_axis=0, file_paths_length=1):
+                raise ValueError(f"Incompatible binary file for spike sorting: {binary_file_path}")
 
         si_sorting: si.sorters.BaseSorter = si.sorters.run_sorter(
             sorter_name=sorter_name,
-            recording=binary_rec,
+            recording=recording_for_sorting,
             folder=sorting_output_dir,
             remove_existing_folder=True,
             verbose=True,

--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -1,23 +1,33 @@
-import datajoint as dj
-import numpy as np
-from pathlib import Path
-import pandas as pd
-import json
-from datetime import datetime, UTC
-import joblib
-import tempfile
-import os
-from typing import Dict, List, Tuple, Any, Optional
+"""DataJoint spike sorting pipeline tables and compute steps.
 
-from aeon.dj_pipeline import acquisition, ephys, get_schema_name
+This module defines the spike sorting workflow, including preprocessing,
+sorting, postprocessing, exports, and ingestion of sorted units/waveforms.
+"""
+
+import importlib
+import json
+import os
+import tempfile
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import datajoint as dj
+import joblib
+import numpy as np
+import pandas as pd
+from swc.aeon.io import api as io_api
+
+from aeon.dj_pipeline import get_schema_name
 from aeon.dj_pipeline.utils.paths import get_sorting_root_dir
 from aeon.dj_pipeline.utils.spike_sorting_utils import (
-    _resolve_analyzer_dir,
-    _strip_non_numeric_properties,
+    resolve_analyzer_dir,
+    strip_non_numeric_properties,
 )
 
-from swc.aeon.io import api as io_api
-from aeon.schema.ephys import social_ephys
+acquisition = importlib.import_module("aeon.dj_pipeline.acquisition")
+ephys = importlib.import_module("aeon.dj_pipeline.ephys")
 
 schema = dj.Schema(get_schema_name("spike_sorting"))
 logger = dj.logger
@@ -25,15 +35,16 @@ logger = dj.logger
 
 @schema
 class ElectrodeGroup(dj.Manual):
+    """A group of electrodes that are used for spike sorting.
+
+    All or subset of the electrodes from a particular electrode configuration
     """
-    A group of electrodes that are used for spike sorting.
-    All or subset of the electrodes from a particular electrode configuration 
-    """
+
     definition = """
     -> ephys.ElectrodeConfig
     electrode_group: varchar(16)  # e.g. 'all', 'shank1', etc.
     ---
-    electrode_group_description: varchar(1000) 
+    electrode_group_description: varchar(1000)
     electrode_count: int32
     """
 
@@ -72,7 +83,7 @@ class SortingMethod(dj.Lookup):
         ("kilosort2", "kilosort2 sorting method"),
         ("kilosort2.5", "kilosort2.5 sorting method"),
         ("kilosort3", "kilosort3 sorting method"),
-        ("kilosort4", "kilosort4 sorting method")
+        ("kilosort4", "kilosort4 sorting method"),
     ]
 
 
@@ -81,7 +92,7 @@ class SortingParamSet(dj.Lookup):
     definition = """ # Parameter set for spike sorting
     paramset_id: varchar(16)
     ---
-    -> SortingMethod    
+    -> SortingMethod
     paramset_description='': varchar(1000)
     params: <blob>  # dictionary of all applicable parameters
     """
@@ -89,13 +100,14 @@ class SortingParamSet(dj.Lookup):
 
 @schema
 class SortingTask(dj.Manual):
-    """
-    A manual table for defining a sorting task ready to be run.
+    """A manual table for defining a sorting task ready to be run.
+
     A sorting task is defined by a unique combination of:
     - ephys block
     - electrode group
     - sorting parameter set
     """
+
     definition = """
     # Manual table for defining a sorting task ready to be run
     -> ephys.EphysBlock
@@ -111,7 +123,7 @@ class PreProcessing(dj.Computed):
     ---
     execution_time: datetime   # datetime of the start of this step
     execution_duration: float64  # execution duration in hours
-    sorting_output_dir: varchar(255)  #  sorting output directory relative to the sorting root data directory
+    sorting_output_dir: varchar(255)  # sorting output directory relative to the sorting root data directory
     """
 
     class File(dj.Part):
@@ -123,14 +135,14 @@ class PreProcessing(dj.Computed):
         """
 
     @classmethod
-    def infer_output_dir(cls, key: Dict[str, Any], relative: bool = False, mkdir: bool = False) -> Path:
+    def infer_output_dir(cls, key: dict[str, Any], relative: bool = False, mkdir: bool = False) -> Path:
         """Generate standardized output directory path for sorting results.
-        
+
         Args:
             key: Sorting task key with experiment, block, and parameter info
             relative: Return path relative to sorting root directory
             mkdir: Create directory if it doesn't exist
-            
+
         Returns:
             Path to the sorting output directory
         """
@@ -139,13 +151,16 @@ class PreProcessing(dj.Computed):
         start_str = key["block_start"].strftime("%Y-%m-%dT%H-%M-%S")
         end_str = key["block_end"].strftime("%Y-%m-%dT%H-%M-%S")
 
-        output_dir = (sorting_root_dir / key["experiment_name"]
-                      / key["subject"]
-                      / f"insertion_{key['insertion_number']}"
-                      / "ephys_blocks"
-                      / f"{start_str}_{end_str}"
-                      / key["electrode_group"]
-                      / f"{sorting_method}_{key['paramset_id']}")
+        output_dir = (
+            sorting_root_dir
+            / key["experiment_name"]
+            / key["subject"]
+            / f"insertion_{key['insertion_number']}"
+            / "ephys_blocks"
+            / f"{start_str}_{end_str}"
+            / key["electrode_group"]
+            / f"{sorting_method}_{key['paramset_id']}"
+        )
 
         if mkdir:
             output_dir.mkdir(parents=True, exist_ok=True)
@@ -154,6 +169,7 @@ class PreProcessing(dj.Computed):
         return output_dir.relative_to(sorting_root_dir) if relative else output_dir
 
     def make_fetch(self, key):
+        """Fetch ephys data and metadata, prepare output directory, and define preprocessing parameters."""
         # Safety check: refuse to overwrite existing data on ceph
         output_dir = self.infer_output_dir(key)
         if output_dir.exists() and any(output_dir.iterdir()):
@@ -169,18 +185,19 @@ class PreProcessing(dj.Computed):
 
         # Load ephys data
         ephys_files, dir_types = (
-            ephys.EphysChunk.File & (ephys.EphysBlockInfo.Chunk & key)
+            ephys.EphysChunk.File
+            & (ephys.EphysBlockInfo.Chunk & key)
             & "file_name LIKE '%AmplifierData%.bin'"
         ).to_arrays("file_path", "directory_type", order_by="chunk_start")
 
         # Channels
         electrodes_query = (
-                ephys.EphysBlockInfo.Channel
-                * ephys.ElectrodeConfig.Electrode
-                * ElectrodeGroup.Electrode
-                * ephys.ProbeType.Electrode
-                & key
-            )
+            ephys.EphysBlockInfo.Channel
+            * ephys.ElectrodeConfig.Electrode
+            * ElectrodeGroup.Electrode
+            * ephys.ProbeType.Electrode
+            & key
+        )
         electrodes_df = electrodes_query.to_pandas().reset_index()
         electrodes_df.drop(columns=list(key), inplace=True, errors="ignore")
 
@@ -190,16 +207,37 @@ class PreProcessing(dj.Computed):
         gain_to_uV = 3.05176
         offset_to_uV = -2048 * gain_to_uV
 
-        return ephys_files, dir_types, electrodes_df, num_channels, fs_hz, gain_to_uV, offset_to_uV, output_dir, recording_file, recording_dir
+        return (
+            ephys_files,
+            dir_types,
+            electrodes_df,
+            num_channels,
+            fs_hz,
+            gain_to_uV,
+            offset_to_uV,
+            output_dir,
+            recording_file,
+            recording_dir,
+        )
 
-    def make_compute(self, key: Dict[str, Any], ephys_files: List[str], dir_types: List[str], 
-                     electrodes_df: pd.DataFrame, num_channels: int, fs_hz: float, 
-                     gain_to_uV: float, offset_to_uV: float, output_dir: Path, 
-                     recording_file: Path, recording_dir: Path) -> Tuple[Path, datetime, Path]:
+    def make_compute(
+        self,
+        key: dict[str, Any],
+        ephys_files: list[str],
+        dir_types: list[str],
+        electrodes_df: pd.DataFrame,
+        num_channels: int,
+        fs_hz: float,
+        gain_to_uV: float,
+        offset_to_uV: float,
+        output_dir: Path,
+        recording_file: Path,
+        recording_dir: Path,
+    ) -> tuple[Path, datetime, Path]:
         """Preprocess ephys data for spike sorting.
-        
+
         Performs data concatenation, channel selection, filtering, and probe setup.
-        
+
         Args:
             key: Sorting task key
             ephys_files: List of ephys file paths
@@ -212,20 +250,20 @@ class PreProcessing(dj.Computed):
             output_dir: Output directory path
             recording_file: Path to save recording object
             recording_dir: Directory for recording files
-            
+
         Returns:
             Tuple of (output_dir, execution_time, recording_dir)
         """
         import probeinterface as pi
         import spikeinterface as si
         import spikeinterface.extractors as se
-        from spikeinterface import sorters, preprocessing
+        from spikeinterface import sorters
 
         execution_time = datetime.now(UTC)
 
         # Concatenate recordings
         si_recs = []
-        for f, d in zip(ephys_files, dir_types):
+        for f, d in zip(ephys_files, dir_types, strict=False):
             ephys_dir = acquisition.Experiment.get_data_directory(key, directory_type=d)
             si_rec = se.read_binary(
                 ephys_dir / f,
@@ -233,7 +271,8 @@ class PreProcessing(dj.Computed):
                 dtype=np.uint16,
                 num_channels=num_channels,
                 gain_to_uV=gain_to_uV,
-                offset_to_uV=offset_to_uV)
+                offset_to_uV=offset_to_uV,
+            )
             si_recs.append(si_rec)
         si_recording = si.concatenate_recordings(si_recs)
 
@@ -242,7 +281,7 @@ class PreProcessing(dj.Computed):
         chn2remove = set(si_recording.channel_ids) - set(in_use_chn_ids)
         si_recording = si_recording.remove_channels(list(chn2remove))
         in_use_chn_ind = [si_recording.channel_ids.tolist().index(chn_id) for chn_id in in_use_chn_ids]
-        electrodes_df.channel_idx = in_use_chn_ind
+        electrodes_df["channel_idx"] = in_use_chn_ind
 
         # Create SI probe object
         probe_df = electrodes_df.copy()
@@ -277,7 +316,7 @@ class PreProcessing(dj.Computed):
             if zarr_path.exists():
                 logger.info(f"{zarr_path} already exists. Skipping zarr write.")
             else:
-                _strip_non_numeric_properties(si_recording)
+                strip_non_numeric_properties(si_recording)
                 logger.info(f"Writing zarr recording to {zarr_path}...")
                 si_recording.save(
                     format="zarr",
@@ -288,30 +327,28 @@ class PreProcessing(dj.Computed):
             binary_file_path = recording_file.parent / "recording.dat"
             if binary_file_path.exists():
                 load_and_verify_binary_file(
-                    binary_file_path=binary_file_path,
-                    se_recording_obj=si_recording)
+                    binary_file_path=binary_file_path, se_recording_obj=si_recording
+                )
                 logger.info(f"{binary_file_path} already exists. Skipping writing binary file.")
             else:
                 logger.info(f"Writing binary recording to {binary_file_path}...")
                 si.core.write_binary_recording(
-                        recording=si_recording,
-                        file_paths=[binary_file_path],
-                        dtype="int16",
-                        **sorters.basesorter.get_job_kwargs(job_kwargs, True),
-                    )
+                    recording=si_recording,
+                    file_paths=[binary_file_path],
+                    dtype="int16",
+                    **sorters.basesorter.get_job_kwargs(job_kwargs, True),
+                )
 
         return output_dir, execution_time, recording_dir
 
     def make_insert(self, key, output_dir, execution_time, recording_dir):
+        """Insert preprocessing results into the database, including file references."""
         self.insert1(
             {
                 **key,
                 "sorting_output_dir": output_dir.relative_to(get_sorting_root_dir()).as_posix(),
                 "execution_time": execution_time,
-                "execution_duration": (
-                    datetime.now(UTC) - execution_time
-                ).total_seconds()
-                / 3600,
+                "execution_duration": (datetime.now(UTC) - execution_time).total_seconds() / 3600,
             }
         )
         self.File.insert(
@@ -343,47 +380,54 @@ class SpikeSorting(dj.Computed):
         """
 
     def make_fetch(self, key):
+        """Fetch recording and parameters for spike sorting."""
         sorting_root_dir = get_sorting_root_dir()
         # Load recording object.
-        sorting_method, params = (
-                SortingTask * SortingParamSet & key
-        ).fetch1("sorting_method", "params")
+        sorting_method, params = (SortingTask * SortingParamSet & key).fetch1("sorting_method", "params")
         output_dir = sorting_root_dir / (PreProcessing & key).fetch1("sorting_output_dir")
 
         try:
             recording_file = Path(
-                (PreProcessing.File
-                 & key & "file_name LIKE '%si_recording.pkl'").fetch1("file").full_path)
+                (PreProcessing.File & key & "file_name LIKE '%si_recording.pkl'").fetch1("file").full_path
+            )
         except dj.errors.DataJointError:
             recording_file = output_dir.parent / "recording" / "si_recording.pkl"
 
         return recording_file, output_dir, params, sorting_method
 
-    def make_compute(self, key: Dict[str, Any], recording_file: Path, output_dir: Path, 
-                     params: Dict[str, Any], sorting_method: str) -> Tuple[Path, datetime, float]:
+    def make_compute(
+        self,
+        key: dict[str, Any],
+        recording_file: Path,
+        output_dir: Path,
+        params: dict[str, Any],
+        sorting_method: str,
+    ) -> tuple[Path, datetime, float]:
         """Run spike sorting using specified algorithm and parameters.
-        
+
         Args:
             key: Sorting task key
             recording_file: Path to preprocessed recording
             output_dir: Base output directory
             params: Sorting parameters dictionary
             sorting_method: Name of sorting algorithm (e.g., kilosort2)
-            
+
         Returns:
             Tuple of (sorting_output_dir, execution_time, execution_duration)
         """
         # Set PyTorch CUDA memory allocator configuration BEFORE importing PyTorch
         # Note: PYTORCH_CUDA_ALLOC_CONF must be set BEFORE PyTorch is imported to take effect.
         # If not already set (e.g., from bash script), use:
-        # - expandable_segments:True allows PyTorch to dynamically expand memory segments to reduce fragmentation
+        # - expandable_segments:True allows PyTorch to dynamically expand memory segments
+        #   to reduce fragmentation
         # - garbage_collection_threshold:0.6 triggers GC when 60% of reserved memory is unused,
         #   helping free reserved but unallocated memory (like the 7.69 GiB in the error)
         if "PYTORCH_CUDA_ALLOC_CONF" not in os.environ:
-            os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True,garbage_collection_threshold:0.6"
-        
+            os.environ["PYTORCH_CUDA_ALLOC_CONF"] = (
+                "expandable_segments:True,garbage_collection_threshold:0.6"
+            )
+
         import spikeinterface as si
-        from spikeinterface import sorters
 
         execution_time = datetime.now(UTC)
         sorter_name = sorting_method.replace(".", "_")
@@ -394,16 +438,13 @@ class SpikeSorting(dj.Computed):
                 f"Sorting output directory already contains data: {sorting_output_dir}. "
                 "Refusing to overwrite existing sorting data."
             )
-        si_recording: si.BaseRecording = si.load(
-            recording_file, base_folder=output_dir
-        )
+        si_recording: si.BaseRecording = si.load(recording_file, base_folder=output_dir)
 
         save_format = params.get("save_format", "zarr")
         sorting_params = params["SI_SORTING_PARAMS"].copy()
 
-        if sorting_method == "kilosort4":
-            if "clear_cache" not in sorting_params:
-                sorting_params["clear_cache"] = True
+        if sorting_method == "kilosort4" and "clear_cache" not in sorting_params:
+            sorting_params["clear_cache"] = True
 
         if save_format == "zarr":
             zarr_path = Path(recording_file).parent / "recording.zarr"
@@ -412,10 +453,12 @@ class SpikeSorting(dj.Computed):
         else:
             binary_file_path = Path(recording_file).parent / "recording.dat"
             recording_for_sorting = load_and_verify_binary_file(
-                binary_file_path=binary_file_path,
-                se_recording_obj=si_recording)
+                binary_file_path=binary_file_path, se_recording_obj=si_recording
+            )
             sorting_params["skip_kilosort_preprocessing"] = False
-            if not recording_for_sorting.binary_compatible_with(dtype="int16", time_axis=0, file_paths_length=1):
+            if not recording_for_sorting.binary_compatible_with(
+                dtype="int16", time_axis=0, file_paths_length=1
+            ):
                 raise ValueError(f"Incompatible binary file for spike sorting: {binary_file_path}")
 
         si_sorting: si.sorters.BaseSorter = si.sorters.run_sorter(
@@ -437,13 +480,8 @@ class SpikeSorting(dj.Computed):
         return sorting_output_dir, execution_time, execution_duration
 
     def make_insert(self, key, sorting_output_dir, execution_time, execution_duration):
-        self.insert1(
-            {
-                **key,
-                "execution_time": execution_time,
-                "execution_duration": execution_duration
-            }
-        )
+        """Insert spike sorting results into the database, including file references."""
+        self.insert1({**key, "execution_time": execution_time, "execution_duration": execution_duration})
         self.File.insert(
             [
                 {**key, "file_name": f.relative_to(sorting_output_dir).as_posix(), "file": f}
@@ -471,61 +509,59 @@ class PostProcessing(dj.Computed):
         """
 
     def make_fetch(self, key):
+        """Fetch recording and sorting results for post-processing."""
         sorting_root_dir = get_sorting_root_dir()
         # Load recording object.
-        sorting_method, params = (
-                SortingTask * SortingParamSet & key
-        ).fetch1("sorting_method", "params")
+        _sorting_method, params = (SortingTask * SortingParamSet & key).fetch1("sorting_method", "params")
         output_dir = sorting_root_dir / (PreProcessing & key).fetch1("sorting_output_dir")
 
         try:
             recording_file = Path(
-                (PreProcessing.File
-                 & key & "file_name LIKE '%si_recording.pkl'").fetch1("file").full_path)
+                (PreProcessing.File & key & "file_name LIKE '%si_recording.pkl'").fetch1("file").full_path
+            )
         except dj.errors.DataJointError:
             recording_file = output_dir.parent / "recording" / "si_recording.pkl"
         try:
             sorting_file = Path(
-                (SpikeSorting.File
-                 & key & "file_name LIKE '%si_sorting.pkl'").fetch1("file").full_path)
+                (SpikeSorting.File & key & "file_name LIKE '%si_sorting.pkl'").fetch1("file").full_path
+            )
         except dj.errors.DataJointError:
             sorting_file = output_dir / "spike_sorting" / "si_sorting.pkl"
 
         return recording_file, sorting_file, output_dir, params
 
-    def make_compute(self, key: Dict[str, Any], recording_file: Path, sorting_file: Path, 
-                     output_dir: Path, params: Dict[str, Any]) -> Tuple[Path, datetime, float]:
+    def make_compute(
+        self,
+        key: dict[str, Any],
+        recording_file: Path,
+        sorting_file: Path,
+        output_dir: Path,
+        params: dict[str, Any],
+    ) -> tuple[Path, datetime, float]:
         """Post-process spike sorting results with quality assessment.
-        
+
         Runs SpikeInterface sorting analyzer to compute quality metrics and extensions.
-        
+
         Args:
             key: Sorting task key
             recording_file: Path to recording object
             sorting_file: Path to sorting results
             output_dir: Base output directory
             params: Post-processing parameters
-            
+
         Returns:
             Tuple of (analyzer_output_dir, execution_time, execution_duration)
         """
         import spikeinterface as si
-        from spikeinterface import sorters
 
         execution_time = datetime.now(UTC)
 
-        si_recording: si.BaseRecording = si.load(
-            recording_file, base_folder=output_dir
-        )
-        si_sorting: si.sorters.BaseSorter = si.load(
-            sorting_file, base_folder=output_dir
-        )
+        si_recording: si.BaseRecording = si.load(recording_file, base_folder=output_dir)
+        si_sorting: si.sorters.BaseSorter = si.load(sorting_file, base_folder=output_dir)
 
         postprocessing_params = params["SI_POSTPROCESSING_PARAMS"]
 
-        job_kwargs = postprocessing_params.get(
-            "job_kwargs", {"n_jobs": -1, "chunk_duration": "1s"}
-        )
+        job_kwargs = postprocessing_params.get("job_kwargs", {"n_jobs": -1, "chunk_duration": "1s"})
 
         analyzer_output_dir = output_dir / "sorting_analyzer"
         for check_dir in [analyzer_output_dir, output_dir / "sorting_analyzer.zarr"]:
@@ -540,7 +576,9 @@ class PostProcessing(dj.Computed):
         # ---- run the analyzer extensions ----
         if not has_units:
             logger.info("No units found in sorting object. Skipping sorting analyzer.")
-            analyzer_output_dir.mkdir(parents=True, exist_ok=True)  # create empty directory anyway, for consistency
+            analyzer_output_dir.mkdir(
+                parents=True, exist_ok=True
+            )  # create empty directory anyway, for consistency
             execution_duration = (datetime.now(UTC) - execution_time).total_seconds() / 3600
             return analyzer_output_dir, execution_time, execution_duration
 
@@ -558,7 +596,8 @@ class PostProcessing(dj.Computed):
         )
 
         # The order of extension computation is drawn from sorting_analyzer.get_computable_extensions()
-        # each extension is parameterized by params specified in extensions_params dictionary (skip if not specified)
+        # each extension is parameterized by params specified in extensions_params dictionary
+        # (skip if not specified)
         extensions_params = postprocessing_params.get("extensions", {})
         extensions_to_compute = {
             ext_name: extensions_params[ext_name]
@@ -576,6 +615,7 @@ class PostProcessing(dj.Computed):
         return analyzer_output_dir, execution_time, execution_duration
 
     def make_insert(self, key, analyzer_output_dir, execution_time, execution_duration):
+        """Insert post-processing results into the database, including file references."""
         self.insert1(
             {
                 **key,
@@ -610,15 +650,15 @@ class SIExport(dj.Computed):
         """
 
     def make(self, key):
+        """Export spike sorting results to standardised formats for downstream analysis and sharing."""
         import spikeinterface as si
-        from spikeinterface import exporters
 
         execution_time = datetime.now(UTC)
 
         sorting_root_dir = get_sorting_root_dir()
         output_dir = sorting_root_dir / (PreProcessing & key).fetch1("sorting_output_dir")
 
-        analyzer_output_dir = _resolve_analyzer_dir(output_dir)
+        analyzer_output_dir = resolve_analyzer_dir(output_dir)
         sorting_analyzer = si.load_sorting_analyzer(folder=analyzer_output_dir)
 
         execution_duration_hours = (datetime.now(UTC) - execution_time).total_seconds() / 3600
@@ -680,15 +720,11 @@ class SortedSpikes(dj.Imported):
         spike_indices: <blob@dj_store>  # array of spike indices into the concatenated binary data (from preprocessing)
         spike_sites : <blob@dj_store>   # array of electrode associated with each spike
         spike_depths=null : <blob@dj_store>  # (um) array of depths associated with each spike, relative to the (0, 0) of the probe
-        """
+        """  # noqa:E501
 
     def make(self, key):
-        """
-        From sorted spikes output, extract units, spike times, electrode, etc.
-        Also, synchronize the spike times to the HARP clock.
-        """
+        """Extract units, spike times, and electrodes from sorting output; sync to HARP clock."""
         import spikeinterface as si
-        from spikeinterface import sorters
 
         execution_time = datetime.now(UTC)
 
@@ -697,18 +733,18 @@ class SortedSpikes(dj.Imported):
 
         # Get channel and electrode-site mapping
         electrode_query = (
-                ephys.EphysBlockInfo.Channel.proj(..., "-channel_name")
-                * ephys.ElectrodeConfig.Electrode
-                * ElectrodeGroup.Electrode
-                * ephys.ProbeType.Electrode.proj("electrode_name")
-                & key
+            ephys.EphysBlockInfo.Channel.proj(..., "-channel_name")
+            * ephys.ElectrodeConfig.Electrode
+            * ElectrodeGroup.Electrode
+            * ephys.ProbeType.Electrode.proj("electrode_name")
+            & key
         )
 
         # Check if there's an official curation for this block
         # If so, use the curated analyzer; otherwise use the raw analyzer
         # Use lazy import to avoid circular dependency
         curation_id = -1
-        analyzer_output_dir = _resolve_analyzer_dir(output_dir)
+        analyzer_output_dir = resolve_analyzer_dir(output_dir)
         try:
             # Lazy import to avoid circular dependency
             import importlib
@@ -725,7 +761,9 @@ class SortedSpikes(dj.Imported):
                         spike_sorting_curation_module.ManualCuration.File
                         & key
                         & {"curation_id": curation_id, "file_name": "curation_applied_analyzer"}
-                    ).fetch1("file").full_path
+                    )
+                    .fetch1("file")
+                    .full_path
                 )
                 logger.info(
                     f"Using curated analyzer (curation_id={curation_id}) from: {analyzer_output_dir}"
@@ -738,18 +776,13 @@ class SortedSpikes(dj.Imported):
             logger.info(f"Using raw analyzer (curation check failed: {e})")
 
         sorting_file = output_dir / "spike_sorting" / "si_sorting.pkl"
-        si_sorting_: si.sorters.BaseSorter = si.load(
-            sorting_file, base_folder=output_dir
-        )
+        si_sorting_: si.sorters.BaseSorter = si.load(sorting_file, base_folder=output_dir)
 
         self.insert1(
             {
                 **key,
                 "execution_time": execution_time,
-                "execution_duration": (
-                    datetime.now(UTC) - execution_time
-                ).total_seconds()
-                / 3600,
+                "execution_duration": (datetime.now(UTC) - execution_time).total_seconds() / 3600,
                 "curation_id": curation_id,
             }
         )
@@ -761,27 +794,24 @@ class SortedSpikes(dj.Imported):
         si_sorting = sorting_analyzer.sorting
 
         # Find representative channel for each unit
-        unit_peak_channel: dict[int, np.ndarray] = (
-            si.ChannelSparsity.from_best_channels(
-                sorting_analyzer,
-                1,
-            ).unit_id_to_channel_indices
-        )
-        unit_peak_channel: dict[int, int] = {
-            u: chn[0] for u, chn in unit_peak_channel.items()
-        }
+        unit_channel_indices: dict[int, np.ndarray] = si.ChannelSparsity.from_best_channels(
+            sorting_analyzer,
+            1,
+        ).unit_id_to_channel_indices
+        unit_peak_channel: dict[int, int] = {u: chn[0] for u, chn in unit_channel_indices.items()}
 
         spike_count_dict: dict[int, int] = si_sorting.count_num_spikes_per_unit()
         # {unit: spike_count}
 
         # create channel2electrode_map
-        electrode_map: dict[int, dict] = {
-            elec["electrode"]: elec for elec in electrode_query.to_dicts()
-        }
+        electrode_map: dict[int, dict] = {elec["electrode"]: elec for elec in electrode_query.to_dicts()}
         channel2electrode_map = {
             chn_idx: electrode_map[int(elec_id)]
-            for chn_idx, elec_id in zip(sorting_analyzer.get_probe().device_channel_indices,
-                                        sorting_analyzer.get_probe().contact_ids)
+            for chn_idx, elec_id in zip(
+                sorting_analyzer.get_probe().device_channel_indices,
+                sorting_analyzer.get_probe().contact_ids,
+                strict=False,
+            )
         }
 
         # Get unit id to quality label mapping
@@ -799,24 +829,23 @@ class SortedSpikes(dj.Imported):
             sorting_analyzer, outputs="index"
         )
         spikes_df = pd.DataFrame(
-            sorting_analyzer.sorting.to_spike_vector(
-                extremum_channel_inds=extremum_channel_inds
-            )
+            sorting_analyzer.sorting.to_spike_vector(extremum_channel_inds=extremum_channel_inds)
         )
-        for unit_idx, unit_id in enumerate(si_sorting.unit_ids):
-            unit_id = int(unit_id)
+        for unit_idx, raw_unit_id in enumerate(si_sorting.unit_ids):
+            unit_id = int(raw_unit_id)
             unit_spikes_df = spikes_df[spikes_df.unit_index == unit_idx]
             spike_sites = np.array(
-                [
-                    channel2electrode_map[chn_idx]["electrode"]
-                    for chn_idx in unit_spikes_df.channel_index
-                ]
+                [channel2electrode_map[chn_idx]["electrode"] for chn_idx in unit_spikes_df.channel_index]
             )
             unit_spikes_loc = spike_locations.get_data()[unit_spikes_df.index]
-            _, spike_depths = zip(*unit_spikes_loc)  # x-coordinates, y-coordinates
+            _, spike_depths = zip(*unit_spikes_loc, strict=True)  # x-coordinates, y-coordinates
             spike_indices = si_sorting.get_unit_spike_train(unit_id)
 
-            assert len(spike_indices) == len(spike_sites) == len(spike_depths)
+            if not (len(spike_indices) == len(spike_sites) == len(spike_depths)):
+                raise ValueError(
+                    f"Unit {unit_id}: mismatched spike data lengths "
+                    f"(indices={len(spike_indices)}, sites={len(spike_sites)}, depths={len(spike_depths)})"
+                )
 
             self.Unit.insert1(
                 {
@@ -828,7 +857,8 @@ class SortedSpikes(dj.Imported):
                     "spike_count": spike_count_dict[unit_id],
                     "spike_sites": spike_sites,
                     "spike_depths": spike_depths,
-                }, ignore_extra_fields=True
+                },
+                ignore_extra_fields=True,
             )
 
 
@@ -853,12 +883,13 @@ class Waveform(dj.Imported):
         # Spike waveforms and their mean across spikes for the given unit at the given electrode
         -> master
         -> SortedSpikes.Unit
-        -> ephys.ElectrodeConfig.Electrode  
-        --- 
-        channel_waveform: <blob>   # (uV) mean waveform across spikes of the given unit at the given electrode
+        -> ephys.ElectrodeConfig.Electrode
+        ---
+        channel_waveform: <blob>   # (uV) mean waveform across spikes of a unit at an electrode
         """
-        
+
     def make(self, key):
+        """Extract spike waveforms for each unit and electrode from sorting analyzer templates."""
         import spikeinterface as si
 
         sorting_root_dir = get_sorting_root_dir()
@@ -866,11 +897,11 @@ class Waveform(dj.Imported):
 
         # Get channel and electrode-site mapping
         electrode_query = (
-                ephys.EphysBlockInfo.Channel.proj(..., "-channel_name")
-                * ephys.ElectrodeConfig.Electrode
-                * ElectrodeGroup.Electrode
-                * ephys.ProbeType.Electrode.proj("electrode_name")
-                & key
+            ephys.EphysBlockInfo.Channel.proj(..., "-channel_name")
+            * ephys.ElectrodeConfig.Electrode
+            * ElectrodeGroup.Electrode
+            * ephys.ProbeType.Electrode.proj("electrode_name")
+            & key
         )
 
         # Get curation_id from SortedSpikes to determine which analyzer to use
@@ -878,6 +909,7 @@ class Waveform(dj.Imported):
         if curation_id != -1:
             # Fetch applied analyzer path from database
             import importlib
+
             spike_sorting_curation_module = importlib.import_module(
                 "aeon.dj_pipeline.spike_sorting_curation"
             )
@@ -886,13 +918,13 @@ class Waveform(dj.Imported):
                     spike_sorting_curation_module.ManualCuration.File
                     & key
                     & {"curation_id": curation_id, "file_name": "curation_applied_analyzer"}
-                ).fetch1("file").full_path
+                )
+                .fetch1("file")
+                .full_path
             )
-            logger.info(
-                f"Using curated analyzer (curation_id={curation_id}) from: {analyzer_output_dir}"
-            )
+            logger.info(f"Using curated analyzer (curation_id={curation_id}) from: {analyzer_output_dir}")
         else:
-            analyzer_output_dir = _resolve_analyzer_dir(output_dir)
+            analyzer_output_dir = resolve_analyzer_dir(output_dir)
             logger.info("Using raw analyzer (curation_id=-1)")
 
         sorting_analyzer = si.load_sorting_analyzer(folder=analyzer_output_dir)
@@ -900,35 +932,30 @@ class Waveform(dj.Imported):
         self.insert1(key)
 
         # Find representative channel for each unit
-        unit_peak_channel: dict[int, np.ndarray] = (
-            si.ChannelSparsity.from_best_channels(
-                sorting_analyzer, 1
-            ).unit_id_to_channel_indices
-        )  # {unit: peak_channel_index}
+        unit_peak_channel: dict[int, np.ndarray] = si.ChannelSparsity.from_best_channels(
+            sorting_analyzer, 1
+        ).unit_id_to_channel_indices  # {unit: peak_channel_index}
         unit_peak_channel = {u: chn[0] for u, chn in unit_peak_channel.items()}
 
         # create channel2electrode_map
-        electrode_map: dict[int, dict] = {
-            elec["electrode"]: elec for elec in electrode_query.to_dicts()
-        }
+        electrode_map: dict[int, dict] = {elec["electrode"]: elec for elec in electrode_query.to_dicts()}
         channel2electrode_map = {
             chn_idx: electrode_map[int(elec_id)]
-            for chn_idx, elec_id in zip(sorting_analyzer.get_probe().device_channel_indices,
-                                        sorting_analyzer.get_probe().contact_ids)
+            for chn_idx, elec_id in zip(
+                sorting_analyzer.get_probe().device_channel_indices,
+                sorting_analyzer.get_probe().contact_ids,
+                strict=True,
+            )
         }
 
         templates = sorting_analyzer.get_extension("templates")
 
         for unit in (SortedSpikes.Unit & key).keys(order_by="unit"):
             # Get mean waveform for this unit from all channels - (sample x channel)
-            unit_waveforms = templates.get_unit_template(
-                unit_id=unit["unit"], operator="average"
-            )
+            unit_waveforms = templates.get_unit_template(unit_id=unit["unit"], operator="average")
             unit_peak_waveform = {
                 **unit,
-                "unit_waveform": unit_waveforms[
-                                           :, unit_peak_channel[unit["unit"]]
-                                           ],
+                "unit_waveform": unit_waveforms[:, unit_peak_channel[unit["unit"]]],
             }
 
             unit_electrode_waveforms = [
@@ -949,7 +976,7 @@ class SortingQuality(dj.Imported):
     definition = """
     -> SortedSpikes
     """
-    
+
     class Metric(dj.Part):
         definition = """  # Quality metrics for a given unit
         -> master
@@ -959,6 +986,7 @@ class SortingQuality(dj.Imported):
         """
 
     def make(self, key):
+        """Extract quality metrics for each unit from sorting analyzer extensions."""
         import spikeinterface as si
 
         sorting_root_dir = get_sorting_root_dir()
@@ -969,6 +997,7 @@ class SortingQuality(dj.Imported):
         if curation_id != -1:
             # Fetch applied analyzer path from database
             import importlib
+
             spike_sorting_curation_module = importlib.import_module(
                 "aeon.dj_pipeline.spike_sorting_curation"
             )
@@ -977,13 +1006,13 @@ class SortingQuality(dj.Imported):
                     spike_sorting_curation_module.ManualCuration.File
                     & key
                     & {"curation_id": curation_id, "file_name": "curation_applied_analyzer"}
-                ).fetch1("file").full_path
+                )
+                .fetch1("file")
+                .full_path
             )
-            logger.info(
-                f"Using curated analyzer (curation_id={curation_id}) from: {analyzer_output_dir}"
-            )
+            logger.info(f"Using curated analyzer (curation_id={curation_id}) from: {analyzer_output_dir}")
         else:
-            analyzer_output_dir = _resolve_analyzer_dir(output_dir)
+            analyzer_output_dir = resolve_analyzer_dir(output_dir)
             logger.info("Using raw analyzer (curation_id=-1)")
 
         sorting_analyzer = si.load_sorting_analyzer(folder=analyzer_output_dir)
@@ -991,16 +1020,12 @@ class SortingQuality(dj.Imported):
         self.insert1(key)
 
         qc_metrics = sorting_analyzer.get_extension("quality_metrics").get_data()
-        template_metrics = sorting_analyzer.get_extension(
-            "template_metrics"
-        ).get_data()
+        template_metrics = sorting_analyzer.get_extension("template_metrics").get_data()
         metrics_df = pd.concat([qc_metrics, template_metrics], axis=1)
 
-        for unit_key in (SortedSpikes.Unit & key).keys():
+        for unit_key in (SortedSpikes.Unit & key).keys():  # noqa: SIM118
             unit_qc = metrics_df.loc[unit_key["unit"]].to_dict()
-            self.Metric.insert1(
-                {**unit_key, "qc_metrics": json.dumps(unit_qc, default=str)}
-            )
+            self.Metric.insert1({**unit_key, "qc_metrics": json.dumps(unit_qc, default=str)})
 
 
 @schema
@@ -1016,15 +1041,15 @@ class SyncedSpikes(dj.Imported):
         -> ephys.EphysChunk
         ---
         spike_count: int32     # how many spikes in this recording for this unit
-        spike_times: <blob@dj_store>  # datetime64[ns] synchronized spike times (in HARP clock) for the respective EphysChunk
+        spike_times: <blob@dj_store>  # datetime64[ns] synchronized spike times (in HARP) for the EphysChunk
         """
 
-    def make(self, key: Dict[str, Any]) -> None:
+    def make(self, key: dict[str, Any]) -> None:
         """Synchronize spike indices to HARP timestamps and organize by ephys chunks.
-        
+
         This method performs the critical step of converting spike indices (from concatenated
         binary data) back to actual timestamps synchronized to the HARP clock system.
-        
+
         Process:
         1. Load sync models for ONIX→HARP timestamp conversion
         2. Load ONIX clock data from all ephys chunks in the block
@@ -1033,24 +1058,22 @@ class SyncedSpikes(dj.Imported):
            - Convert indices to ONIX timestamps using clock data
            - Apply sync models to convert ONIX→HARP timestamps
            - Group results by ephys chunk for downstream analysis
-        
+
         Args:
             key: Dictionary containing sorting task identifiers
         """
         # Load ephys sync models
         sync_models = {}
         with tempfile.TemporaryDirectory() as tempdir, dj.config.override(download_path=tempdir):
-            sync_ = (ephys.EphysChunk.SyncModel * ephys.EphysSyncModel & (ephys.EphysBlockInfo.Chunk & key)).to_arrays(
-                "onix_ts_start", "onix_ts_end", "sync_model",
-                order_by="onix_ts_start"
-            )
-            for s, e, m in zip(*sync_):
+            sync_ = (
+                ephys.EphysChunk.SyncModel * ephys.EphysSyncModel & (ephys.EphysBlockInfo.Chunk & key)
+            ).to_arrays("onix_ts_start", "onix_ts_end", "sync_model", order_by="onix_ts_start")
+            for s, e, m in zip(*sync_, strict=True):
                 sync_models[(s, e)] = joblib.load(m)
 
         # Load ephys onix times
         _clock_query = (
-            ephys.EphysChunk.File & (ephys.EphysBlockInfo.Chunk & key)
-            & "file_name LIKE '%Clock%.bin'"
+            ephys.EphysChunk.File & (ephys.EphysBlockInfo.Chunk & key) & "file_name LIKE '%Clock%.bin'"
         )
         _clock_rows = _clock_query.to_dicts(order_by="chunk_start")
         _pk = _clock_query.primary_key
@@ -1059,21 +1082,21 @@ class SyncedSpikes(dj.Imported):
         dir_types = [r["directory_type"] for r in _clock_rows]
 
         onix_times = []
-        for f, d in zip(ephys_files, dir_types):
+        for f, d in zip(ephys_files, dir_types, strict=True):
             ephys_dir = acquisition.Experiment.get_data_directory(key, directory_type=d)
             onix_ts = np.memmap(ephys_dir / f, mode="r", dtype=np.uint64)
             onix_times.append(onix_ts)
         onix_lengths = np.cumsum([len(s) for s in onix_times])
 
-        def indices2syncedtimes(spike_indices: np.ndarray) -> Tuple[Dict[str, Any], np.ndarray]:
+        def indices2syncedtimes(spike_indices: np.ndarray) -> Iterator[tuple[dict[str, Any], np.ndarray]]:
             """Convert spike indices to HARP-synchronized timestamps by ephys chunk.
-            
+
             Maps spike indices (from concatenated binary data) back to their original
             ephys chunks and converts to HARP timestamps using sync models.
-            
+
             Args:
                 spike_indices: Array of spike indices in concatenated recording
-                
+
             Yields:
                 Tuple of (chunk_key, synced_timestamps) for each ephys chunk
             """
@@ -1082,7 +1105,9 @@ class SyncedSpikes(dj.Imported):
                 if idx == 0:
                     spk_ind = spike_indices[spike_indices <= onix_bound]
                 else:
-                    spk_ind = spike_indices[(spike_indices > onix_lengths[idx - 1]) & (spike_indices <= onix_bound)]
+                    spk_ind = spike_indices[
+                        (spike_indices > onix_lengths[idx - 1]) & (spike_indices <= onix_bound)
+                    ]
 
                 if not len(spk_ind):  # no spikes in this chunk
                     continue
@@ -1090,7 +1115,7 @@ class SyncedSpikes(dj.Imported):
                 # Convert absolute indices to relative indices within this chunk
                 spk_ind -= spk_ind[0]  # make relative to chunk start
                 spk_times = onix_times[idx][spk_ind]  # get ONIX timestamps
-                
+
                 # Apply sync models to convert ONIX→HARP timestamps
                 synced_ts = []
                 for (start, end), model in sync_models.items():
@@ -1132,7 +1157,10 @@ class UnitMatchingMethod(dj.Lookup):
     matching_method_description: varchar(1000)
     """
     contents = [
-        ("spike_time_overlap", "Matches units by comparing spike times during overlapping time windows between ephys blocks"),
+        (
+            "spike_time_overlap",
+            "Matches units by comparing spike times during overlapping time windows between ephys blocks",
+        ),
     ]
 
 
@@ -1214,9 +1242,7 @@ class UnitMatching(dj.Computed):
         # Case 2: seed already processed -> find frontiers
         processed = all_candidates & self  # already done
         # Bounds of the processed region
-        group_keys = (
-            "experiment_name", "subject", "insertion_number", "matching_paramset_id"
-        )
+        group_keys = ("experiment_name", "subject", "insertion_number", "matching_paramset_id")
         processed_bounds = dj.U(*group_keys).aggr(
             processed, proc_min="MIN(block_start)", proc_max="MAX(block_start)"
         )
@@ -1257,17 +1283,13 @@ class UnitMatching(dj.Computed):
         from spikeinterface.core import NumpySorting
 
         execution_time = datetime.now(UTC)
-        matching_method = (UnitMatchingParamSet & key).fetch1("matching_method")
+        _matching_method = (UnitMatchingParamSet & key).fetch1("matching_method")
 
-        insertion_key = {
-            k: key[k] for k in ("experiment_name", "subject", "insertion_number")
-        }
+        insertion_key = {k: key[k] for k in ("experiment_name", "subject", "insertion_number")}
         paramset_key = {"matching_paramset_id": key["matching_paramset_id"]}
 
         # ---- Load block boundaries (used by guard and later) ----
-        block_start, block_end = (ephys.EphysBlock & key).fetch1(
-            "block_start", "block_end"
-        )
+        block_start, block_end = (ephys.EphysBlock & key).fetch1("block_start", "block_end")
 
         # ---- Seed / overlap guard ----
         previously_matched = (self & insertion_key & paramset_key).to_dicts()
@@ -1283,8 +1305,7 @@ class UnitMatching(dj.Computed):
         else:
             # Subsequent blocks: must overlap with at least one processed block
             has_overlap = any(
-                s["block_start"] < block_end and s["block_end"] > block_start
-                for s in previously_matched
+                s["block_start"] < block_end and s["block_end"] > block_start for s in previously_matched
             )
             if not has_overlap:
                 raise ValueError(
@@ -1300,7 +1321,7 @@ class UnitMatching(dj.Computed):
             this_block_units[unit_id].append(unit_entry["spike_times"])
 
         # Concatenate spike times across chunks per unit, convert to epoch seconds
-        for unit_id in this_block_units:
+        for unit_id in this_block_units:  # noqa: PLC0206
             concatenated = np.sort(np.concatenate(this_block_units[unit_id]))
             if concatenated.dtype.kind == "M":  # datetime64
                 concatenated = concatenated.astype("datetime64[ns]").astype(np.int64) / 1e9
@@ -1308,17 +1329,18 @@ class UnitMatching(dj.Computed):
 
         if not this_block_units:
             logger.warning(f"No synced spike data found for block {key}. Skipping.")
-            self.insert1({
-                **key,
-                "execution_time": execution_time,
-                "execution_duration": 0.0,
-            })
+            self.insert1(
+                {
+                    **key,
+                    "execution_time": execution_time,
+                    "execution_duration": 0.0,
+                }
+            )
             return
 
         # ---- Find overlapping previous blocks (reuse previously_matched from guard) ----
         overlapping_blocks = [
-            s for s in previously_matched
-            if s["block_start"] < block_end and s["block_end"] > block_start
+            s for s in previously_matched if s["block_start"] < block_end and s["block_end"] > block_start
         ]
 
         # Map: this block's unit_id -> global_unit (if matched)
@@ -1357,7 +1379,7 @@ class UnitMatching(dj.Computed):
                     if uid not in prev_units:
                         prev_units[uid] = []
                     prev_units[uid].append(unit_entry["spike_times"])
-                for uid in prev_units:
+                for uid in prev_units:  # noqa: PLC0206
                     concatenated = np.sort(np.concatenate(prev_units[uid]))
                     if concatenated.dtype.kind == "M":
                         concatenated = concatenated.astype("datetime64[ns]").astype(np.int64) / 1e9
@@ -1383,12 +1405,8 @@ class UnitMatching(dj.Computed):
                     continue
 
                 # Compare using SpikeInterface
-                sorting_this = NumpySorting.from_unit_dict(
-                    this_spike_trains, sampling_frequency=30000
-                )
-                sorting_prev = NumpySorting.from_unit_dict(
-                    prev_spike_trains, sampling_frequency=30000
-                )
+                sorting_this = NumpySorting.from_unit_dict(this_spike_trains, sampling_frequency=30000)
+                sorting_prev = NumpySorting.from_unit_dict(prev_spike_trains, sampling_frequency=30000)
                 comparison = compare_two_sorters(
                     sorting1=sorting_prev,
                     sorting2=sorting_this,
@@ -1433,8 +1451,7 @@ class UnitMatching(dj.Computed):
             gu_key = {**insertion_key, **paramset_key, "global_unit": gu_id}
             if unit_id not in unit_electrodes:
                 raise ValueError(
-                    f"No electrode info found for unit {unit_id} in SortedSpikes.Unit. "
-                    f"Key: {key}"
+                    f"No electrode info found for unit {unit_id} in SortedSpikes.Unit. Key: {key}"
                 )
             electrode = unit_electrodes[unit_id]
             if not (GlobalUnit & gu_key):
@@ -1446,20 +1463,25 @@ class UnitMatching(dj.Computed):
 
         # ---- Insert master entry ----
         execution_duration = (datetime.now(UTC) - execution_time).total_seconds() / 3600
-        self.insert1({
-            **key,
-            "execution_time": execution_time,
-            "execution_duration": execution_duration,
-        })
+        self.insert1(
+            {
+                **key,
+                "execution_time": execution_time,
+                "execution_duration": execution_duration,
+            }
+        )
 
         # ---- Insert UnitMatching.Unit entries ----
         for unit_id, gu_id in unit_to_global.items():
-            self.Unit.insert1({
-                **key,
-                "unit": unit_id,
-                **insertion_key,
-                "global_unit": gu_id,
-            }, ignore_extra_fields=True)
+            self.Unit.insert1(
+                {
+                    **key,
+                    "unit": unit_id,
+                    **insertion_key,
+                    "global_unit": gu_id,
+                },
+                ignore_extra_fields=True,
+            )
 
         # ---- Insert UnitMatching.Spikes with ownership convention ----
         # For each (global_unit, chunk): skip if an earlier block already owns it
@@ -1492,14 +1514,17 @@ class UnitMatching(dj.Computed):
                     continue  # no spikes for this unit in this chunk
 
                 spike_times = synced_entry.fetch1("spike_times")
-                self.Spikes.insert1({
-                    **key,
-                    **insertion_key,
-                    "global_unit": gu_id,
-                    "chunk_start": chunk_start,
-                    "spike_times": spike_times,
-                    "spike_count": len(spike_times),
-                }, ignore_extra_fields=True)
+                self.Spikes.insert1(
+                    {
+                        **key,
+                        **insertion_key,
+                        "global_unit": gu_id,
+                        "chunk_start": chunk_start,
+                        "spike_times": spike_times,
+                        "spike_count": len(spike_times),
+                    },
+                    ignore_extra_fields=True,
+                )
 
         logger.info(
             f"Unit matching complete for block {key['block_start']}:\n"
@@ -1511,40 +1536,36 @@ class UnitMatching(dj.Computed):
 
 # ---- Ephys preprocessing with spike interface ----
 
+
 def ephys_preproc(recording) -> Any:
     """Apply standard ephys preprocessing pipeline.
-    
+
     Performs unsigned-to-signed conversion, bandpass filtering (300-6000 Hz),
     and common average referencing using median.
-    
+
     Args:
         recording: SpikeInterface recording object
-        
+
     Returns:
         Preprocessed recording object
     """
     import spikeinterface as si
-    from spikeinterface import preprocessing
 
-    recording = si.preprocessing.bandpass_filter(
-        recording=recording, freq_min=300, freq_max=6000
-    )
-    recording = si.preprocessing.common_reference(
-        recording=recording, operator="median"
-    )
+    recording = si.preprocessing.bandpass_filter(recording=recording, freq_min=300, freq_max=6000)
+    recording = si.preprocessing.common_reference(recording=recording, operator="median")
     return recording
 
 
 def load_and_verify_binary_file(binary_file_path: Path, se_recording_obj: Any) -> Any:
     """Load and verify binary recording file matches original recording.
-    
+
     Args:
         binary_file_path: Path to binary recording file
         se_recording_obj: Original SpikeInterface recording object
-        
+
     Returns:
         Binary recording object with probe geometry
-        
+
     Raises:
         ValueError: If sample counts don't match between files
     """
@@ -1555,10 +1576,13 @@ def load_and_verify_binary_file(binary_file_path: Path, se_recording_obj: Any) -
         sampling_frequency=se_recording_obj.get_sampling_frequency(),
         dtype=se_recording_obj.dtype,
         num_channels=se_recording_obj.get_num_channels(),
-        gain_to_uV=se_recording_obj.get_channel_gains()[0])
+        gain_to_uV=se_recording_obj.get_channel_gains()[0],
+    )
     if binary_rec.get_num_samples() != se_recording_obj.get_num_samples():
-        raise ValueError(f"Number of samples in binary file ({binary_rec.get_num_samples()})"
-                         f" does not match the original recording ({se_recording_obj.get_num_samples()}).")
+        raise ValueError(
+            f"Number of samples in binary file ({binary_rec.get_num_samples()})"
+            f" does not match the original recording ({se_recording_obj.get_num_samples()})."
+        )
 
     binary_rec.set_probe(probe=se_recording_obj.get_probe(), in_place=True)
     # force rename channel_ids?

--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -614,7 +614,7 @@ class SIExport(dj.Computed):
         sorting_root_dir = get_sorting_root_dir()
         output_dir = sorting_root_dir / (PreProcessing & key).fetch1("sorting_output_dir")
 
-        analyzer_output_dir = output_dir / "sorting_analyzer"
+        analyzer_output_dir = _resolve_analyzer_dir(output_dir)
         sorting_analyzer = si.load_sorting_analyzer(folder=analyzer_output_dir)
 
         execution_duration_hours = (datetime.now(UTC) - execution_time).total_seconds() / 3600
@@ -704,7 +704,7 @@ class SortedSpikes(dj.Imported):
         # If so, use the curated analyzer; otherwise use the raw analyzer
         # Use lazy import to avoid circular dependency
         curation_id = -1
-        analyzer_output_dir = output_dir / "sorting_analyzer"
+        analyzer_output_dir = _resolve_analyzer_dir(output_dir)
         try:
             # Lazy import to avoid circular dependency
             import importlib
@@ -888,7 +888,7 @@ class Waveform(dj.Imported):
                 f"Using curated analyzer (curation_id={curation_id}) from: {analyzer_output_dir}"
             )
         else:
-            analyzer_output_dir = output_dir / "sorting_analyzer"
+            analyzer_output_dir = _resolve_analyzer_dir(output_dir)
             logger.info("Using raw analyzer (curation_id=-1)")
 
         sorting_analyzer = si.load_sorting_analyzer(folder=analyzer_output_dir)
@@ -979,7 +979,7 @@ class SortingQuality(dj.Imported):
                 f"Using curated analyzer (curation_id={curation_id}) from: {analyzer_output_dir}"
             )
         else:
-            analyzer_output_dir = output_dir / "sorting_analyzer"
+            analyzer_output_dir = _resolve_analyzer_dir(output_dir)
             logger.info("Using raw analyzer (curation_id=-1)")
 
         sorting_analyzer = si.load_sorting_analyzer(folder=analyzer_output_dir)

--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -357,7 +357,7 @@ class PreProcessing(dj.Computed):
                 for f in recording_dir.rglob("*")
                 if f.is_file()
                 and f.name != "recording.dat"
-                and not str(f).startswith(str(recording_dir / "recording.zarr"))
+                and not f.is_relative_to(recording_dir / "recording.zarr")
             ]
         )
 

--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -11,6 +11,10 @@ from typing import Dict, List, Tuple, Any, Optional
 
 from aeon.dj_pipeline import acquisition, ephys, get_schema_name
 from aeon.dj_pipeline.utils.paths import get_sorting_root_dir
+from aeon.dj_pipeline.utils.spike_sorting_utils import (
+    _resolve_analyzer_dir,
+    _strip_non_numeric_properties,
+)
 
 from swc.aeon.io import api as io_api
 from aeon.schema.ephys import social_ephys
@@ -1529,22 +1533,6 @@ def ephys_preproc(recording) -> Any:
         recording=recording, operator="median"
     )
     return recording
-
-
-def _resolve_analyzer_dir(output_dir: Path) -> Path:
-    """Find sorting analyzer directory, checking both binary and zarr paths."""
-    analyzer_dir = output_dir / "sorting_analyzer"
-    if not analyzer_dir.exists():
-        analyzer_dir = output_dir / "sorting_analyzer.zarr"
-    return analyzer_dir
-
-
-def _strip_non_numeric_properties(si_recording) -> None:
-    """Remove non-numeric recording properties that zarr v2 cannot serialize."""
-    for prop in list(si_recording.get_property_keys()):
-        values = si_recording.get_property(prop)
-        if np.asarray(values).dtype.kind not in ("f", "i", "u", "b"):
-            si_recording.delete_property(prop)
 
 
 def load_and_verify_binary_file(binary_file_path: Path, se_recording_obj: Any) -> Any:

--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -1509,6 +1509,22 @@ def ephys_preproc(recording) -> Any:
     return recording
 
 
+def _resolve_analyzer_dir(output_dir: Path) -> Path:
+    """Find sorting analyzer directory, checking both binary and zarr paths."""
+    analyzer_dir = output_dir / "sorting_analyzer"
+    if not analyzer_dir.exists():
+        analyzer_dir = output_dir / "sorting_analyzer.zarr"
+    return analyzer_dir
+
+
+def _strip_non_numeric_properties(si_recording) -> None:
+    """Remove non-numeric recording properties that zarr v2 cannot serialize."""
+    for prop in list(si_recording.get_property_keys()):
+        values = si_recording.get_property(prop)
+        if np.asarray(values).dtype.kind not in ("f", "i", "u", "b"):
+            si_recording.delete_property(prop)
+
+
 def load_and_verify_binary_file(binary_file_path: Path, se_recording_obj: Any) -> Any:
     """Load and verify binary recording file matches original recording.
     

--- a/aeon/dj_pipeline/spike_sorting_curation.py
+++ b/aeon/dj_pipeline/spike_sorting_curation.py
@@ -164,7 +164,14 @@ class ApplyOfficialCuration(dj.Imported):
         # Keep raw analyzer in sorting_analyzer, curated in sorting_analyzer_curated_id{curation_id}
         curated_analyzer_dir = output_dir / f"sorting_analyzer_curated_id{curation_id}"
         logger.info(f"Saving curated analyzer to: {curated_analyzer_dir}")
-        curated_analyzer.save(folder=curated_analyzer_dir, overwrite=True)
+        params = (spike_sorting.SortingParamSet & key).fetch1("params")
+        save_format = params.get("save_format", "zarr")
+        if save_format == "zarr":
+            if curated_analyzer_dir.exists():
+                shutil.rmtree(curated_analyzer_dir)
+            curated_analyzer.save_as(format="zarr", folder=curated_analyzer_dir)
+        else:
+            curated_analyzer.save(folder=curated_analyzer_dir, overwrite=True)
         
         # Store the applied analyzer directory path in ManualCuration.File
         analyzer_file_entry = {

--- a/aeon/dj_pipeline/spike_sorting_curation.py
+++ b/aeon/dj_pipeline/spike_sorting_curation.py
@@ -134,7 +134,7 @@ class ApplyOfficialCuration(dj.Imported):
         )
 
         # Load original sorting analyzer
-        analyzer_output_dir = output_dir / "sorting_analyzer"
+        analyzer_output_dir = spike_sorting._resolve_analyzer_dir(output_dir)
         if not analyzer_output_dir.exists():
             raise FileNotFoundError(
                 f"Sorting analyzer directory not found: {analyzer_output_dir}"
@@ -263,8 +263,7 @@ def _get_analyzer_dir_from_key(key: dict) -> Path:
     """
     sorting_root_dir = get_sorting_root_dir()
     output_dir = sorting_root_dir / (spike_sorting.PreProcessing & key).fetch1("sorting_output_dir")
-    analyzer_dir = output_dir / "sorting_analyzer"
-    return analyzer_dir
+    return spike_sorting._resolve_analyzer_dir(output_dir)
 
 
 def launch_spikeinterface_gui(

--- a/aeon/dj_pipeline/spike_sorting_curation.py
+++ b/aeon/dj_pipeline/spike_sorting_curation.py
@@ -128,15 +128,9 @@ class ApplyOfficialCuration(dj.Imported):
         with open(curation_file_path) as f:
             curation_dict = json.load(f)
 
-        # Get sorting output directory
-        sorting_root_dir = get_sorting_root_dir()
-        output_dir = sorting_root_dir / (spike_sorting.PreProcessing & key).fetch1("sorting_output_dir")
-
         # Load original sorting analyzer
-        analyzer_output_dir = resolve_analyzer_dir(output_dir)
-        if not analyzer_output_dir.exists():
-            raise FileNotFoundError(f"Sorting analyzer directory not found: {analyzer_output_dir}")
-
+        analyzer_output_dir = _get_analyzer_dir_from_key(key)
+        output_dir = analyzer_output_dir.parent
         sorting_analyzer = si.load_sorting_analyzer(folder=analyzer_output_dir)
 
         # Track original unit IDs for comparison
@@ -285,12 +279,6 @@ def launch_spikeinterface_gui(key: dict, parent_curation_id: int | None = None) 
     import spikeinterface as si
 
     analyzer_dir = _get_analyzer_dir_from_key(key)
-
-    if not analyzer_dir.exists():
-        raise FileNotFoundError(
-            f"Sorting analyzer directory not found: {analyzer_dir}\n"
-            f"Please verify the key is correct and that PreProcessing has been run for this block."
-        )
 
     # Handle parent curation if specified
     gui_dir = analyzer_dir / "spikeinterface_gui"

--- a/aeon/dj_pipeline/spike_sorting_curation.py
+++ b/aeon/dj_pipeline/spike_sorting_curation.py
@@ -10,6 +10,7 @@ import pandas as pd
 
 from aeon.dj_pipeline import ephys, spike_sorting, get_schema_name
 from aeon.dj_pipeline.utils.paths import get_sorting_root_dir
+from aeon.dj_pipeline.utils.spike_sorting_utils import _resolve_analyzer_dir
 
 schema = dj.Schema(get_schema_name("spike_sorting_curation"))
 logger = dj.logger
@@ -134,7 +135,7 @@ class ApplyOfficialCuration(dj.Imported):
         )
 
         # Load original sorting analyzer
-        analyzer_output_dir = spike_sorting._resolve_analyzer_dir(output_dir)
+        analyzer_output_dir = _resolve_analyzer_dir(output_dir)
         if not analyzer_output_dir.exists():
             raise FileNotFoundError(
                 f"Sorting analyzer directory not found: {analyzer_output_dir}"
@@ -270,7 +271,7 @@ def _get_analyzer_dir_from_key(key: dict) -> Path:
     """
     sorting_root_dir = get_sorting_root_dir()
     output_dir = sorting_root_dir / (spike_sorting.PreProcessing & key).fetch1("sorting_output_dir")
-    return spike_sorting._resolve_analyzer_dir(output_dir)
+    return _resolve_analyzer_dir(output_dir)
 
 
 def launch_spikeinterface_gui(

--- a/aeon/dj_pipeline/spike_sorting_curation.py
+++ b/aeon/dj_pipeline/spike_sorting_curation.py
@@ -1,16 +1,15 @@
-import os
-import datajoint as dj
-from datetime import datetime, UTC
-from pathlib import Path
-from typing import Optional
+"""DataJoint tables for spike sorting manual and official curation workflows."""
+
 import json
 import shutil
-import numpy as np
-import pandas as pd
+from datetime import UTC, datetime
+from pathlib import Path
 
-from aeon.dj_pipeline import ephys, spike_sorting, get_schema_name
+import datajoint as dj
+
+from aeon.dj_pipeline import get_schema_name, spike_sorting
 from aeon.dj_pipeline.utils.paths import get_sorting_root_dir
-from aeon.dj_pipeline.utils.spike_sorting_utils import _resolve_analyzer_dir
+from aeon.dj_pipeline.utils.spike_sorting_utils import resolve_analyzer_dir
 
 schema = dj.Schema(get_schema_name("spike_sorting_curation"))
 logger = dj.logger
@@ -20,7 +19,7 @@ logger = dj.logger
 class CurationMethod(dj.Lookup):
     definition = """
     # Curation method
-    curation_method: varchar(16)  # method/package used to perform manual curation (e.g. SpikeInterface, Phy, FigURL, etc.)
+    curation_method: varchar(16)  # manual curation method/package (e.g. SpikeInterface, Phy, FigURL)
     """
     contents = [
         ("Phy",),
@@ -37,7 +36,7 @@ class ManualCuration(dj.Manual):
     ---
     curation_datetime: datetime    # UTC time when the curation was performed
     parent_curation_id=-1: int32   # if -1, this curation is based on the raw spike sorting results
-    -> CurationMethod              # which method/package used for manual curation (inform how to ingest the results)
+    -> CurationMethod              # manual curation method/package (inform how to ingest the results)
     description="": varchar(1000)  # user-defined description/note of the curation
     """
 
@@ -70,8 +69,7 @@ class ApplyOfficialCuration(dj.Imported):
     """
 
     def make(self, key):
-        """
-        Update/overwrite the SortedSpikes (and downstream) with the official curation results.
+        """Update/overwrite the SortedSpikes (and downstream) with the official curation results.
 
         This function:
         1. Loads the curation JSON from ManualCuration
@@ -101,12 +99,14 @@ class ApplyOfficialCuration(dj.Imported):
                 sorted_key = (spike_sorting.SortedSpikes & key).fetch1("KEY")
                 spike_sorting.SortedSpikes.update1({**sorted_key, "curation_id": curation_id})
 
-                self.insert1({
-                    **key,
-                    "execution_time": execution_time,
-                    "new_unit_count": 0,
-                    "removed_unit_count": 0,
-                })
+                self.insert1(
+                    {
+                        **key,
+                        "execution_time": execution_time,
+                        "new_unit_count": 0,
+                        "removed_unit_count": 0,
+                    }
+                )
                 logger.info(
                     f"Auto-approved curation (curation_id={curation_id}): "
                     "raw sorting results accepted as official. No changes applied."
@@ -125,21 +125,17 @@ class ApplyOfficialCuration(dj.Imported):
             )
 
         # Load curation dictionary
-        with open(curation_file_path, "r") as f:
+        with open(curation_file_path) as f:
             curation_dict = json.load(f)
 
         # Get sorting output directory
         sorting_root_dir = get_sorting_root_dir()
-        output_dir = sorting_root_dir / (spike_sorting.PreProcessing & key).fetch1(
-            "sorting_output_dir"
-        )
+        output_dir = sorting_root_dir / (spike_sorting.PreProcessing & key).fetch1("sorting_output_dir")
 
         # Load original sorting analyzer
-        analyzer_output_dir = _resolve_analyzer_dir(output_dir)
+        analyzer_output_dir = resolve_analyzer_dir(output_dir)
         if not analyzer_output_dir.exists():
-            raise FileNotFoundError(
-                f"Sorting analyzer directory not found: {analyzer_output_dir}"
-            )
+            raise FileNotFoundError(f"Sorting analyzer directory not found: {analyzer_output_dir}")
 
         sorting_analyzer = si.load_sorting_analyzer(folder=analyzer_output_dir)
 
@@ -173,7 +169,7 @@ class ApplyOfficialCuration(dj.Imported):
             curated_analyzer.save_as(format="zarr", folder=curated_analyzer_dir)
         else:
             curated_analyzer.save(folder=curated_analyzer_dir, overwrite=True)
-        
+
         # Store the applied analyzer directory path in ManualCuration.File
         analyzer_file_entry = {
             **key,
@@ -186,12 +182,10 @@ class ApplyOfficialCuration(dj.Imported):
         logger.debug(f"Stored applied analyzer path in database for curation_id={curation_id}")
 
         # Check current curation state in SortedSpikes
-        # There can only be one SortedSpikes entry per primary key (curation_id is an attribute, not part of PK)
+        # There can only be one SortedSpikes entry per primary key
+        # (curation_id is an attribute, not part of PK)
         current_sorted_spikes = spike_sorting.SortedSpikes & key
-        if current_sorted_spikes:
-            current_curation_id = current_sorted_spikes.fetch1("curation_id")
-        else:
-            current_curation_id = None
+        current_curation_id = current_sorted_spikes.fetch1("curation_id") if current_sorted_spikes else None
 
         # Handle different scenarios based on current curation state
         if current_curation_id == curation_id:
@@ -205,9 +199,9 @@ class ApplyOfficialCuration(dj.Imported):
         if current_curation_id is not None and current_curation_id != -1:
             # A different curation is already applied
             raise ValueError(
-                f"A different curation (curation_id={current_curation_id}) has already been applied to this block. "
-                f"Cannot apply curation_id={curation_id}. "
-                "If you want to apply a new curation, the data needs to be reverted to the uncurated version first."
+                f"A different curation (curation_id={current_curation_id}) has already been applied to this"
+                f" block. Cannot apply curation_id={curation_id}. If you want to apply a new curation, the"
+                f" data needs to be reverted to the uncurated version first."
             )
 
         # Current state: curation_id == -1 or no entry exists
@@ -222,13 +216,9 @@ class ApplyOfficialCuration(dj.Imported):
         # re-curating after undoing a previous curation, restore_raw_sorting()
         # handles the unit matching cleanup before we get here.
         if current_curation_id == -1:
-            logger.info(
-                "Deleting old SortedSpikes (curation_id=-1) and downstream tables..."
-            )
+            logger.info("Deleting old SortedSpikes (curation_id=-1) and downstream tables...")
             (spike_sorting.SortedSpikes & key).delete(safemode=False)
-            logger.info(
-                "Deleted SortedSpikes (downstream tables auto-deleted by DataJoint)"
-            )
+            logger.info("Deleted SortedSpikes (downstream tables auto-deleted by DataJoint)")
 
         # Insert ApplyOfficialCuration entry
         self.insert1(
@@ -248,15 +238,17 @@ class ApplyOfficialCuration(dj.Imported):
             f"  Raw analyzer remains in: {output_dir / 'sorting_analyzer'}"
         )
 
-        logger.info("Run .populate() on spike_sorting.SortedSpikes and downstream tables to load the curated sorting results into the pipeline.")
+        logger.info(
+            "Run .populate() on spike_sorting.SortedSpikes and downstream tables to load the curated "
+            "sorting results into the pipeline."
+        )
 
 
 # Helper functions for curation workflows
 
 
 def _get_analyzer_dir_from_key(key: dict) -> Path:
-    """
-    Construct the path to the sorting_analyzer directory from a key using database paths.
+    """Construct the path to the sorting_analyzer directory from a key using database paths.
 
     Args:
         key: Dictionary key identifying the sorting task. Must contain:
@@ -271,14 +263,11 @@ def _get_analyzer_dir_from_key(key: dict) -> Path:
     """
     sorting_root_dir = get_sorting_root_dir()
     output_dir = sorting_root_dir / (spike_sorting.PreProcessing & key).fetch1("sorting_output_dir")
-    return _resolve_analyzer_dir(output_dir)
+    return resolve_analyzer_dir(output_dir)
 
 
-def launch_spikeinterface_gui(
-    key: dict, parent_curation_id: Optional[int] = None
-) -> None:
-    """
-    Launch SpikeInterface GUI for manual spike sorting curation.
+def launch_spikeinterface_gui(key: dict, parent_curation_id: int | None = None) -> None:
+    """Launch SpikeInterface GUI for manual spike sorting curation.
 
     Args:
         key: Dictionary key identifying the sorting task. Must contain:
@@ -291,8 +280,9 @@ def launch_spikeinterface_gui(
             the curation_data.json file will be initialized from the specified curation.
             If None, starts from the raw sorting results.
     """
-    import spikeinterface as si
     import shutil
+
+    import spikeinterface as si
 
     analyzer_dir = _get_analyzer_dir_from_key(key)
 
@@ -313,14 +303,11 @@ def launch_spikeinterface_gui(
         parent_curation_key = {**key, "curation_id": parent_curation_id}
         if not (ManualCuration & parent_curation_key):
             raise ValueError(
-                f"Parent curation with curation_id={parent_curation_id} not found "
-                f"for this sorting task."
+                f"Parent curation with curation_id={parent_curation_id} not found for this sorting task."
             )
 
         # Get the parent curation file path
-        parent_file = Path(
-            (ManualCuration.File & parent_curation_key).fetch1("file").full_path
-        )
+        parent_file = Path((ManualCuration.File & parent_curation_key).fetch1("file").full_path)
 
         if not parent_file.exists():
             raise FileNotFoundError(
@@ -349,11 +336,10 @@ def launch_spikeinterface_gui(
         logger.info(f"Saved parent curation metadata to: {metadata_file}")
 
     # Handle metadata file when parent_curation_id is None
-    if parent_curation_id is None:
+    if parent_curation_id is None and metadata_file.exists():
         # Delete metadata file if it exists (clearing any previous parent)
-        if metadata_file.exists():
-            metadata_file.unlink()
-            logger.info("Cleared previous parent curation metadata (starting from raw)")
+        metadata_file.unlink()
+        logger.info("Cleared previous parent curation metadata (starting from raw)")
 
     # Check for existing curation_data.json file (if not loading from parent)
     if curation_data_file.exists() and parent_curation_id is None:
@@ -392,8 +378,7 @@ def launch_spikeinterface_gui(
 
 
 def save_manual_curation(key: dict, description: str = "") -> int:
-    """
-    Save manual curation results from SpikeInterface GUI to the database.
+    """Save manual curation results from SpikeInterface GUI to the database.
 
     Args:
         key: Dictionary key identifying the sorting task. Must contain:
@@ -437,13 +422,12 @@ def save_manual_curation(key: dict, description: str = "") -> int:
 
     # Verify the copied file is valid JSON
     try:
-        with open(curated_file_path, "r") as f:
+        with open(curated_file_path) as f:
             json.load(f)  # Verify it's valid JSON
     except json.JSONDecodeError as e:
         raise RuntimeError(
-            f"Copied curation file is not valid JSON: {e}\n"
-            f"Original file preserved at: {curation_data_file}"
-        )
+            f"Copied curation file is not valid JSON.\nOriginal file preserved at: {curation_data_file}"
+        ) from e
 
     # Now safe to delete the original file
     curation_data_file.unlink()
@@ -454,7 +438,7 @@ def save_manual_curation(key: dict, description: str = "") -> int:
     parent_curation_id = -1  # Default: based on raw sorting results
     if metadata_file.exists():
         try:
-            with open(metadata_file, "r") as f:
+            with open(metadata_file) as f:
                 metadata = json.load(f)
                 parent_curation_id = metadata.get("parent_curation_id", -1)
             logger.info(f"Using parent_curation_id={parent_curation_id} from metadata file")
@@ -500,8 +484,7 @@ def save_manual_curation(key: dict, description: str = "") -> int:
 
 
 def make_curation_official(key: dict, curation_id: int) -> None:
-    """
-    Designate an existing curation as official.
+    """Designate an existing curation as official.
 
     Args:
         key: Dictionary key identifying the sorting task. Must contain:
@@ -515,14 +498,10 @@ def make_curation_official(key: dict, curation_id: int) -> None:
     # Verify the curation exists
     curation_key = {**key, "curation_id": curation_id}
     if not (ManualCuration & curation_key):
-        raise ValueError(
-            f"Curation with curation_id={curation_id} not found for this sorting task."
-        )
+        raise ValueError(f"Curation with curation_id={curation_id} not found for this sorting task.")
 
     # Get the SortedSpikes key (need to find the one with curation_id=-1, the raw sorting)
-    sorted_spikes_key = (spike_sorting.SortedSpikes & key & {"curation_id": -1}).fetch1(
-        "KEY"
-    )
+    sorted_spikes_key = (spike_sorting.SortedSpikes & key & {"curation_id": -1}).fetch1("KEY")
 
     # Check if OfficialCuration already exists for this SortedSpikes
     if OfficialCuration & sorted_spikes_key:
@@ -600,7 +579,7 @@ def restore_raw_sorting(key: dict) -> None:
     # (those with no remaining UnitMatching.Unit references from any block)
     insertion_key = {k: key[k] for k in ("experiment_name", "subject", "insertion_number")}
     n_orphans = 0
-    for gu_key in (spike_sorting.GlobalUnit & insertion_key).keys():
+    for gu_key in (spike_sorting.GlobalUnit & insertion_key).keys():  # noqa: SIM118
         if len(spike_sorting.UnitMatching.Unit & gu_key) == 0:
             logger.info(f"Deleting orphaned GlobalUnit {gu_key['global_unit']}...")
             (spike_sorting.GlobalUnit & gu_key).delete(safemode=False)
@@ -622,4 +601,7 @@ def restore_raw_sorting(key: dict) -> None:
             "  4. Run UnitMatching.populate() to re-match units and generate Spikes"
         )
     else:
-        logger.info("No SortedSpikes entry found (run populate to load the raw sorting results back into the pipeline).")
+        logger.info(
+            "No SortedSpikes entry found. "
+            "Run populate to load the raw sorting results back into the pipeline."
+        )

--- a/aeon/dj_pipeline/utils/spike_sorting_utils.py
+++ b/aeon/dj_pipeline/utils/spike_sorting_utils.py
@@ -11,11 +11,22 @@ import numpy as np
 
 
 def resolve_analyzer_dir(output_dir: Path) -> Path:
-    """Find sorting analyzer directory, checking both binary and zarr paths."""
+    """Find sorting analyzer directory, checking both binary and zarr paths.
+
+    Raises:
+        FileNotFoundError: If neither sorting_analyzer nor sorting_analyzer.zarr exists.
+    """
     analyzer_dir = output_dir / "sorting_analyzer"
-    if not analyzer_dir.exists():
-        analyzer_dir = output_dir / "sorting_analyzer.zarr"
-    return analyzer_dir
+    if analyzer_dir.exists():
+        return analyzer_dir
+    analyzer_dir = output_dir / "sorting_analyzer.zarr"
+    if analyzer_dir.exists():
+        return analyzer_dir
+    raise FileNotFoundError(
+        f"Sorting analyzer directory not found in {output_dir} "
+        f"(checked sorting_analyzer and sorting_analyzer.zarr). "
+        f"Please verify the key is correct and that PreProcessing has been run for this block."
+    )
 
 
 def strip_non_numeric_properties(si_recording) -> None:

--- a/aeon/dj_pipeline/utils/spike_sorting_utils.py
+++ b/aeon/dj_pipeline/utils/spike_sorting_utils.py
@@ -1,0 +1,26 @@
+"""Pure helpers for the spike sorting pipeline's zarr/binary intermediate handling.
+
+These functions have no database or table dependencies, so they live here (rather
+than in spike_sorting.py) to keep them importable and unit-testable without
+activating the spike_sorting schema.
+"""
+
+from pathlib import Path
+
+import numpy as np
+
+
+def _resolve_analyzer_dir(output_dir: Path) -> Path:
+    """Find sorting analyzer directory, checking both binary and zarr paths."""
+    analyzer_dir = output_dir / "sorting_analyzer"
+    if not analyzer_dir.exists():
+        analyzer_dir = output_dir / "sorting_analyzer.zarr"
+    return analyzer_dir
+
+
+def _strip_non_numeric_properties(si_recording) -> None:
+    """Remove non-numeric recording properties that zarr v2 cannot serialize."""
+    for prop in list(si_recording.get_property_keys()):
+        values = si_recording.get_property(prop)
+        if np.asarray(values).dtype.kind not in ("f", "i", "u", "b"):
+            si_recording.delete_property(prop)

--- a/aeon/dj_pipeline/utils/spike_sorting_utils.py
+++ b/aeon/dj_pipeline/utils/spike_sorting_utils.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import numpy as np
 
 
-def _resolve_analyzer_dir(output_dir: Path) -> Path:
+def resolve_analyzer_dir(output_dir: Path) -> Path:
     """Find sorting analyzer directory, checking both binary and zarr paths."""
     analyzer_dir = output_dir / "sorting_analyzer"
     if not analyzer_dir.exists():
@@ -18,7 +18,7 @@ def _resolve_analyzer_dir(output_dir: Path) -> Path:
     return analyzer_dir
 
 
-def _strip_non_numeric_properties(si_recording) -> None:
+def strip_non_numeric_properties(si_recording) -> None:
     """Remove non-numeric recording properties that zarr v2 cannot serialize."""
     for prop in list(si_recording.get_property_keys()):
         values = si_recording.get_property(prop)

--- a/docs/ephys_runbooks/step03_spike_sorting.py
+++ b/docs/ephys_runbooks/step03_spike_sorting.py
@@ -114,6 +114,9 @@ def setup_sorting_prerequisites(
 
     if not (spike_sorting.SortingParamSet & {"paramset_id": paramset_id_str}):
         params = {
+            # Storage format for recording, sorting output, and analyzer
+            # ("zarr" or "binary"). Defaults to "zarr" if omitted.
+            "save_format": "zarr",
             # NOTE: Preprocessing is fixed in the pipeline (bandpass 300-6000 Hz
             # + median common average referencing, via ephys_preproc() in
             # spike_sorting.py). It is not configurable through this params dict.

--- a/docs/specs/SPEC_ZARR_INTERMEDIATES.md
+++ b/docs/specs/SPEC_ZARR_INTERMEDIATES.md
@@ -127,7 +127,7 @@ This keeps `gain_to_uV` (float64), `offset_to_uV` (int64), `location`
 with string/object sub-fields). The filter runs only on the zarr path. The
 binary path is unchanged.
 
-This logic is extracted into the helper `_strip_non_numeric_properties` in
+This logic is extracted into the helper `strip_non_numeric_properties` in
 `aeon/dj_pipeline/utils/spike_sorting_utils.py` (see change 3 for why the
 helpers live in a utils module) and called from `PreProcessing.make_compute`
 on the zarr path only.
@@ -154,7 +154,7 @@ The fallback logic is a shared helper rather than duplicated in each
 location:
 
 ```python
-def _resolve_analyzer_dir(output_dir: Path) -> Path:
+def resolve_analyzer_dir(output_dir: Path) -> Path:
     """Find sorting analyzer directory, checking both binary and zarr paths."""
     analyzer_dir = output_dir / "sorting_analyzer"
     if not analyzer_dir.exists():
@@ -162,14 +162,14 @@ def _resolve_analyzer_dir(output_dir: Path) -> Path:
     return analyzer_dir
 ```
 
-This helper, together with `_strip_non_numeric_properties`, lives in
+This helper, together with `strip_non_numeric_properties`, lives in
 `aeon/dj_pipeline/utils/spike_sorting_utils.py`, imported by both
 `spike_sorting.py` and `spike_sorting_curation.py`. The helpers are pure
 (no table or schema dependency), so placing them in a utils module keeps
 them importable and unit-testable without activating the spike_sorting
 schema (importing `spike_sorting.py` triggers a DB connection). Each
 consumer replaces its hardcoded path with a call to
-`_resolve_analyzer_dir(output_dir)`.
+`resolve_analyzer_dir(output_dir)`.
 
 **4. PostProcessing safety check and return path**
 
@@ -276,8 +276,8 @@ new default.
 
 A new unit test module, `tests/dj_pipeline/utils/test_spike_sorting_utils_unit.py`,
 covers the two relocated helpers (see change 3). It tests
-`_resolve_analyzer_dir` for the binary-preferred, zarr-fallback, neither-exists,
-and both-exist cases, and `_strip_non_numeric_properties` for keeping numeric
+`resolve_analyzer_dir` for the binary-preferred, zarr-fallback, neither-exists,
+and both-exist cases, and `strip_non_numeric_properties` for keeping numeric
 properties (float/int/uint/bool) while stripping string properties. These run
 under `-m unit` and need no database, since the helpers live in a pure utils
 module.

--- a/docs/specs/SPEC_ZARR_INTERMEDIATES.md
+++ b/docs/specs/SPEC_ZARR_INTERMEDIATES.md
@@ -157,9 +157,12 @@ location:
 def resolve_analyzer_dir(output_dir: Path) -> Path:
     """Find sorting analyzer directory, checking both binary and zarr paths."""
     analyzer_dir = output_dir / "sorting_analyzer"
-    if not analyzer_dir.exists():
-        analyzer_dir = output_dir / "sorting_analyzer.zarr"
-    return analyzer_dir
+    if analyzer_dir.exists():
+        return analyzer_dir
+    analyzer_dir = output_dir / "sorting_analyzer.zarr"
+    if analyzer_dir.exists():
+        return analyzer_dir
+    raise FileNotFoundError(...)
 ```
 
 This helper, together with `strip_non_numeric_properties`, lives in
@@ -171,26 +174,22 @@ schema (importing `spike_sorting.py` triggers a DB connection). Each
 consumer replaces its hardcoded path with a call to
 `resolve_analyzer_dir(output_dir)`.
 
-**4. PostProcessing safety check and return path**
+**4. PostProcessing safety check**
 
-The safety check for pre-existing analyzer directories checks both variants:
-
-```python
-for check_dir in [analyzer_output_dir, output_dir / "sorting_analyzer.zarr"]:
-    if check_dir.exists() and any(check_dir.iterdir()):
-        raise FileExistsError(...)
-```
-
-`PostProcessing.make_compute` passes `output_dir / "sorting_analyzer"` to
-`create_sorting_analyzer`, but with `format="zarr"` SpikeInterface writes to
-`sorting_analyzer.zarr/`. So after the analyzer is built, the returned path
-must be corrected to the real directory, otherwise `make_insert` iterates a
-non-existent path and registers zero files in the File part table:
+The analyzer output directory is now determined upfront based on `save_format`,
+so the safety check only verifies the relevant directory:
 
 ```python
-if analyzer_format == "zarr":
-    analyzer_output_dir = output_dir / "sorting_analyzer.zarr"
+analyzer_name = "sorting_analyzer.zarr" if save_format == "zarr" else "sorting_analyzer"
+analyzer_output_dir = output_dir / analyzer_name
+
+if analyzer_output_dir.exists() and any(analyzer_output_dir.iterdir()):
+    raise FileExistsError(...)
 ```
+
+The correct path is passed directly to `create_sorting_analyzer`. SI's
+`clean_zarr_folder_name` ensures `.zarr` is not double-appended, so no
+post-hoc path correction is needed.
 
 **5. File registration exclusions**
 
@@ -276,8 +275,9 @@ new default.
 
 A new unit test module, `tests/dj_pipeline/utils/test_spike_sorting_utils_unit.py`,
 covers the two relocated helpers (see change 3). It tests
-`resolve_analyzer_dir` for the binary-preferred, zarr-fallback, neither-exists,
-and both-exist cases, and `strip_non_numeric_properties` for keeping numeric
+`resolve_analyzer_dir` for the binary-preferred, zarr-fallback, neither-exists
+(raises `FileNotFoundError`), and both-exist cases, and
+`strip_non_numeric_properties` for keeping numeric
 properties (float/int/uint/bool) while stripping string properties. These run
 under `-m unit` and need no database, since the helpers live in a pure utils
 module.

--- a/docs/specs/SPEC_ZARR_INTERMEDIATES.md
+++ b/docs/specs/SPEC_ZARR_INTERMEDIATES.md
@@ -258,9 +258,11 @@ new default.
    `test_recording_zarr_exists`. Check that `recording/recording.zarr/`
    exists and is a non-empty directory. The binary-specific size checks
    (frame-size divisibility, minimum 500 MB) do not apply to compressed
-   zarr. Instead, verify the recording loads correctly via `si.load()` and
-   has the expected channel count and sample count range. Remove the
-   `INT16_BYTES` constant.
+   zarr. Instead, verify the recording loads via `si.load()`, has the
+   expected channel count, sits in a plausible duration range (catches a
+   truncated write), and reads back a non-zero trace slice (confirms the
+   zarr actually decompresses to real data). Remove the `INT16_BYTES`
+   constant.
 
 2. **`test_sorting_analyzer_created`** — Update to check for
    `sorting_analyzer.zarr` (SI appends `.zarr` to the folder name when

--- a/docs/specs/SPEC_ZARR_INTERMEDIATES.md
+++ b/docs/specs/SPEC_ZARR_INTERMEDIATES.md
@@ -74,11 +74,11 @@ output.
 All changes are in `aeon/dj_pipeline/`. No changes to `aeon/schema/`,
 `aeon/io/`, or any other package.
 
-**1. Default flip (one-line change in four locations across two files)**
+**1. Default flip (four locations across two files)**
 
 In `spike_sorting.py` (`PreProcessing.make_compute`,
 `SpikeSorting.make_compute`, `PostProcessing.make_compute`) and
-`spike_sorting_curation.py` (`ApplyCuration.make_compute`):
+`spike_sorting_curation.py` (`ApplyOfficialCuration.make`):
 
 ```python
 # Before
@@ -87,6 +87,26 @@ save_format = params.get("save_format", "binary")
 # After
 save_format = params.get("save_format", "zarr")
 ```
+
+In the three `spike_sorting.py` locations this is a one-line default change.
+In `ApplyOfficialCuration.make` it is more than a flip: on main this method
+had no format handling at all (it always called
+`curated_analyzer.save(folder=..., overwrite=True)`), so a zarr branch was
+added:
+
+```python
+save_format = params.get("save_format", "zarr")
+if save_format == "zarr":
+    if curated_analyzer_dir.exists():
+        shutil.rmtree(curated_analyzer_dir)
+    curated_analyzer.save_as(format="zarr", folder=curated_analyzer_dir)
+else:
+    curated_analyzer.save(folder=curated_analyzer_dir, overwrite=True)
+```
+
+The `shutil.rmtree` is needed because `SortingAnalyzer.save_as` has no
+`overwrite` flag (unlike `save`), so a pre-existing curated directory from a
+prior apply/revert/re-apply of the same `curation_id` must be cleared first.
 
 **2. Zarr property filter**
 
@@ -107,10 +127,10 @@ This keeps `gain_to_uV` (float64), `offset_to_uV` (int64), `location`
 with string/object sub-fields). The filter runs only on the zarr path. The
 binary path is unchanged.
 
-This code already exists on `es/compression-spec` inside
-`PreProcessing.make_compute`. For the implementation PR it should be
-extracted to a small helper so it is not duplicated if other save points
-need it.
+This logic is extracted into the helper `_strip_non_numeric_properties` in
+`aeon/dj_pipeline/utils/spike_sorting_utils.py` (see change 3 for why the
+helpers live in a utils module) and called from `PreProcessing.make_compute`
+on the zarr path only.
 
 **3. Sorting analyzer path fallback (all consumers)**
 
@@ -120,22 +140,18 @@ appends `.zarr` to the folder name. So when PostProcessing passes
 Every location that loads a sorting analyzer by hardcoding
 `output_dir / "sorting_analyzer"` needs to also check the `.zarr` path.
 
-There are 7 such locations across two files:
+The consumer locations across two files are:
 
-- `spike_sorting.py`:
-  - `PostProcessing.make_compute` (safety check, line ~540) — already
-    handles both paths on `es/compression-spec`
-  - `SIExport.make` (line ~629)
-  - `SortedSpikes.make` (line ~719) — already has fallback on
-    `es/compression-spec`
-  - `Waveform.make_compute` (line ~905)
-  - `SortingQuality.make_compute` (line ~996)
-- `spike_sorting_curation.py`:
-  - `ApplyCuration.make_compute` (line ~137)
-  - `_get_analyzer_dir` helper (line ~274)
+- `spike_sorting.py`: `SIExport.make`, `SortedSpikes.make`, `Waveform.make`,
+  `SortingQuality.make`
+- `spike_sorting_curation.py`: `ApplyOfficialCuration.make` and the
+  `_get_analyzer_dir_from_key` helper
 
-The fallback logic should be extracted to a shared helper rather than
-duplicated in each location:
+(`PostProcessing.make_compute` is the creator, not a consumer; its safety
+check explicitly tests both paths — see change 4.)
+
+The fallback logic is a shared helper rather than duplicated in each
+location:
 
 ```python
 def _resolve_analyzer_dir(output_dir: Path) -> Path:
@@ -146,14 +162,18 @@ def _resolve_analyzer_dir(output_dir: Path) -> Path:
     return analyzer_dir
 ```
 
-This helper lives in `spike_sorting.py` and is imported by
-`spike_sorting_curation.py`. Each of the 7 locations replaces its
-hardcoded path with a call to `_resolve_analyzer_dir(output_dir)`.
+This helper, together with `_strip_non_numeric_properties`, lives in
+`aeon/dj_pipeline/utils/spike_sorting_utils.py`, imported by both
+`spike_sorting.py` and `spike_sorting_curation.py`. The helpers are pure
+(no table or schema dependency), so placing them in a utils module keeps
+them importable and unit-testable without activating the spike_sorting
+schema (importing `spike_sorting.py` triggers a DB connection). Each
+consumer replaces its hardcoded path with a call to
+`_resolve_analyzer_dir(output_dir)`.
 
-**4. PostProcessing safety check**
+**4. PostProcessing safety check and return path**
 
-The existing safety check for pre-existing analyzer directories also needs
-to check the `.zarr` variant:
+The safety check for pre-existing analyzer directories checks both variants:
 
 ```python
 for check_dir in [analyzer_output_dir, output_dir / "sorting_analyzer.zarr"]:
@@ -161,7 +181,16 @@ for check_dir in [analyzer_output_dir, output_dir / "sorting_analyzer.zarr"]:
         raise FileExistsError(...)
 ```
 
-This code already exists on `es/compression-spec`.
+`PostProcessing.make_compute` passes `output_dir / "sorting_analyzer"` to
+`create_sorting_analyzer`, but with `format="zarr"` SpikeInterface writes to
+`sorting_analyzer.zarr/`. So after the analyzer is built, the returned path
+must be corrected to the real directory, otherwise `make_insert` iterates a
+non-existent path and registers zero files in the File part table:
+
+```python
+if analyzer_format == "zarr":
+    analyzer_output_dir = output_dir / "sorting_analyzer.zarr"
+```
 
 **5. File registration exclusions**
 
@@ -241,23 +270,38 @@ new default.
 3. **Docstrings and comments** — Update references to `recording.dat` and
    `binary_folder` in test class docstrings.
 
+**New unit tests:**
+
+A new unit test module, `tests/dj_pipeline/utils/test_spike_sorting_utils_unit.py`,
+covers the two relocated helpers (see change 3). It tests
+`_resolve_analyzer_dir` for the binary-preferred, zarr-fallback, neither-exists,
+and both-exist cases, and `_strip_non_numeric_properties` for keeping numeric
+properties (float/int/uint/bool) while stripping string properties. These run
+under `-m unit` and need no database, since the helpers live in a pure utils
+module.
+
 ### Verification on HPC
 
-After the test changes are made, run the full test suite on the HPC against
-the golden data to confirm everything passes with zarr output. This is the
-final validation before the PR is ready for review.
+Validated on the SWC HPC against the golden dataset (fresh checkout, DB on
+`aeon-db` with a dedicated test prefix, CPU node — the golden suite
+force-injects SpikeSorting so no GPU is needed):
+
+- Unit suite: 121 passed (includes the 6 new helper tests).
+- Ephys golden integration: 29/29, including `test_recording_zarr_exists`
+  and `test_sorting_analyzer_created`.
 
 ---
 
 ## PR checklist
 
-- [ ] Create `es/zarr-intermediates` branch off current main
-- [ ] Cherry-pick or reimplement production code changes from
-      `es/compression-spec` (property filter, zarr branching, path
-      fallbacks, file registration exclusions)
-- [ ] Change default from `"binary"` to `"zarr"` in all four
+- [x] Create `es/zarr-intermediates` branch off current main
+- [x] Reimplement production code changes (property filter, zarr branching,
+      path fallbacks, file registration exclusions)
+- [x] Change default from `"binary"` to `"zarr"` in all four
       `params.get("save_format", ...)` calls
-- [ ] Add this spec document (`SPEC_ZARR_INTERMEDIATES.md`)
-- [ ] Update test assertions (recording path, analyzer path)
-- [ ] Run tests on HPC, verify all pass
-- [ ] Open PR into main
+- [x] Relocate the pure helpers to `utils/spike_sorting_utils.py` and add
+      unit tests
+- [x] Add this spec document (`SPEC_ZARR_INTERMEDIATES.md`)
+- [x] Update test assertions (recording path, analyzer path)
+- [x] Run tests on HPC, verify all pass
+- [x] Open PR into main (draft #589)

--- a/docs/specs/SPEC_ZARR_INTERMEDIATES.md
+++ b/docs/specs/SPEC_ZARR_INTERMEDIATES.md
@@ -1,0 +1,263 @@
+# Zarr Compression for Pipeline Intermediates
+
+Spec for switching the spike sorting pipeline's intermediate file format from
+uncompressed binary to zarr with Blosc-zstd compression. Covers the code
+changes, test updates, and PR scope for a single implementation PR into main.
+
+**Status:** Approved at team meeting 2026-06-11. Compression testing complete
+on branch `es/compression-spec` (results in `REPORT_COMPRESSION_RESULTS.md`
+on that branch). This spec defines the implementation PR.
+
+**Branch:** `es/zarr-intermediates` (new, off main)
+
+---
+
+## Background
+
+The spike sorting pipeline produces two large intermediate artifacts per
+block per electrode group:
+
+- **Preprocessed recording** — `recording.dat`, an uncompressed int16
+  binary written by `PreProcessing.make_compute`. For a 30-minute block
+  with 96 channels at 30 kHz, this is ~12.7 GB.
+
+- **Sorting analyzer** — `sorting_analyzer/`, a directory of numpy arrays
+  written by `PostProcessing.make_compute`. Contains waveforms, templates,
+  quality metrics. Typically 0.3-0.5 GB per block.
+
+These files live on Ceph and are the dominant consumers of pipeline disk
+space. They are fully derived from the raw data and can be regenerated at
+any time.
+
+SpikeInterface supports zarr as an alternative storage format. Zarr applies
+Blosc-zstd compression (lossless, built-in, no extra dependencies) to each
+data chunk independently. The compression is transparent to downstream
+code — `si.load()` handles both formats.
+
+## Measured results
+
+Tested on `es/compression-spec` branch using abcGolden01, subject
+IAA-1147881, insertion 1, electrode group shank0 (96 channels). Single
+30-minute block.
+
+| File | Binary | Zarr | Reduction |
+|------|--------|------|-----------|
+| Recording | 12.67 GB | 5.03 GB | 60% |
+| Sorting analyzer | 0.50 GB | 0.30 GB | 40% |
+| **Total** | **13.17 GB** | **5.33 GB** | **60%** |
+
+Pipeline execution time with zarr intermediates was 20% faster overall
+(36.9 min vs 46.2 min), because compressed I/O reduces Ceph network
+bandwidth. PreProcessing was 2.6x faster, PostProcessing 15% faster.
+SpikeSorting was slightly slower (7.8 min vs 6.2 min mean) because the
+Kilosort wrapper decompresses zarr to a temporary binary internally, but
+this was within the normal run-to-run variation range (4.1-8.3 min).
+
+Scaling rates per shank: ~25 GB/h binary vs ~10 GB/h zarr for recording,
+~1 GB/h binary vs ~0.6 GB/h zarr for analyzer.
+
+## Design
+
+### Format switching mechanism
+
+The pipeline already supports a `save_format` key in each paramset's
+`params` dict (added on `es/compression-spec`). The value is either
+`"binary"` or `"zarr"`. When absent, a default is used.
+
+**This PR changes the default from `"binary"` to `"zarr"`.** Existing
+paramsets that explicitly set `save_format` continue to work as before. New
+paramsets and paramsets without an explicit `save_format` now produce zarr
+output.
+
+### Code changes
+
+All changes are in `aeon/dj_pipeline/`. No changes to `aeon/schema/`,
+`aeon/io/`, or any other package.
+
+**1. Default flip (one-line change in four locations across two files)**
+
+In `spike_sorting.py` (`PreProcessing.make_compute`,
+`SpikeSorting.make_compute`, `PostProcessing.make_compute`) and
+`spike_sorting_curation.py` (`ApplyCuration.make_compute`):
+
+```python
+# Before
+save_format = params.get("save_format", "binary")
+
+# After
+save_format = params.get("save_format", "zarr")
+```
+
+**2. Zarr property filter**
+
+When saving a recording to zarr, non-numeric recording properties (strings,
+object arrays, structured arrays like `contact_vector`) must be stripped
+because zarr v2 cannot serialize them without an explicit object codec. The
+filter uses a numeric dtype allowlist:
+
+```python
+for prop in list(si_recording.get_property_keys()):
+    values = si_recording.get_property(prop)
+    if np.asarray(values).dtype.kind not in ("f", "i", "u", "b"):
+        si_recording.delete_property(prop)
+```
+
+This keeps `gain_to_uV` (float64), `offset_to_uV` (int64), `location`
+(float64), `group` (int64) and strips `contact_vector` (structured array
+with string/object sub-fields). The filter runs only on the zarr path. The
+binary path is unchanged.
+
+This code already exists on `es/compression-spec` inside
+`PreProcessing.make_compute`. For the implementation PR it should be
+extracted to a small helper so it is not duplicated if other save points
+need it.
+
+**3. Sorting analyzer path fallback (all consumers)**
+
+SpikeInterface's `create_sorting_analyzer(format="zarr", folder=path)`
+appends `.zarr` to the folder name. So when PostProcessing passes
+`output_dir / "sorting_analyzer"`, SI creates `sorting_analyzer.zarr/`.
+Every location that loads a sorting analyzer by hardcoding
+`output_dir / "sorting_analyzer"` needs to also check the `.zarr` path.
+
+There are 7 such locations across two files:
+
+- `spike_sorting.py`:
+  - `PostProcessing.make_compute` (safety check, line ~540) — already
+    handles both paths on `es/compression-spec`
+  - `SIExport.make` (line ~629)
+  - `SortedSpikes.make` (line ~719) — already has fallback on
+    `es/compression-spec`
+  - `Waveform.make_compute` (line ~905)
+  - `SortingQuality.make_compute` (line ~996)
+- `spike_sorting_curation.py`:
+  - `ApplyCuration.make_compute` (line ~137)
+  - `_get_analyzer_dir` helper (line ~274)
+
+The fallback logic should be extracted to a shared helper rather than
+duplicated in each location:
+
+```python
+def _resolve_analyzer_dir(output_dir: Path) -> Path:
+    """Find sorting analyzer directory, checking both binary and zarr paths."""
+    analyzer_dir = output_dir / "sorting_analyzer"
+    if not analyzer_dir.exists():
+        analyzer_dir = output_dir / "sorting_analyzer.zarr"
+    return analyzer_dir
+```
+
+This helper lives in `spike_sorting.py` and is imported by
+`spike_sorting_curation.py`. Each of the 7 locations replaces its
+hardcoded path with a call to `_resolve_analyzer_dir(output_dir)`.
+
+**4. PostProcessing safety check**
+
+The existing safety check for pre-existing analyzer directories also needs
+to check the `.zarr` variant:
+
+```python
+for check_dir in [analyzer_output_dir, output_dir / "sorting_analyzer.zarr"]:
+    if check_dir.exists() and any(check_dir.iterdir()):
+        raise FileExistsError(...)
+```
+
+This code already exists on `es/compression-spec`.
+
+**5. File registration exclusions**
+
+`PreProcessing.make_insert` already excludes `recording.dat` and
+`recording.zarr/` contents from the DJ File part table (zarr directories
+contain thousands of chunk files that should not be registered individually).
+This code already exists on `es/compression-spec`.
+
+### What is NOT included in this PR
+
+- **`CompressionTest` table** — Testing artifact from `es/compression-spec`.
+  Not production code.
+- **`scripts/compression_report.py`** — Testing artifact.
+- **Existing spec/plan/report documents** from `es/compression-spec` — This
+  spec replaces them.
+- **Raw data compression** — Separate effort, separate repo. See
+  `SPEC_RAW_COMPRESSION.md`.
+- **Historical data migration** — Existing binary intermediates remain
+  as-is. `si.load()` handles both formats transparently when loading. New
+  runs produce zarr; old data does not need to be converted.
+
+### Backward compatibility
+
+- `si.load()` detects format from folder contents and handles both binary
+  and zarr transparently. No downstream code needs to know which format a
+  given recording or analyzer uses.
+- Existing paramsets with explicit `save_format: "binary"` continue to
+  produce binary output.
+- The `load_and_verify_binary_file` utility remains available for the binary
+  path.
+- No DB migration needed. The `sorting_output_dir` column stores a varchar
+  path. The directory name doesn't change (it's the contents that change
+  format).
+
+---
+
+## Test updates
+
+### Current test state (main, as of PR #585)
+
+The ephys integration tests in `tests/dj_pipeline/test_ephys_ingestion.py`
+use the `foraging_abc_ephys_2026_05_11` golden dataset (abcGolden01 on
+AEONX1, 384 recording channels, 8-channel sorting subset). The test flow:
+
+1. `EphysEpoch.ingest_epochs` + `EphysEpochConfig.populate` +
+   `EphysSyncModel.ingest` (fixture: `ephys_test_epochs`)
+2. `EphysChunk.ingest_chunks` + `EphysBlockInfo.populate` (fixtures)
+3. `PreProcessing.populate` — **runs live** against golden raw data
+4. `SpikeSorting` — **force-injected** from pre-computed golden KS4 output
+5. `PostProcessing.populate` — **runs live**
+6. `SortedSpikes.populate` + `SyncedSpikes.populate` — **run live**
+
+### What changes in tests
+
+**No golden data changes needed.** The golden sorting output
+(`golden_test_sorting/sorting_output`) contains KS4's native Kilosort
+output (spike times, cluster assignments). It is format-agnostic and works
+regardless of whether PreProcessing produced binary or zarr. PreProcessing
+and PostProcessing run live and will naturally produce zarr output with the
+new default.
+
+**Test assertion updates:**
+
+1. **`test_recording_binary_exists`** — Rename to
+   `test_recording_zarr_exists`. Check that `recording/recording.zarr/`
+   exists and is a non-empty directory. The binary-specific size checks
+   (frame-size divisibility, minimum 500 MB) do not apply to compressed
+   zarr. Instead, verify the recording loads correctly via `si.load()` and
+   has the expected channel count and sample count range. Remove the
+   `INT16_BYTES` constant.
+
+2. **`test_sorting_analyzer_created`** — Update to check for
+   `sorting_analyzer.zarr` (SI appends `.zarr` to the folder name when
+   using zarr format). The `any(analyzer_dir.iterdir())` check still
+   applies.
+
+3. **Docstrings and comments** — Update references to `recording.dat` and
+   `binary_folder` in test class docstrings.
+
+### Verification on HPC
+
+After the test changes are made, run the full test suite on the HPC against
+the golden data to confirm everything passes with zarr output. This is the
+final validation before the PR is ready for review.
+
+---
+
+## PR checklist
+
+- [ ] Create `es/zarr-intermediates` branch off current main
+- [ ] Cherry-pick or reimplement production code changes from
+      `es/compression-spec` (property filter, zarr branching, path
+      fallbacks, file registration exclusions)
+- [ ] Change default from `"binary"` to `"zarr"` in all four
+      `params.get("save_format", ...)` calls
+- [ ] Add this spec document (`SPEC_ZARR_INTERMEDIATES.md`)
+- [ ] Update test assertions (recording path, analyzer path)
+- [ ] Run tests on HPC, verify all pass
+- [ ] Open PR into main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ test = [
   "pytest>=7.0",
   "pytest-cov",
   "testcontainers[mysql]>=3.7",
+  "spikeinterface>=0.104.0",
 ]
 test-golden = [
   { include-group = "test" },

--- a/tests/dj_pipeline/test_ephys_ingestion.py
+++ b/tests/dj_pipeline/test_ephys_ingestion.py
@@ -41,15 +41,12 @@ class TestEphysEpochDiscovery:
 
     def test_probe_insertions_created(self, ephys_test_epochs, ctx):
         insertions = (
-            ctx.ephys.EphysEpochConfig.Insertion
-            & {"experiment_name": ctx.cfg["experiment_name"]}
+            ctx.ephys.EphysEpochConfig.Insertion & {"experiment_name": ctx.cfg["experiment_name"]}
         ).to_dicts()
         assert len(insertions) == ctx.cfg["expected_probe_count"]
 
     def test_probe_insertion_links_correct_subject(self, ephys_test_epochs, ctx):
-        pis = (
-            ctx.ephys.ProbeInsertion & {"experiment_name": ctx.cfg["experiment_name"]}
-        ).to_dicts()
+        pis = (ctx.ephys.ProbeInsertion & {"experiment_name": ctx.cfg["experiment_name"]}).to_dicts()
         assert len(pis) >= 1
         assert all(pi["subject"] == ctx.cfg["subject"] for pi in pis)
 
@@ -72,17 +69,13 @@ class TestEphysChunkIngestion:
         assert count >= 1
 
     def test_chunk_timestamps_valid(self, ephys_chunks_ingested, ctx):
-        chunks = (
-            ctx.ephys.EphysChunk & {"experiment_name": ctx.cfg["experiment_name"]}
-        ).to_dicts()
+        chunks = (ctx.ephys.EphysChunk & {"experiment_name": ctx.cfg["experiment_name"]}).to_dicts()
         for chunk in chunks:
             assert chunk["chunk_start"] < chunk["chunk_end"]
 
     def test_chunk_files_registered(self, ephys_chunks_ingested, ctx):
         files = list(
-            (
-                ctx.ephys.EphysChunk.File & {"experiment_name": ctx.cfg["experiment_name"]}
-            ).fetch("file_name")
+            (ctx.ephys.EphysChunk.File & {"experiment_name": ctx.cfg["experiment_name"]}).fetch("file_name")
         )
         assert any("AmplifierData_0.bin" in fn for fn in files), (
             f"AmplifierData_0.bin not registered. Got first 5: {files[:5]}"
@@ -90,9 +83,7 @@ class TestEphysChunkIngestion:
         assert any("Clock_0.bin" in fn for fn in files), (
             f"Clock_0.bin not registered. Got first 5: {files[:5]}"
         )
-        assert len(files) % 2 == 0, (
-            f"Expected even file count (Amp+Clock pairs), got {len(files)}"
-        )
+        assert len(files) % 2 == 0, f"Expected even file count (Amp+Clock pairs), got {len(files)}"
 
 
 class TestEphysBlockInfo:
@@ -107,16 +98,12 @@ class TestEphysBlockInfo:
         # Block is set up as exactly 35 minutes (block_end - block_start in the
         # ephys_test_blocks fixture); block_duration in hours is exactly 35/60.
         # Tight tolerance to catch any conversion drift.
-        infos = (
-            ctx.ephys.EphysBlockInfo & {"experiment_name": ctx.cfg["experiment_name"]}
-        ).to_dicts()
+        infos = (ctx.ephys.EphysBlockInfo & {"experiment_name": ctx.cfg["experiment_name"]}).to_dicts()
         for info in infos:
             assert info["block_duration"] == pytest.approx(35 / 60, abs=1e-6)
 
     def test_block_chunks_associated(self, ephys_block_info_populated, ctx):
-        chunk_links = len(
-            ctx.ephys.EphysBlockInfo.Chunk & {"experiment_name": ctx.cfg["experiment_name"]}
-        )
+        chunk_links = len(ctx.ephys.EphysBlockInfo.Chunk & {"experiment_name": ctx.cfg["experiment_name"]})
         assert chunk_links >= 1
 
     def test_channel_mappings_created(self, ephys_block_info_populated, ctx):
@@ -144,33 +131,28 @@ class TestPreProcessing:
         ctx.ephys.EphysBlockInfo.populate()
         ctx.spike_sorting.PreProcessing.populate(display_progress=True, suppress_errors=False)
 
-    def test_preprocessing_populated(
-        self, ephys_sorting_setup, require_ephys_golden_data, ctx
-    ):
+    def test_preprocessing_populated(self, ephys_sorting_setup, require_ephys_golden_data, ctx):
         self._ensure_prerequisites(ctx)
-        count = len(
-            ctx.spike_sorting.PreProcessing & {"experiment_name": ctx.cfg["experiment_name"]}
-        )
+        count = len(ctx.spike_sorting.PreProcessing & {"experiment_name": ctx.cfg["experiment_name"]})
         assert count >= 1
 
-    def test_recording_files_registered(
-        self, ephys_sorting_setup, require_ephys_golden_data, ctx
-    ):
+    def test_recording_files_registered(self, ephys_sorting_setup, require_ephys_golden_data, ctx):
         self._ensure_prerequisites(ctx)
         files = (
-            ctx.spike_sorting.PreProcessing.File
-            & {"experiment_name": ctx.cfg["experiment_name"]}
+            ctx.spike_sorting.PreProcessing.File & {"experiment_name": ctx.cfg["experiment_name"]}
         ).to_dicts()
         file_names = [f["file_name"] for f in files]
         assert any("si_recording.pkl" in fn for fn in file_names)
+        assert not any("recording.dat" in fn for fn in file_names), "recording.dat should not be registered"
+        assert not any("recording.zarr" in fn for fn in file_names), (
+            "recording.zarr contents should not be registered"
+        )
 
-    def test_recording_zarr_exists(
-        self, ephys_sorting_setup, require_ephys_golden_data, ctx
-    ):
+    def test_recording_zarr_exists(self, ephys_sorting_setup, require_ephys_golden_data, ctx):
         self._ensure_prerequisites(ctx)
-        key = (
-            ctx.spike_sorting.SortingTask & {"experiment_name": ctx.cfg["experiment_name"]}
-        ).to_dicts()[0]
+        key = (ctx.spike_sorting.SortingTask & {"experiment_name": ctx.cfg["experiment_name"]}).to_dicts()[
+            0
+        ]
         output_dir = ctx.spike_sorting.PreProcessing.infer_output_dir(key)
         recording_zarr = output_dir.parent / "recording" / "recording.zarr"
         assert recording_zarr.exists(), f"Expected zarr recording at {recording_zarr}"
@@ -211,9 +193,7 @@ class TestPostProcessing:
 
     def test_postprocessing_populated(self, ephys_sorting_injected, ctx):
         self._ensure_prerequisites(ctx)
-        count = len(
-            ctx.spike_sorting.PostProcessing & {"experiment_name": ctx.cfg["experiment_name"]}
-        )
+        count = len(ctx.spike_sorting.PostProcessing & {"experiment_name": ctx.cfg["experiment_name"]})
         assert count >= 1
 
     def test_sorting_analyzer_created(self, ephys_sorting_injected, ctx):
@@ -237,24 +217,18 @@ class TestSortedSpikes:
 
     def test_sorted_spikes_populated(self, ephys_sorting_injected, ctx):
         self._ensure_prerequisites(ctx)
-        count = len(
-            ctx.spike_sorting.SortedSpikes & {"experiment_name": ctx.cfg["experiment_name"]}
-        )
+        count = len(ctx.spike_sorting.SortedSpikes & {"experiment_name": ctx.cfg["experiment_name"]})
         assert count >= 1
 
     def test_unit_count(self, ephys_sorting_injected, ctx):
         self._ensure_prerequisites(ctx)
-        units = len(
-            ctx.spike_sorting.SortedSpikes.Unit
-            & {"experiment_name": ctx.cfg["experiment_name"]}
-        )
+        units = len(ctx.spike_sorting.SortedSpikes.Unit & {"experiment_name": ctx.cfg["experiment_name"]})
         assert units == ctx.cfg["expected_unit_count"]
 
     def test_spike_counts_reasonable(self, ephys_sorting_injected, ctx):
         self._ensure_prerequisites(ctx)
         units = (
-            ctx.spike_sorting.SortedSpikes.Unit
-            & {"experiment_name": ctx.cfg["experiment_name"]}
+            ctx.spike_sorting.SortedSpikes.Unit & {"experiment_name": ctx.cfg["experiment_name"]}
         ).to_dicts()
         for u in units:
             assert u["spike_count"] > 0
@@ -264,16 +238,14 @@ class TestSortedSpikes:
     def test_quality_labels_assigned(self, ephys_sorting_injected, ctx):
         self._ensure_prerequisites(ctx)
         units = (
-            ctx.spike_sorting.SortedSpikes.Unit
-            & {"experiment_name": ctx.cfg["experiment_name"]}
+            ctx.spike_sorting.SortedSpikes.Unit & {"experiment_name": ctx.cfg["experiment_name"]}
         ).to_dicts()
         qualities = [u["unit_quality"] for u in units]
         assert set(qualities) <= {"good", "mua", "noise"}
         expected = ctx.cfg["expected_quality_counts"]
         for label, count in expected.items():
             assert qualities.count(label) == count, (
-                f"Quality label '{label}' count mismatch: expected {count}, "
-                f"got {qualities.count(label)}"
+                f"Quality label '{label}' count mismatch: expected {count}, got {qualities.count(label)}"
             )
 
 
@@ -291,9 +263,7 @@ class TestSyncedSpikes:
 
     def test_synced_spikes_populated(self, ephys_sorting_injected, ctx):
         self._ensure_prerequisites(ctx)
-        count = len(
-            ctx.spike_sorting.SyncedSpikes & {"experiment_name": ctx.cfg["experiment_name"]}
-        )
+        count = len(ctx.spike_sorting.SyncedSpikes & {"experiment_name": ctx.cfg["experiment_name"]})
         assert count >= 1
 
     def test_spike_times_are_datetimes(self, ephys_sorting_injected, ctx):
@@ -301,8 +271,7 @@ class TestSyncedSpikes:
         import numpy as np
 
         units = (
-            ctx.spike_sorting.SyncedSpikes.Unit
-            & {"experiment_name": ctx.cfg["experiment_name"]}
+            ctx.spike_sorting.SyncedSpikes.Unit & {"experiment_name": ctx.cfg["experiment_name"]}
         ).to_dicts()
         assert len(units) >= 1
         for unit in units:
@@ -312,15 +281,12 @@ class TestSyncedSpikes:
         self._ensure_prerequisites(ctx)
         import numpy as np
 
-        sync_rows = (
-            ctx.ephys.EphysSyncModel & {"experiment_name": ctx.cfg["experiment_name"]}
-        ).to_dicts()
+        sync_rows = (ctx.ephys.EphysSyncModel & {"experiment_name": ctx.cfg["experiment_name"]}).to_dicts()
         sync_start = np.datetime64(min(r["sync_start"] for r in sync_rows))
         sync_end = np.datetime64(max(r["sync_end"] for r in sync_rows))
 
         units = (
-            ctx.spike_sorting.SyncedSpikes.Unit
-            & {"experiment_name": ctx.cfg["experiment_name"]}
+            ctx.spike_sorting.SyncedSpikes.Unit & {"experiment_name": ctx.cfg["experiment_name"]}
         ).to_dicts()
         for unit in units:
             assert unit["spike_times"].min() >= sync_start
@@ -337,18 +303,14 @@ class TestEphysSyncModel:
     """
 
     def test_one_sync_row_per_harpsync_csv(self, ephys_test_epochs, ctx):
-        rows = (
-            ctx.ephys.EphysSyncModel & {"experiment_name": ctx.cfg["experiment_name"]}
-        ).to_dicts()
+        rows = (ctx.ephys.EphysSyncModel & {"experiment_name": ctx.cfg["experiment_name"]}).to_dicts()
         assert len(rows) == 3, (
             f"Expected 3 EphysSyncModel rows (one per hourly HarpSync CSV in the "
             f"golden epoch); got {len(rows)}."
         )
 
     def test_sync_model_regression_quality(self, ephys_test_epochs, ctx):
-        rows = (
-            ctx.ephys.EphysSyncModel & {"experiment_name": ctx.cfg["experiment_name"]}
-        ).to_dicts()
+        rows = (ctx.ephys.EphysSyncModel & {"experiment_name": ctx.cfg["experiment_name"]}).to_dicts()
         for row in rows:
             assert row["r2"] > 0.99, (
                 f"HARP↔ONIX regression r² is suspiciously low: r²={row['r2']:.6f} "
@@ -357,9 +319,9 @@ class TestEphysSyncModel:
             )
 
     def test_sync_model_bounds_monotonic(self, ephys_test_epochs, ctx):
-        rows = (
-            ctx.ephys.EphysSyncModel & {"experiment_name": ctx.cfg["experiment_name"]}
-        ).to_dicts(order_by="sync_start")
+        rows = (ctx.ephys.EphysSyncModel & {"experiment_name": ctx.cfg["experiment_name"]}).to_dicts(
+            order_by="sync_start"
+        )
         # Per-row: start < end on both clocks.
         for row in rows:
             assert row["sync_start"] < row["sync_end"], (
@@ -391,15 +353,9 @@ class TestOnixImuChunkOnGoldenData:
             display_progress=False,
             suppress_errors=False,
         )
-        n_sync = len(
-            ctx.ephys.EphysSyncModel & {"experiment_name": ctx.cfg["experiment_name"]}
-        )
-        n_imu = len(
-            ctx.ephys.OnixImuChunk & {"experiment_name": ctx.cfg["experiment_name"]}
-        )
-        assert n_imu == n_sync, (
-            f"Expected one OnixImuChunk per EphysSyncModel ({n_sync}); got {n_imu}."
-        )
+        n_sync = len(ctx.ephys.EphysSyncModel & {"experiment_name": ctx.cfg["experiment_name"]})
+        n_imu = len(ctx.ephys.OnixImuChunk & {"experiment_name": ctx.cfg["experiment_name"]})
+        assert n_imu == n_sync, f"Expected one OnixImuChunk per EphysSyncModel ({n_sync}); got {n_imu}."
 
     def test_all_chunks_have_imu_samples(self, ephys_test_epochs, ctx):
         ctx.ephys.OnixImuChunk.populate(
@@ -408,10 +364,9 @@ class TestOnixImuChunkOnGoldenData:
             suppress_errors=False,
         )
         sample_counts = list(
-            (
-                ctx.ephys.OnixImuChunk
-                & {"experiment_name": ctx.cfg["experiment_name"]}
-            ).to_arrays("sample_count")
+            (ctx.ephys.OnixImuChunk & {"experiment_name": ctx.cfg["experiment_name"]}).to_arrays(
+                "sample_count"
+            )
         )
         # The golden recording is fully covered by Bno055 chunks, so every
         # sync window overlaps real IMU data.

--- a/tests/dj_pipeline/test_ephys_ingestion.py
+++ b/tests/dj_pipeline/test_ephys_ingestion.py
@@ -175,10 +175,27 @@ class TestPreProcessing:
         recording_zarr = output_dir.parent / "recording" / "recording.zarr"
         assert recording_zarr.exists(), f"Expected zarr recording at {recording_zarr}"
         assert any(recording_zarr.iterdir()), "recording.zarr directory is empty"
+
+        import numpy as np
         import spikeinterface as si
+
         rec = si.load(recording_zarr)
         assert rec.get_num_channels() == ctx.cfg["n_channels"]
-        assert rec.get_num_samples() > 0
+
+        # Sample count should reflect a real multi-minute block, not a truncated
+        # write (the golden block is ~30 min at 30 kHz). A duration range catches
+        # truncation that a bare "> 0" check would miss.
+        duration_s = rec.get_num_samples() / rec.get_sampling_frequency()
+        assert 300 < duration_s < 7200, (
+            f"recording.zarr duration {duration_s:.1f}s outside expected range "
+            "(expected a multi-minute block)"
+        )
+
+        # Read a slice back to confirm the zarr actually decompresses to real
+        # data, not just that the directory and metadata exist.
+        traces = rec.get_traces(start_frame=0, end_frame=1000)
+        assert traces.shape == (1000, ctx.cfg["n_channels"])
+        assert np.any(traces != 0), "recording.zarr decompressed to all-zero traces"
 
 
 class TestPostProcessing:

--- a/tests/dj_pipeline/test_ephys_ingestion.py
+++ b/tests/dj_pipeline/test_ephys_ingestion.py
@@ -17,8 +17,6 @@ Pipeline cascade tested (all live except SpikeSorting):
 
 import pytest
 
-INT16_BYTES = 2  # sizeof(int16); recording.dat stores int16 per channel-sample
-
 pytestmark = pytest.mark.integration
 pytest.importorskip("probeinterface", reason="Ephys tests require probeinterface")
 pytest.importorskip("aeon.schema.ephys", reason="Ephys tests require aeon.schema.ephys (from swc-aeon)")
@@ -138,7 +136,7 @@ class TestPreProcessing:
 
     PreProcessing reads raw ephys binary, selects electrode group channels,
     applies bandpass filter + common average reference, and writes
-    recording.dat + si_recording.pkl.
+    recording.zarr + si_recording.pkl.
     """
 
     def _ensure_prerequisites(self, ctx):
@@ -166,7 +164,7 @@ class TestPreProcessing:
         file_names = [f["file_name"] for f in files]
         assert any("si_recording.pkl" in fn for fn in file_names)
 
-    def test_recording_binary_exists(
+    def test_recording_zarr_exists(
         self, ephys_sorting_setup, require_ephys_golden_data, ctx
     ):
         self._ensure_prerequisites(ctx)
@@ -174,17 +172,13 @@ class TestPreProcessing:
             ctx.spike_sorting.SortingTask & {"experiment_name": ctx.cfg["experiment_name"]}
         ).to_dicts()[0]
         output_dir = ctx.spike_sorting.PreProcessing.infer_output_dir(key)
-        recording_dat = output_dir.parent / "recording" / "recording.dat"
-        assert recording_dat.exists()
-        file_size = recording_dat.stat().st_size
-        assert file_size > 0
-        expected_size = ctx.cfg["n_channels"] * INT16_BYTES
-        assert file_size % expected_size == 0, (
-            f"File size {file_size} not divisible by frame size {expected_size}"
-        )
-        assert file_size >= 500_000_000, (
-            f"recording.dat too small ({file_size} bytes), expected ~1 GB"
-        )
+        recording_zarr = output_dir.parent / "recording" / "recording.zarr"
+        assert recording_zarr.exists(), f"Expected zarr recording at {recording_zarr}"
+        assert any(recording_zarr.iterdir()), "recording.zarr directory is empty"
+        import spikeinterface as si
+        rec = si.load(recording_zarr)
+        assert rec.get_num_channels() == ctx.cfg["n_channels"]
+        assert rec.get_num_samples() > 0
 
 
 class TestPostProcessing:
@@ -208,8 +202,8 @@ class TestPostProcessing:
     def test_sorting_analyzer_created(self, ephys_sorting_injected, ctx):
         self._ensure_prerequisites(ctx)
         output_dir = ephys_sorting_injected["output_dir"]
-        analyzer_dir = output_dir / "sorting_analyzer"
-        assert analyzer_dir.exists()
+        analyzer_dir = output_dir / "sorting_analyzer.zarr"
+        assert analyzer_dir.exists(), f"Expected zarr analyzer at {analyzer_dir}"
         assert any(analyzer_dir.iterdir())
 
 

--- a/tests/dj_pipeline/test_ephys_ingestion.py
+++ b/tests/dj_pipeline/test_ephys_ingestion.py
@@ -6,8 +6,6 @@ if data unavailable.
 
 Requirements:
 1. Ephys golden dataset at ~/sciops-data/project_aeon/aeon/data/raw/AEONX1/...
-2. probeinterface package installed
-3. aeon.schema.ephys available (from swc-aeon package)
 
 Pipeline cascade tested (all live except SpikeSorting):
     EphysChunk.ingest_chunks → EphysBlockInfo.populate → PreProcessing.populate
@@ -18,8 +16,6 @@ Pipeline cascade tested (all live except SpikeSorting):
 import pytest
 
 pytestmark = pytest.mark.integration
-pytest.importorskip("probeinterface", reason="Ephys tests require probeinterface")
-pytest.importorskip("aeon.schema.ephys", reason="Ephys tests require aeon.schema.ephys (from swc-aeon)")
 
 
 class TestEphysEpochDiscovery:

--- a/tests/dj_pipeline/test_ephys_synthetic_integration.py
+++ b/tests/dj_pipeline/test_ephys_synthetic_integration.py
@@ -20,9 +20,6 @@ import pytest
 logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.integration
 
-pytest.importorskip("probeinterface", reason="Ephys tests require probeinterface")
-pytest.importorskip("aeon.schema.ephys", reason="Ephys tests require aeon.schema.ephys (from swc-aeon)")
-
 
 # ---------------------------------------------------------------------------
 # Helpers (local — different scope from tests/fixtures/ephys/ephys_factories.py
@@ -30,28 +27,28 @@ pytest.importorskip("aeon.schema.ephys", reason="Ephys tests require aeon.schema
 # ---------------------------------------------------------------------------
 
 
-def _write_harpsync_csv(epoch_dir: Path, device_name: str, ts_label: str,
-                        harp_base: float, onix_base: int, n_rows: int = 60):
+def _write_harpsync_csv(
+    epoch_dir: Path, device_name: str, ts_label: str, harp_base: float, onix_base: int, n_rows: int = 60
+):
     """Write one HarpSync_*.csv with monotonically-increasing HARP + ONIX clocks."""
     device_dir = epoch_dir / device_name
     device_dir.mkdir(parents=True, exist_ok=True)
     csv_path = device_dir / f"{device_name}_HarpSync_{ts_label}.csv"
     with open(csv_path, "w", newline="") as f:
-        writer = csv.DictWriter(
-            f, fieldnames=["aeon_time", "clock", "hub_clock", "harp_time"]
-        )
+        writer = csv.DictWriter(f, fieldnames=["aeon_time", "clock", "hub_clock", "harp_time"])
         writer.writeheader()
         for s in range(n_rows):
-            writer.writerow({
-                "aeon_time": harp_base + s,
-                "clock": onix_base + 1000 * s,
-                "hub_clock": s,
-                "harp_time": harp_base + s,
-            })
+            writer.writerow(
+                {
+                    "aeon_time": harp_base + s,
+                    "clock": onix_base + 1000 * s,
+                    "hub_clock": s,
+                    "harp_time": harp_base + s,
+                }
+            )
 
 
-def _write_metadata_yml(epoch_dir: Path, device_name: str,
-                        probe_b_filename: str | None = None):
+def _write_metadata_yml(epoch_dir: Path, device_name: str, probe_b_filename: str | None = None):
     """Write a minimal Metadata.yml with one or two probe configurations."""
     metadata = {
         "Devices": {
@@ -59,7 +56,8 @@ def _write_metadata_yml(epoch_dir: Path, device_name: str,
                 "DeviceName": device_name,
                 "ConfigurationA": {"ProbeInterfaceFileName": None},  # disabled
                 "ConfigurationB": {"ProbeInterfaceFileName": probe_b_filename}
-                if probe_b_filename else {"ProbeInterfaceFileName": None},
+                if probe_b_filename
+                else {"ProbeInterfaceFileName": None},
             },
         },
     }
@@ -154,12 +152,18 @@ class TestEphysEpochEndLookback:
         (raw_dir / epoch_a_name).mkdir()
         (raw_dir / epoch_b_name).mkdir()
         _write_harpsync_csv(
-            raw_dir / epoch_a_name, device_name, "2024-06-04T10-00-00",
-            harp_base=harp_a_start, onix_base=1,
+            raw_dir / epoch_a_name,
+            device_name,
+            "2024-06-04T10-00-00",
+            harp_base=harp_a_start,
+            onix_base=1,
         )
         _write_harpsync_csv(
-            raw_dir / epoch_b_name, device_name, "2024-06-04T11-00-00",
-            harp_base=harp_b_start, onix_base=600_001,
+            raw_dir / epoch_b_name,
+            device_name,
+            "2024-06-04T11-00-00",
+            harp_base=harp_b_start,
+            onix_base=600_001,
         )
 
         _register_experiment_only(tmp_path, raw_dir, experiment_name)
@@ -167,15 +171,11 @@ class TestEphysEpochEndLookback:
         ephys.EphysEpoch.ingest_epochs(experiment_name)
 
         # Two EphysEpoch rows
-        epochs = (
-            ephys.EphysEpoch & {"experiment_name": experiment_name}
-        ).to_dicts(order_by="epoch_start")
+        epochs = (ephys.EphysEpoch & {"experiment_name": experiment_name}).to_dicts(order_by="epoch_start")
         assert len(epochs) == 2, f"Expected 2 EphysEpoch rows, got {len(epochs)}"
 
         # Exactly one EphysEpochEnd row — for the FIRST epoch
-        ends = (
-            ephys.EphysEpochEnd & {"experiment_name": experiment_name}
-        ).to_dicts()
+        ends = (ephys.EphysEpochEnd & {"experiment_name": experiment_name}).to_dicts()
         assert len(ends) == 1, (
             f"Expected 1 EphysEpochEnd row (look-back backfills only the previous "
             f"epoch when a newer one is discovered); got {len(ends)}"
@@ -194,9 +194,9 @@ class TestEphysEpochEndLookback:
         # And — positively assert the LAST epoch has NO EphysEpochEnd row
         # (it should only get one when a newer epoch arrives).
         exp_key = {"experiment_name": experiment_name}
-        assert not (
-            ephys.EphysEpochEnd & {**exp_key, "epoch_start": epochs[1]["epoch_start"]}
-        ), "Most recent epoch must have no EphysEpochEnd until a successor is discovered"
+        assert not (ephys.EphysEpochEnd & {**exp_key, "epoch_start": epochs[1]["epoch_start"]}), (
+            "Most recent epoch must have no EphysEpochEnd until a successor is discovered"
+        )
 
         # Duration is in hours
         expected_duration_hours = (
@@ -269,12 +269,15 @@ class TestEphysBlockInfoMultiConfigValidation:
 
         # Experiment + subject scaffolding (skip the directory machinery — not needed)
         from aeon.dj_pipeline import acquisition, lab
+
         lab.Arena.insert1(
             {
                 "arena_name": "synthetic-arena",
                 "arena_description": "",
                 "arena_shape": "circular",
-                "arena_x_dim": 2.0, "arena_y_dim": 2.0, "arena_z_dim": 0.2,
+                "arena_x_dim": 2.0,
+                "arena_y_dim": 2.0,
+                "arena_z_dim": 0.2,
             },
             skip_duplicates=True,
         )
@@ -301,6 +304,7 @@ class TestEphysBlockInfoMultiConfigValidation:
 
         # Two epochs, same ProbeInsertion, different ElectrodeConfigs
         from datetime import datetime
+
         epoch_a_start = datetime(2024, 6, 4, 10, 0, 0)
         epoch_b_start = datetime(2024, 6, 4, 11, 0, 0)
         for es in (epoch_a_start, epoch_b_start):

--- a/tests/dj_pipeline/utils/test_ephys_utils_unit.py
+++ b/tests/dj_pipeline/utils/test_ephys_utils_unit.py
@@ -384,15 +384,10 @@ class TestCreateElectrodeConfig:
     """
 
     FIXTURE_JSON = (
-        Path(__file__).parent.parent.parent
-        / "fixtures" / "ephys" / "synthetic_np2_multishank.json"
+        Path(__file__).parent.parent.parent / "fixtures" / "ephys" / "synthetic_np2_multishank.json"
     )
     N_TOTAL_CONTACTS = 16
     N_ACTIVE_CONTACTS = 8
-
-    @pytest.fixture(autouse=True)
-    def _require_probeinterface(self):
-        pytest.importorskip("probeinterface")
 
     def test_returns_canonical_keys(self):
         from aeon.dj_pipeline.utils.ephys_utils import create_electrode_config
@@ -430,10 +425,7 @@ class TestCreateElectrodeConfig:
         ec_call = electrode_config_table.Electrode.insert.call_args
         ec_rows = list(ec_call.args[0])
         assert len(ec_rows) == self.N_ACTIVE_CONTACTS
-        assert all(
-            {"probe_type", "electrode_config_name", "electrode"} <= set(r.keys())
-            for r in ec_rows
-        )
+        assert all({"probe_type", "electrode_config_name", "electrode"} <= set(r.keys()) for r in ec_rows)
 
     def test_config_name_override(self):
         from aeon.dj_pipeline.utils.ephys_utils import create_electrode_config
@@ -495,20 +487,26 @@ class TestParseMetadataProbeConfigs:
     def test_probe_a_and_b_both_active(self, tmp_path):
         from aeon.dj_pipeline.utils.ephys_utils import parse_metadata_probe_configs
 
-        ep = self._write_metadata(tmp_path, {
-            "ConfigurationA": {"ProbeInterfaceFileName": r"Z:\dir\probeA.json"},
-            "ConfigurationB": {"ProbeInterfaceFileName": r"Z:\dir\probeB.json"},
-        })
+        ep = self._write_metadata(
+            tmp_path,
+            {
+                "ConfigurationA": {"ProbeInterfaceFileName": r"Z:\dir\probeA.json"},
+                "ConfigurationB": {"ProbeInterfaceFileName": r"Z:\dir\probeB.json"},
+            },
+        )
         result = parse_metadata_probe_configs(ep)
         assert result == {"ProbeA": "probeA.json", "ProbeB": "probeB.json"}
 
     def test_probe_a_disabled(self, tmp_path):
         from aeon.dj_pipeline.utils.ephys_utils import parse_metadata_probe_configs
 
-        ep = self._write_metadata(tmp_path, {
-            "ConfigurationA": {"ProbeInterfaceFileName": None},
-            "ConfigurationB": {"ProbeInterfaceFileName": r"Z:\dir\probeB.json"},
-        })
+        ep = self._write_metadata(
+            tmp_path,
+            {
+                "ConfigurationA": {"ProbeInterfaceFileName": None},
+                "ConfigurationB": {"ProbeInterfaceFileName": r"Z:\dir\probeB.json"},
+            },
+        )
         result = parse_metadata_probe_configs(ep)
         assert result == {"ProbeA": None, "ProbeB": "probeB.json"}
 
@@ -523,8 +521,15 @@ class TestParseMetadataProbeConfigs:
         from aeon.dj_pipeline.utils.ephys_utils import parse_metadata_probe_configs
 
         epoch_path = (
-            Path.home() / "sciops-data" / "project_aeon" / "aeon" / "data"
-            / "raw" / "AEONX1" / "abcGolden01" / "2026-05-11T07-50-11"
+            Path.home()
+            / "sciops-data"
+            / "project_aeon"
+            / "aeon"
+            / "data"
+            / "raw"
+            / "AEONX1"
+            / "abcGolden01"
+            / "2026-05-11T07-50-11"
         )
         if not epoch_path.exists():
             pytest.skip(f"Golden epoch not on disk: {epoch_path}")
@@ -593,8 +598,7 @@ class TestLoadDeviceChannelMap:
     """
 
     FIXTURE_JSON = (
-        Path(__file__).parent.parent.parent
-        / "fixtures" / "ephys" / "synthetic_np2_multishank.json"
+        Path(__file__).parent.parent.parent / "fixtures" / "ephys" / "synthetic_np2_multishank.json"
     )
 
     def test_returns_active_contacts_mapping(self):

--- a/tests/dj_pipeline/utils/test_ephys_utils_unit.py
+++ b/tests/dj_pipeline/utils/test_ephys_utils_unit.py
@@ -390,6 +390,10 @@ class TestCreateElectrodeConfig:
     N_TOTAL_CONTACTS = 16
     N_ACTIVE_CONTACTS = 8
 
+    @pytest.fixture(autouse=True)
+    def _require_probeinterface(self):
+        pytest.importorskip("probeinterface")
+
     def test_returns_canonical_keys(self):
         from aeon.dj_pipeline.utils.ephys_utils import create_electrode_config
 

--- a/tests/dj_pipeline/utils/test_spike_sorting_utils_unit.py
+++ b/tests/dj_pipeline/utils/test_spike_sorting_utils_unit.py
@@ -1,7 +1,7 @@
-"""Unit tests for spike_sorting_utils pure helpers: analyzer dir resolution and
-non-numeric property filtering.
+"""Unit tests for spike_sorting_utils pure helpers.
 
-Tests target pure functions with no database dependency. Imports from
+Covers analyzer dir resolution and non-numeric property filtering. Tests
+target pure functions with no database dependency. Imports from
 aeon.dj_pipeline are done inside test methods (not at module level) so pytest
 collection does not trigger aeon/dj_pipeline/__init__.py schema activation.
 """
@@ -45,8 +45,7 @@ class TestStripNonNumericProperties:
     """_strip_non_numeric_properties keeps numeric properties and removes the rest."""
 
     def _make_recording(self):
-        import spikeinterface as si
-
+        si = pytest.importorskip("spikeinterface")
         traces = np.zeros((1000, 4), dtype="int16")
         return si.NumpyRecording(traces, sampling_frequency=30000.0)
 

--- a/tests/dj_pipeline/utils/test_spike_sorting_utils_unit.py
+++ b/tests/dj_pipeline/utils/test_spike_sorting_utils_unit.py
@@ -13,36 +13,36 @@ pytestmark = pytest.mark.unit
 
 
 class TestResolveAnalyzerDir:
-    """_resolve_analyzer_dir picks the binary dir if present, else the zarr dir."""
+    """resolve_analyzer_dir picks the binary dir if present, else the zarr dir."""
 
     def test_binary_dir_when_present(self, tmp_path):
         (tmp_path / "sorting_analyzer").mkdir()
-        from aeon.dj_pipeline.utils.spike_sorting_utils import _resolve_analyzer_dir
+        from aeon.dj_pipeline.utils.spike_sorting_utils import resolve_analyzer_dir
 
-        assert _resolve_analyzer_dir(tmp_path) == tmp_path / "sorting_analyzer"
+        assert resolve_analyzer_dir(tmp_path) == tmp_path / "sorting_analyzer"
 
     def test_zarr_dir_when_only_zarr_present(self, tmp_path):
         (tmp_path / "sorting_analyzer.zarr").mkdir()
-        from aeon.dj_pipeline.utils.spike_sorting_utils import _resolve_analyzer_dir
+        from aeon.dj_pipeline.utils.spike_sorting_utils import resolve_analyzer_dir
 
-        assert _resolve_analyzer_dir(tmp_path) == tmp_path / "sorting_analyzer.zarr"
+        assert resolve_analyzer_dir(tmp_path) == tmp_path / "sorting_analyzer.zarr"
 
     def test_zarr_path_when_neither_present(self, tmp_path):
         # Falls back to the zarr path (the expected location for new runs)
-        from aeon.dj_pipeline.utils.spike_sorting_utils import _resolve_analyzer_dir
+        from aeon.dj_pipeline.utils.spike_sorting_utils import resolve_analyzer_dir
 
-        assert _resolve_analyzer_dir(tmp_path) == tmp_path / "sorting_analyzer.zarr"
+        assert resolve_analyzer_dir(tmp_path) == tmp_path / "sorting_analyzer.zarr"
 
     def test_binary_dir_preferred_when_both_present(self, tmp_path):
         (tmp_path / "sorting_analyzer").mkdir()
         (tmp_path / "sorting_analyzer.zarr").mkdir()
-        from aeon.dj_pipeline.utils.spike_sorting_utils import _resolve_analyzer_dir
+        from aeon.dj_pipeline.utils.spike_sorting_utils import resolve_analyzer_dir
 
-        assert _resolve_analyzer_dir(tmp_path) == tmp_path / "sorting_analyzer"
+        assert resolve_analyzer_dir(tmp_path) == tmp_path / "sorting_analyzer"
 
 
 class TestStripNonNumericProperties:
-    """_strip_non_numeric_properties keeps numeric properties and removes the rest."""
+    """strip_non_numeric_properties keeps numeric properties and removes the rest."""
 
     def _make_recording(self):
         si = pytest.importorskip("spikeinterface")
@@ -50,15 +50,15 @@ class TestStripNonNumericProperties:
         return si.NumpyRecording(traces, sampling_frequency=30000.0)
 
     def test_keeps_numeric_strips_string(self):
-        from aeon.dj_pipeline.utils.spike_sorting_utils import _strip_non_numeric_properties
+        from aeon.dj_pipeline.utils.spike_sorting_utils import strip_non_numeric_properties
 
         rec = self._make_recording()
-        rec.set_property("myfloat", np.array([1.0, 2.0, 3.0, 4.0]))          # kind 'f' -> keep
-        rec.set_property("myint", np.array([0, 1, 0, 1], dtype="int64"))     # kind 'i' -> keep
-        rec.set_property("mybool", np.array([True, False, True, False]))     # kind 'b' -> keep
-        rec.set_property("mystr", np.array(["a", "b", "c", "d"]))            # kind 'U' -> strip
+        rec.set_property("myfloat", np.array([1.0, 2.0, 3.0, 4.0]))  # kind 'f' -> keep
+        rec.set_property("myint", np.array([0, 1, 0, 1], dtype="int64"))  # kind 'i' -> keep
+        rec.set_property("mybool", np.array([True, False, True, False]))  # kind 'b' -> keep
+        rec.set_property("mystr", np.array(["a", "b", "c", "d"]))  # kind 'U' -> strip
 
-        _strip_non_numeric_properties(rec)
+        strip_non_numeric_properties(rec)
 
         keys = set(rec.get_property_keys())
         assert "myfloat" in keys
@@ -67,11 +67,11 @@ class TestStripNonNumericProperties:
         assert "mystr" not in keys
 
     def test_keeps_uint_property(self):
-        from aeon.dj_pipeline.utils.spike_sorting_utils import _strip_non_numeric_properties
+        from aeon.dj_pipeline.utils.spike_sorting_utils import strip_non_numeric_properties
 
         rec = self._make_recording()
-        rec.set_property("myuint", np.array([1, 2, 3, 4], dtype="uint32"))   # kind 'u' -> keep
+        rec.set_property("myuint", np.array([1, 2, 3, 4], dtype="uint32"))  # kind 'u' -> keep
 
-        _strip_non_numeric_properties(rec)
+        strip_non_numeric_properties(rec)
 
         assert "myuint" in set(rec.get_property_keys())

--- a/tests/dj_pipeline/utils/test_spike_sorting_utils_unit.py
+++ b/tests/dj_pipeline/utils/test_spike_sorting_utils_unit.py
@@ -45,7 +45,8 @@ class TestStripNonNumericProperties:
     """strip_non_numeric_properties keeps numeric properties and removes the rest."""
 
     def _make_recording(self):
-        si = pytest.importorskip("spikeinterface")
+        import spikeinterface as si
+
         traces = np.zeros((1000, 4), dtype="int16")
         return si.NumpyRecording(traces, sampling_frequency=30000.0)
 

--- a/tests/dj_pipeline/utils/test_spike_sorting_utils_unit.py
+++ b/tests/dj_pipeline/utils/test_spike_sorting_utils_unit.py
@@ -1,0 +1,78 @@
+"""Unit tests for spike_sorting_utils pure helpers: analyzer dir resolution and
+non-numeric property filtering.
+
+Tests target pure functions with no database dependency. Imports from
+aeon.dj_pipeline are done inside test methods (not at module level) so pytest
+collection does not trigger aeon/dj_pipeline/__init__.py schema activation.
+"""
+
+import numpy as np
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class TestResolveAnalyzerDir:
+    """_resolve_analyzer_dir picks the binary dir if present, else the zarr dir."""
+
+    def test_binary_dir_when_present(self, tmp_path):
+        (tmp_path / "sorting_analyzer").mkdir()
+        from aeon.dj_pipeline.utils.spike_sorting_utils import _resolve_analyzer_dir
+
+        assert _resolve_analyzer_dir(tmp_path) == tmp_path / "sorting_analyzer"
+
+    def test_zarr_dir_when_only_zarr_present(self, tmp_path):
+        (tmp_path / "sorting_analyzer.zarr").mkdir()
+        from aeon.dj_pipeline.utils.spike_sorting_utils import _resolve_analyzer_dir
+
+        assert _resolve_analyzer_dir(tmp_path) == tmp_path / "sorting_analyzer.zarr"
+
+    def test_zarr_path_when_neither_present(self, tmp_path):
+        # Falls back to the zarr path (the expected location for new runs)
+        from aeon.dj_pipeline.utils.spike_sorting_utils import _resolve_analyzer_dir
+
+        assert _resolve_analyzer_dir(tmp_path) == tmp_path / "sorting_analyzer.zarr"
+
+    def test_binary_dir_preferred_when_both_present(self, tmp_path):
+        (tmp_path / "sorting_analyzer").mkdir()
+        (tmp_path / "sorting_analyzer.zarr").mkdir()
+        from aeon.dj_pipeline.utils.spike_sorting_utils import _resolve_analyzer_dir
+
+        assert _resolve_analyzer_dir(tmp_path) == tmp_path / "sorting_analyzer"
+
+
+class TestStripNonNumericProperties:
+    """_strip_non_numeric_properties keeps numeric properties and removes the rest."""
+
+    def _make_recording(self):
+        import spikeinterface as si
+
+        traces = np.zeros((1000, 4), dtype="int16")
+        return si.NumpyRecording(traces, sampling_frequency=30000.0)
+
+    def test_keeps_numeric_strips_string(self):
+        from aeon.dj_pipeline.utils.spike_sorting_utils import _strip_non_numeric_properties
+
+        rec = self._make_recording()
+        rec.set_property("myfloat", np.array([1.0, 2.0, 3.0, 4.0]))          # kind 'f' -> keep
+        rec.set_property("myint", np.array([0, 1, 0, 1], dtype="int64"))     # kind 'i' -> keep
+        rec.set_property("mybool", np.array([True, False, True, False]))     # kind 'b' -> keep
+        rec.set_property("mystr", np.array(["a", "b", "c", "d"]))            # kind 'U' -> strip
+
+        _strip_non_numeric_properties(rec)
+
+        keys = set(rec.get_property_keys())
+        assert "myfloat" in keys
+        assert "myint" in keys
+        assert "mybool" in keys
+        assert "mystr" not in keys
+
+    def test_keeps_uint_property(self):
+        from aeon.dj_pipeline.utils.spike_sorting_utils import _strip_non_numeric_properties
+
+        rec = self._make_recording()
+        rec.set_property("myuint", np.array([1, 2, 3, 4], dtype="uint32"))   # kind 'u' -> keep
+
+        _strip_non_numeric_properties(rec)
+
+        assert "myuint" in set(rec.get_property_keys())

--- a/tests/dj_pipeline/utils/test_spike_sorting_utils_unit.py
+++ b/tests/dj_pipeline/utils/test_spike_sorting_utils_unit.py
@@ -27,11 +27,11 @@ class TestResolveAnalyzerDir:
 
         assert resolve_analyzer_dir(tmp_path) == tmp_path / "sorting_analyzer.zarr"
 
-    def test_zarr_path_when_neither_present(self, tmp_path):
-        # Falls back to the zarr path (the expected location for new runs)
+    def test_raises_when_neither_present(self, tmp_path):
         from aeon.dj_pipeline.utils.spike_sorting_utils import resolve_analyzer_dir
 
-        assert resolve_analyzer_dir(tmp_path) == tmp_path / "sorting_analyzer.zarr"
+        with pytest.raises(FileNotFoundError):
+            resolve_analyzer_dir(tmp_path)
 
     def test_binary_dir_preferred_when_both_present(self, tmp_path):
         (tmp_path / "sorting_analyzer").mkdir()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <3.13"
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform == 'darwin'",
@@ -63,6 +63,7 @@ dev = [
     { name = "ruff" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "spikeinterface" },
     { name = "testcontainers", extra = ["mysql"] },
 ]
 docs = [
@@ -72,11 +73,13 @@ docs = [
 test = [
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "spikeinterface" },
     { name = "testcontainers", extra = ["mysql"] },
 ]
 test-golden = [
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "spikeinterface" },
     { name = "swc-aeon-rigs-foragingabc" },
     { name = "testcontainers", extra = ["mysql"] },
 ]
@@ -125,17 +128,20 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "sphinx" },
+    { name = "spikeinterface", specifier = ">=0.104.0" },
     { name = "testcontainers", extras = ["mysql"], specifier = ">=3.7" },
 ]
 docs = [{ name = "sphinx" }]
 test = [
     { name = "pytest", specifier = ">=7.0" },
     { name = "pytest-cov" },
+    { name = "spikeinterface", specifier = ">=0.104.0" },
     { name = "testcontainers", extras = ["mysql"], specifier = ">=3.7" },
 ]
 test-golden = [
     { name = "pytest", specifier = ">=7.0" },
     { name = "pytest-cov" },
+    { name = "spikeinterface", specifier = ">=0.104.0" },
     { name = "swc-aeon-rigs-foragingabc", git = "https://github.com/SainsburyWellcomeCentre/aeon_exp_foragingABC.git?branch=tn%2Fenv-data-readers" },
     { name = "testcontainers", extras = ["mysql"], specifier = ">=3.7" },
 ]
@@ -1031,7 +1037,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/cb/48e964c452ca2b92175a9b2dca037a553036cb053ba69e284650ce755f13/greenlet-3.3.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:e29f3018580e8412d6aaf5641bb7745d38c85228dacf51a73bd4e26ddf2a6a8e", size = 274908, upload-time = "2025-12-04T14:23:26.435Z" },
     { url = "https://files.pythonhosted.org/packages/28/da/38d7bff4d0277b594ec557f479d65272a893f1f2a716cad91efeb8680953/greenlet-3.3.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a687205fb22794e838f947e2194c0566d3812966b41c78709554aa883183fb62", size = 577113, upload-time = "2025-12-04T14:50:05.493Z" },
     { url = "https://files.pythonhosted.org/packages/3c/f2/89c5eb0faddc3ff014f1c04467d67dee0d1d334ab81fadbf3744847f8a8a/greenlet-3.3.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4243050a88ba61842186cb9e63c7dfa677ec146160b0efd73b855a3d9c7fcf32", size = 590338, upload-time = "2025-12-04T14:57:41.136Z" },
-    { url = "https://files.pythonhosted.org/packages/80/d7/db0a5085035d05134f8c089643da2b44cc9b80647c39e93129c5ef170d8f/greenlet-3.3.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:670d0f94cd302d81796e37299bcd04b95d62403883b24225c6b5271466612f45", size = 601098, upload-time = "2025-12-04T15:07:11.898Z" },
     { url = "https://files.pythonhosted.org/packages/dc/a6/e959a127b630a58e23529972dbc868c107f9d583b5a9f878fb858c46bc1a/greenlet-3.3.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6cb3a8ec3db4a3b0eb8a3c25436c2d49e3505821802074969db017b87bc6a948", size = 590206, upload-time = "2025-12-04T14:26:01.254Z" },
     { url = "https://files.pythonhosted.org/packages/48/60/29035719feb91798693023608447283b266b12efc576ed013dd9442364bb/greenlet-3.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2de5a0b09eab81fc6a382791b995b1ccf2b172a9fec934747a7a23d2ff291794", size = 1550668, upload-time = "2025-12-04T15:04:22.439Z" },
     { url = "https://files.pythonhosted.org/packages/0a/5f/783a23754b691bfa86bd72c3033aa107490deac9b2ef190837b860996c9f/greenlet-3.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4449a736606bd30f27f8e1ff4678ee193bc47f6ca810d705981cfffd6ce0d8c5", size = 1615483, upload-time = "2025-12-04T14:27:28.083Z" },
@@ -1039,7 +1044,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/0a/a3871375c7b9727edaeeea994bfff7c63ff7804c9829c19309ba2e058807/greenlet-3.3.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:b01548f6e0b9e9784a2c99c5651e5dc89ffcbe870bc5fb2e5ef864e9cc6b5dcb", size = 276379, upload-time = "2025-12-04T14:23:30.498Z" },
     { url = "https://files.pythonhosted.org/packages/43/ab/7ebfe34dce8b87be0d11dae91acbf76f7b8246bf9d6b319c741f99fa59c6/greenlet-3.3.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:349345b770dc88f81506c6861d22a6ccd422207829d2c854ae2af8025af303e3", size = 597294, upload-time = "2025-12-04T14:50:06.847Z" },
     { url = "https://files.pythonhosted.org/packages/a4/39/f1c8da50024feecd0793dbd5e08f526809b8ab5609224a2da40aad3a7641/greenlet-3.3.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e8e18ed6995e9e2c0b4ed264d2cf89260ab3ac7e13555b8032b25a74c6d18655", size = 607742, upload-time = "2025-12-04T14:57:42.349Z" },
-    { url = "https://files.pythonhosted.org/packages/77/cb/43692bcd5f7a0da6ec0ec6d58ee7cddb606d055ce94a62ac9b1aa481e969/greenlet-3.3.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c024b1e5696626890038e34f76140ed1daf858e37496d33f2af57f06189e70d7", size = 622297, upload-time = "2025-12-04T15:07:13.552Z" },
     { url = "https://files.pythonhosted.org/packages/75/b0/6bde0b1011a60782108c01de5913c588cf51a839174538d266de15e4bf4d/greenlet-3.3.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:047ab3df20ede6a57c35c14bf5200fcf04039d50f908270d3f9a7a82064f543b", size = 609885, upload-time = "2025-12-04T14:26:02.368Z" },
     { url = "https://files.pythonhosted.org/packages/49/0e/49b46ac39f931f59f987b7cd9f34bfec8ef81d2a1e6e00682f55be5de9f4/greenlet-3.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2d9ad37fc657b1102ec880e637cccf20191581f75c64087a549e66c57e1ceb53", size = 1567424, upload-time = "2025-12-04T15:04:23.757Z" },
     { url = "https://files.pythonhosted.org/packages/05/f5/49a9ac2dff7f10091935def9165c90236d8f175afb27cbed38fb1d61ab6b/greenlet-3.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83cd0e36932e0e7f36a64b732a6f60c2fc2df28c351bae79fbaf4f8092fe7614", size = 1636017, upload-time = "2025-12-04T14:27:29.688Z" },


### PR DESCRIPTION
Switches the spike sorting pipeline's default intermediate format from uncompressed binary to zarr with Blosc-zstd compression. PreProcessing now writes `recording.zarr` instead of `recording.dat`, and PostProcessing writes `sorting_analyzer.zarr`. The compression is lossless and built into SpikeInterface, so there are no new dependencies.

On the golden data this is roughly a 60% reduction in on-disk size (recording 12.7 GB to 5.0 GB, sorting analyzer 0.5 GB to 0.3 GB), and pipeline I/O is faster because less data moves over the Ceph network.

Binary is still fully supported. The format is controlled by a `save_format` key in each paramset's params, and this PR only changes the default from "binary" to "zarr". Paramsets that explicitly set `save_format: "binary"` behave exactly as before.

Main changes:
- Default flipped to "zarr" in PreProcessing, SpikeSorting, PostProcessing, and ApplyOfficialCuration.
- Non-numeric recording properties (structured arrays like `contact_vector`, string and object arrays) are stripped before the zarr write, because zarr v2 cannot serialize them without an explicit object codec.
- SpikeInterface appends `.zarr` to the analyzer folder name, so a shared `_resolve_analyzer_dir` helper resolves the analyzer path for all consumers, and PostProcessing returns the actual `.zarr` path so its files register correctly.
- Zarr chunk files are excluded from the File part table, since a zarr directory is thousands of small files.
- The two pure helpers live in `aeon/dj_pipeline/utils/spike_sorting_utils.py` so they can be unit tested without a database connection.
- Adds `docs/specs/SPEC_ZARR_INTERMEDIATES.md` describing the approach and measured results.

Backward compatible: `si.load()` reads both formats, existing binary intermediates are untouched, and there is no database migration. Old data does not need to be converted.

Validated on the SWC HPC against the golden dataset: the full unit suite passes and the ephys golden integration suite is 29/29, including new assertions for the zarr recording and analyzer.
