### PR TITLE
Clean up ephys pipeline setup, dependencies, and test infrastructure

### DIFF
--- a/aeon/__init__.py
+++ b/aeon/__init__.py
@@ -4,7 +4,7 @@ from importlib.metadata import PackageNotFoundError, version
 
 try:
     # Change here if project is renamed and does not equal the package name
-    dist_name = "aeon"
+    dist_name = "aeon-mecha"
     __version__ = version(dist_name)
 except PackageNotFoundError:
     __version__ = "unknown"

--- a/docs/ephys_runbooks/run_aeon_spike_sorting.py
+++ b/docs/ephys_runbooks/run_aeon_spike_sorting.py
@@ -12,8 +12,16 @@ To run a single task interactively (e.g. for debugging):
 """
 
 import argparse
+import sys
+import traceback
 
 from aeon.dj_pipeline import spike_sorting
+
+# DataJoint 2.x installs a sys.excepthook that prints only "[ERROR]: Uncaught
+# exception" with no traceback. Restore the default hook AFTER importing the
+# pipeline (DJ overwrites it at import time) so a crashed sort task logs a full
+# traceback to its SLURM .err file.
+sys.excepthook = lambda *args: traceback.print_exception(*args)
 
 # =============================================================================
 # Configuration

--- a/docs/ephys_runbooks/run_aeon_spike_sorting.sh
+++ b/docs/ephys_runbooks/run_aeon_spike_sorting.sh
@@ -50,9 +50,12 @@ module load uv
 cd "$SLURM_SUBMIT_DIR"
 echo "Working directory: $(pwd)"
 
-# Ensure venv exists and deps match lockfile
+# Ensure venv exists and deps match lockfile.
+# The spike_sorting extra (spikeinterface[full], spython, cuda-python) is
+# required to actually run the sort — a bare `uv sync` would uninstall it and
+# the job would crash at `import spikeinterface`.
 echo "Syncing dependencies..."
-uv sync
+uv sync --extra spike_sorting
 
 # Set PyTorch CUDA memory allocator configuration to free reserved memory
 # This helps prevent CUDA out of memory errors during long-running Kilosort4 jobs

--- a/docs/ephys_runbooks/step00_setup.md
+++ b/docs/ephys_runbooks/step00_setup.md
@@ -10,7 +10,7 @@ walks through each one.
 
 - **SSH access to the SWC HPC.** If you don't have an account, ask your PI or
   the SWC IT team.
-- **Database credentials** for `aeon-db`. Ask the pipeline team for a username
+- **Database credentials** for `aeondj`. Ask the pipeline team for a username
   and password.
 - **Basic familiarity with DataJoint.** The guide explains each pipeline step,
   but it assumes you know what tables, schemas, and `populate()` calls are. If
@@ -112,6 +112,19 @@ run` prefix ensures you're using the project's virtual environment with the
 correct dependencies, regardless of what other Python installations exist on
 the system.
 
+### Spike-sorting dependencies
+
+The spike-sorting stack (`spikeinterface`, `spython`, `cuda-python`) lives in
+the optional `spike_sorting` extra, not the base install. If you'll run any
+ephys sorting, install it explicitly:
+
+```bash
+uv sync --extra spike_sorting
+```
+
+A bare `uv sync` does **not** include it, so the sort would crash at `import
+spikeinterface`.
+
 ---
 
 ## Database Configuration
@@ -140,7 +153,7 @@ Open the generated file and set these values:
 
 ```json
 {
-  "database.host": "aeon-db",
+  "database.host": "aeondj",
   "database.database_prefix": "u_<yourname>_aeon_ephys_v2_test_",
   "stores": {
     "dj_store": {
@@ -154,9 +167,7 @@ Open the generated file and set these values:
 
 What each field does:
 
-- `database.host` -- Use `aeon-db`. This is the primary database server. Do
-  **not** use `aeon-db2`, which only hosts old historical data from a previous
-  experiment.
+- `database.host` -- Use `aeondj`. This is the primary database server.
 - `database.database_prefix` -- Prepended to every schema name the pipeline
   creates. Using a test prefix like `u_yourname_aeon_ephys_v2_test_` keeps your
   test schemas completely separate from production schemas (which use the
@@ -186,7 +197,7 @@ After setting up the config and credentials, verify the connection:
 uv run python -c "import datajoint as dj; dj.conn()"
 ```
 
-You should see a message confirming a successful connection to `aeon-db`.
+You should see a message confirming a successful connection to `aeondj`.
 
 ---
 

--- a/docs/ephys_runbooks/step03_spike_sorting.py
+++ b/docs/ephys_runbooks/step03_spike_sorting.py
@@ -462,8 +462,16 @@ To run a single task interactively (e.g. for debugging):
 """
 
 import argparse
+import sys
+import traceback
 
 from aeon.dj_pipeline import spike_sorting
+
+# DataJoint 2.x installs a sys.excepthook that prints only "[ERROR]: Uncaught
+# exception" with no traceback. Restore the default hook AFTER importing the
+# pipeline (DJ overwrites it at import time) so a crashed sort task logs a full
+# traceback to its SLURM .err file.
+sys.excepthook = lambda *args: traceback.print_exception(*args)
 
 # =============================================================================
 # Configuration
@@ -584,9 +592,12 @@ module load uv
 cd "$SLURM_SUBMIT_DIR"
 echo "Working directory: $(pwd)"
 
-# Ensure venv exists and deps match lockfile
+# Ensure venv exists and deps match lockfile.
+# The spike_sorting extra (spikeinterface[full], spython, cuda-python) is
+# required to actually run the sort — a bare `uv sync` would uninstall it and
+# the job would crash at `import spikeinterface`.
 echo "Syncing dependencies..."
-uv sync
+uv sync --extra spike_sorting
 
 # Set PyTorch CUDA memory allocator configuration to free reserved memory
 # This helps prevent CUDA out of memory errors during long-running Kilosort4 jobs

--- a/docs/running_golden_tests_on_hpc.md
+++ b/docs/running_golden_tests_on_hpc.md
@@ -15,8 +15,8 @@ PreProcessing reading the amplifier data off Ceph).
 
 ## 1. Get a compute node
 
-Ceph is only visible from compute nodes, not the gateway, so grab a CPU node
-first with a generous walltime:
+The suite is heavy (~35 minutes, lots of Ceph I/O), so run it on a compute node
+rather than on the gateway. Grab a CPU node with a generous walltime:
 
 ```
 srun --nodes=1 --ntasks-per-node=1 --cpus-per-task=8 -p cpu --time=04:00:00 --mem=16G --pty bash -i

--- a/docs/running_golden_tests_on_hpc.md
+++ b/docs/running_golden_tests_on_hpc.md
@@ -1,25 +1,22 @@
 # Running the ephys golden-dataset tests on the SWC HPC
 
-How to run the ephys golden integration suite (`tests/dj_pipeline/test_ephys_ingestion.py`)
-against the staged golden dataset on the SWC HPC. The suite force-injects the
-pre-computed sorting, so it needs **no GPU** — a CPU node is enough and a full
-run takes ~35 minutes (the time is PreProcessing reading the amplifier data off
-Ceph).
+How to run the ephys golden integration suite
+(`tests/dj_pipeline/test_ephys_ingestion.py`) against the golden dataset on the
+SWC HPC. The suite force-injects the pre-computed sorting, so it needs **no
+GPU** — a CPU node is enough, and a full run takes ~35 minutes (most of that is
+PreProcessing reading the amplifier data off Ceph).
 
 ## Prerequisites
 
-- HPC access as your SWC user (`ssh aeon-hpc`).
-- The golden data is already staged in shared home at
-  `~/sciops-data/project_aeon/aeon/data/` (this is the default
-  `DEFAULT_GOLDEN_DATA_ROOT`, so the tests find it automatically). You do not
-  need to stage anything.
-- A database account on `aeondj` (or `aeon-db`). You only need a `datajoint.json`
-  plus a `.secrets/` directory; the steps below copy a known-good pair.
+- HPC access (`ssh aeon-hpc`).
+- A database account on `aeon-db` or `aeondj` (either works — pick one). If you
+  don't have one yet, set one up via the team's DB onboarding or ask Thinh/Elissa.
+- Access to the golden data, which lives on Ceph (see step 4).
 
 ## 1. Get a compute node
 
 Ceph is only visible from compute nodes, not the gateway, so grab a CPU node
-first. Give it a generous walltime so the run isn't cut off:
+first with a generous walltime:
 
 ```
 srun --nodes=1 --ntasks-per-node=1 --cpus-per-task=8 -p cpu --time=04:00:00 --mem=16G --pty bash -i
@@ -27,7 +24,7 @@ srun --nodes=1 --ntasks-per-node=1 --cpus-per-task=8 -p cpu --time=04:00:00 --me
 
 ## 2. Check out the code and install dependencies
 
-Use your own checkout directory so you don't collide with other sessions:
+Use your own checkout directory:
 
 ```
 module load uv
@@ -39,29 +36,46 @@ Both flags matter. `--extra spike_sorting` pulls in spikeinterface/probeinterfac
 (without it the ephys tests skip and some unit tests hard-fail). `--group
 test-golden` pulls in `swc-aeon-rigs-foragingabc`, needed by the golden fixtures.
 
-If your DB is `aeondj` (MySQL), also install the auth dependency it needs:
+If you connect to **aeondj** (MySQL), also install the auth dependency it needs:
 
 ```
 uv pip install cryptography
 ```
 
-## 3. Point at the database
+(Not needed for `aeon-db`.)
+
+## 3. Point at your database
 
 The integration tests need an external database (there is no Docker on the HPC).
-Setting `TEST_DB_PREFIX` tells the test harness to skip testcontainers and use
-your `datajoint.json` + `.secrets/` instead. Copy a known-good config:
+Setting `TEST_DB_PREFIX` tells the test harness to skip testcontainers and use a
+`datajoint.json` + `.secrets/` in your checkout directory. Create them with your
+own credentials.
+
+`datajoint.json` (set `host` to whichever server you're using):
+
+```json
+{
+  "database": {
+    "host": "aeon-db",
+    "port": 3306,
+    "reconnect": true,
+    "database_prefix": "u_<your_user>_test_"
+  },
+  "stores": {
+    "dj_store": {
+      "protocol": "file",
+      "location": "/ceph/aeon/aeon/dj_store",
+      "stage": "/ceph/aeon/aeon/dj_store"
+    }
+  }
+}
+```
+
+`.secrets/` with two files holding just the credential values:
 
 ```
-cp ~/ProjectAeon/foragingABC_analysis/datajoint.json .
-cp -r ~/ProjectAeon/foragingABC_analysis/.secrets .
-```
-
-Confirm `datajoint.json` points at the server you want (`aeon-db` or `aeondj`).
-To switch it to aeondj, set the host and your aeondj password:
-
-```
-uv run python -c "import json; d=json.load(open('datajoint.json')); d['database']['host']='aeondj'; json.dump(d,open('datajoint.json','w'),indent=2)"
-printf '%s' 'YOUR_AEONDJ_PASSWORD' > .secrets/database.password
+.secrets/database.user       # your DB username
+.secrets/database.password   # your DB password (for aeondj, your aeondj password)
 ```
 
 Then set a **distinct** schema prefix. It must end in `_`, and it should be
@@ -72,38 +86,60 @@ server:
 export TEST_DB_PREFIX=u_${USER}_golden_tests_
 ```
 
-## 4. Sanity-check before the long run
+(The test fixtures override the `dj_store` to a per-session temp dir, so the
+`stores` entry above is just to make the config valid — the tests don't write to
+the production store.)
 
-Confirm the connection and namespace are what you expect. This actually connects,
-so it's your early check that the host, password, and (for aeondj) cryptography
-are all good before committing to a 35-minute run:
+## 4. Make sure the golden data is reachable
+
+By default the tests look for the data under
+`~/sciops-data/project_aeon/aeon/data` (per-user, see
+`DEFAULT_GOLDEN_DATA_ROOT` in `tests/dj_pipeline/conftest.py`). The source of
+truth lives on Ceph, so you have two options:
+
+- **Point at the Ceph copy** by setting the `DJ_REPOSITORY_CONFIG` env var to a
+  DataJoint config whose `repository_config` maps `ceph_aeon` to the golden-data
+  root, or
+- **Stage a local copy** into `~/sciops-data/...` (rsync from Ceph — see the
+  staging pattern in `docs/specs/SPEC_TESTING.md`).
+
+Either way, confirm the ephys golden epoch and its required files are visible at
+whichever root you use before running. The dataset's `experiment_path`,
+`epoch_dir`, and `required_files` are listed in the `GOLDEN_DATASETS` registry in
+`tests/dj_pipeline/conftest.py` (the ephys entry is
+`foraging_abc_ephys_2026_05_11`). A quick `ls` of the epoch directory is a good
+check.
+
+Important: if the data isn't found at the configured root, `_check_golden_data`
+calls `pytest.skip(...)` rather than failing — so a run full of **skips** means
+the data root isn't set right, not that everything passed.
+
+## 5. Sanity-check before the long run
+
+Confirm the database connection and namespace are what you expect. This actually
+connects, so it catches host/password (and, for aeondj, cryptography) problems
+before you commit to a 35-minute run:
 
 ```
 uv run python -c "import os, datajoint as dj; dj.conn(); print('host:', dj.config.database.host); print('user:', dj.config.database.user); print('prefix:', os.environ.get('TEST_DB_PREFIX'))"
 ```
 
-Confirm the golden data is visible from this node:
-
-```
-ls ~/sciops-data/project_aeon/aeon/data/raw/AEONX1/abcGolden01/2026-05-11T07-50-11/
-```
-
-## 5. Run the tests
+## 6. Run the tests
 
 ```
 uv run pytest -m integration tests/dj_pipeline/test_ephys_ingestion.py -v --tb=short -ra 2>&1 | tee golden_test_output.txt
 ```
 
-## 6. Reading the output
+## 7. Reading the output
 
 - **Expected result: `29 passed`.** That is the golden baseline for this module.
-- A test that **skips** rather than runs usually means a dependency or the golden
-  data isn't found. If the whole module skips, recheck step 2 (the extra/group)
-  and step 4 (the `ls`).
-- A test that **fails** is a real signal — the `--tb=short` traceback tells you
-  where. The ones most worth watching for ephys/zarr changes are
-  `test_recording_zarr_exists` (PreProcessing's recording output) and
-  `test_sorting_analyzer_created` (PostProcessing's analyzer output).
+- **Skipped** tests mean a dependency or the golden data wasn't found. A run
+  that's mostly skips is NOT a pass — recheck step 2 (the extra/group) and step 4
+  (the data root).
+- **Failed** tests are a real signal; the `--tb=short` traceback shows where. The
+  ones most worth watching for ephys/zarr changes are `test_recording_zarr_exists`
+  (PreProcessing's recording output) and `test_sorting_analyzer_created`
+  (PostProcessing's analyzer output).
 
 ## Re-running
 

--- a/docs/running_golden_tests_on_hpc.md
+++ b/docs/running_golden_tests_on_hpc.md
@@ -1,0 +1,123 @@
+# Running the ephys golden-dataset tests on the SWC HPC
+
+How to run the ephys golden integration suite (`tests/dj_pipeline/test_ephys_ingestion.py`)
+against the staged golden dataset on the SWC HPC. The suite force-injects the
+pre-computed sorting, so it needs **no GPU** — a CPU node is enough and a full
+run takes ~35 minutes (the time is PreProcessing reading the amplifier data off
+Ceph).
+
+## Prerequisites
+
+- HPC access as your SWC user (`ssh aeon-hpc`).
+- The golden data is already staged in shared home at
+  `~/sciops-data/project_aeon/aeon/data/` (this is the default
+  `DEFAULT_GOLDEN_DATA_ROOT`, so the tests find it automatically). You do not
+  need to stage anything.
+- A database account on `aeondj` (or `aeon-db`). You only need a `datajoint.json`
+  plus a `.secrets/` directory; the steps below copy a known-good pair.
+
+## 1. Get a compute node
+
+Ceph is only visible from compute nodes, not the gateway, so grab a CPU node
+first. Give it a generous walltime so the run isn't cut off:
+
+```
+srun --nodes=1 --ntasks-per-node=1 --cpus-per-task=8 -p cpu --time=04:00:00 --mem=16G --pty bash -i
+```
+
+## 2. Check out the code and install dependencies
+
+Use your own checkout directory so you don't collide with other sessions:
+
+```
+module load uv
+cd <your_aeon_mecha_checkout>
+uv sync --extra spike_sorting --group test-golden
+```
+
+Both flags matter. `--extra spike_sorting` pulls in spikeinterface/probeinterface
+(without it the ephys tests skip and some unit tests hard-fail). `--group
+test-golden` pulls in `swc-aeon-rigs-foragingabc`, needed by the golden fixtures.
+
+If your DB is `aeondj` (MySQL), also install the auth dependency it needs:
+
+```
+uv pip install cryptography
+```
+
+## 3. Point at the database
+
+The integration tests need an external database (there is no Docker on the HPC).
+Setting `TEST_DB_PREFIX` tells the test harness to skip testcontainers and use
+your `datajoint.json` + `.secrets/` instead. Copy a known-good config:
+
+```
+cp ~/ProjectAeon/foragingABC_analysis/datajoint.json .
+cp -r ~/ProjectAeon/foragingABC_analysis/.secrets .
+```
+
+Confirm `datajoint.json` points at the server you want (`aeon-db` or `aeondj`).
+To switch it to aeondj, set the host and your aeondj password:
+
+```
+uv run python -c "import json; d=json.load(open('datajoint.json')); d['database']['host']='aeondj'; json.dump(d,open('datajoint.json','w'),indent=2)"
+printf '%s' 'YOUR_AEONDJ_PASSWORD' > .secrets/database.password
+```
+
+Then set a **distinct** schema prefix. It must end in `_`, and it should be
+unique to you so you don't collide with anyone else's test schemas on the shared
+server:
+
+```
+export TEST_DB_PREFIX=u_${USER}_golden_tests_
+```
+
+## 4. Sanity-check before the long run
+
+Confirm the connection and namespace are what you expect. This actually connects,
+so it's your early check that the host, password, and (for aeondj) cryptography
+are all good before committing to a 35-minute run:
+
+```
+uv run python -c "import os, datajoint as dj; dj.conn(); print('host:', dj.config.database.host); print('user:', dj.config.database.user); print('prefix:', os.environ.get('TEST_DB_PREFIX'))"
+```
+
+Confirm the golden data is visible from this node:
+
+```
+ls ~/sciops-data/project_aeon/aeon/data/raw/AEONX1/abcGolden01/2026-05-11T07-50-11/
+```
+
+## 5. Run the tests
+
+```
+uv run pytest -m integration tests/dj_pipeline/test_ephys_ingestion.py -v --tb=short -ra 2>&1 | tee golden_test_output.txt
+```
+
+## 6. Reading the output
+
+- **Expected result: `29 passed`.** That is the golden baseline for this module.
+- A test that **skips** rather than runs usually means a dependency or the golden
+  data isn't found. If the whole module skips, recheck step 2 (the extra/group)
+  and step 4 (the `ls`).
+- A test that **fails** is a real signal — the `--tb=short` traceback tells you
+  where. The ones most worth watching for ephys/zarr changes are
+  `test_recording_zarr_exists` (PreProcessing's recording output) and
+  `test_sorting_analyzer_created` (PostProcessing's analyzer output).
+
+## Re-running
+
+The integration fixtures don't drop their schemas on an external DB, so stale
+schemas from a previous run can cause confusing failures. Before re-running,
+drop your test schemas. **Check the namespace first** so you only ever drop your
+own prefix:
+
+```
+uv run python -c "import os, datajoint as dj; pref=os.environ['TEST_DB_PREFIX']; print('host:', dj.config.database.host, 'prefix:', pref); [print('would drop:', s) for s in dj.list_schemas() if s.startswith(pref)]"
+```
+
+Then drop them:
+
+```
+uv run python -c "import os, datajoint as dj; dj.config.safemode=False; pref=os.environ['TEST_DB_PREFIX']; assert pref.endswith('_') and 'test' in pref; [dj.Schema(s).drop() for s in dj.list_schemas() if s.startswith(pref)]; print('dropped')"
+```

--- a/docs/specs/SPEC_TESTING.md
+++ b/docs/specs/SPEC_TESTING.md
@@ -162,7 +162,7 @@ Without it, the test module skips at import time via `pytest.importorskip`.
 
 The full ephys suite runs on the HPC against `/ceph` data. From `aeon-hpc`:
 
-1. **Get onto a compute node** (Ceph isn't visible from the gateway):
+1. **Get onto a compute node** (the suite is heavy; run it off the shared gateway):
    ```bash
    srun --cpus-per-task=2 --mem=8G --time=2:00:00 --pty bash
    ```
@@ -240,7 +240,7 @@ uv run pytest --cov=aeon --cov-report=html
 
 **"Cannot connect to Docker daemon" on local runs.** Testcontainers needs Docker. On HPC use `TEST_DB_PREFIX` against an external DB instead (see HPC setup).
 
-**"Cannot touch /ceph/..." / Ceph not visible.** You're on the gateway. `srun` onto a compute node first.
+**"Cannot touch /ceph/..." / Ceph access problems.** Ceph is now mounted on the gateway as well as the compute nodes, so this is rare; if you do hit it, `srun` onto a compute node.
 
 **Stale test schemas from a crashed run.** Manually drop:
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ license = { file = "license.md" }
 readme = "readme.md"
 dependencies = [
   "bottleneck>=1.2.1,<2",
+  "cryptography",
   "datajoint>=2.2.2",
   "swc-aeon>=0.1.0",
   "fastparquet",

--- a/tests/dj_pipeline/conftest.py
+++ b/tests/dj_pipeline/conftest.py
@@ -248,14 +248,21 @@ def streams_schema(dj_config_integration):
     }
 
     # Teardown
-    # - drop test schema (may already be dropped by full_pipeline)
+    # - Drop test schemas ONLY when running against an external database
+    #   (TEST_DB_PREFIX set, e.g. on the HPC), so re-runs start clean instead of
+    #   silently reusing stale schemas. _drop_test_schemas() is scoped strictly
+    #   to dj.config.database.database_prefix (== TEST_DB_PREFIX, which must end
+    #   in "_"); it only removes schemas whose name starts with that prefix, so
+    #   it can never touch production ("aeon_") or another user's schemas.
+    #   When TEST_DB_PREFIX is unset, the tests use a throwaway testcontainer
+    #   that is discarded at session end, so we drop nothing and leave any
+    #   local/hand-managed database alone.
+    #   This is the single session-end cleanup: full_pipeline is parametrized
+    #   over multiple goldens, so dropping here (rather than in full_pipeline's
+    #   per-iteration teardown) avoids wiping schemas a later iteration needs.
     # - restore original streams.py file
-    import datajoint as dj
-
-    try:
-        dj.Schema(streams.schema.database).drop()
-    except Exception:
-        pass
+    if os.environ.get("TEST_DB_PREFIX"):
+        _drop_test_schemas()
 
     if original is not None:
         f.write_bytes(original)
@@ -371,9 +378,11 @@ def full_pipeline(dj_config_integration, streams_schema, golden_dataset_config):
     }
 
     # No per-iteration teardown — golden_dataset_config is parametrized, so
-    # this fixture runs once per dataset. Dropping schemas between iterations
-    # would invalidate the cached streams_schema fixture. Final cleanup
-    # happens when the MySQL testcontainer shuts down at session end.
+    # this fixture runs once per dataset, and dropping schemas between
+    # iterations would invalidate the cached streams_schema fixture. The single
+    # session-end cleanup (dropping this run's test-prefixed schemas, and only
+    # on an external DB) lives in the streams_schema teardown, which runs
+    # exactly once after all params.
 
 
 @pytest.fixture(scope="session")
@@ -513,10 +522,15 @@ def ephys_full_pipeline(dj_config_integration, tmp_path_factory):
             "sorting_root": sorting_root,
         }
     finally:
-        # Restore the original function and drop test schemas, regardless of
-        # whether the fixture body or any consumer test raised.
+        # Always restore the patched function, regardless of whether the
+        # fixture body or any consumer test raised. Then, only when running
+        # against an external DB (TEST_DB_PREFIX set), drop this run's
+        # test-prefixed schemas so re-runs start clean. The drop is scoped
+        # strictly to the configured prefix (never production or another
+        # user's schemas); the default throwaway testcontainer needs no drop.
         ss_module.get_sorting_root_dir = _original_get_sorting_root
-        _drop_test_schemas()
+        if os.environ.get("TEST_DB_PREFIX"):
+            _drop_test_schemas()
 
 
 @pytest.fixture(scope="session")

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,7 @@ version = "0.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "bottleneck" },
+    { name = "cryptography" },
     { name = "datajoint" },
     { name = "fastparquet" },
     { name = "graphviz" },
@@ -87,6 +88,7 @@ test-golden = [
 [package.metadata]
 requires-dist = [
     { name = "bottleneck", specifier = ">=1.2.1,<2" },
+    { name = "cryptography" },
     { name = "cuda-python", marker = "extra == 'spike-sorting'" },
     { name = "cupy", marker = "extra == 'gpu'" },
     { name = "dask", marker = "extra == 'gpu'" },
@@ -1037,6 +1039,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/cb/48e964c452ca2b92175a9b2dca037a553036cb053ba69e284650ce755f13/greenlet-3.3.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:e29f3018580e8412d6aaf5641bb7745d38c85228dacf51a73bd4e26ddf2a6a8e", size = 274908, upload-time = "2025-12-04T14:23:26.435Z" },
     { url = "https://files.pythonhosted.org/packages/28/da/38d7bff4d0277b594ec557f479d65272a893f1f2a716cad91efeb8680953/greenlet-3.3.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a687205fb22794e838f947e2194c0566d3812966b41c78709554aa883183fb62", size = 577113, upload-time = "2025-12-04T14:50:05.493Z" },
     { url = "https://files.pythonhosted.org/packages/3c/f2/89c5eb0faddc3ff014f1c04467d67dee0d1d334ab81fadbf3744847f8a8a/greenlet-3.3.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4243050a88ba61842186cb9e63c7dfa677ec146160b0efd73b855a3d9c7fcf32", size = 590338, upload-time = "2025-12-04T14:57:41.136Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d7/db0a5085035d05134f8c089643da2b44cc9b80647c39e93129c5ef170d8f/greenlet-3.3.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:670d0f94cd302d81796e37299bcd04b95d62403883b24225c6b5271466612f45", size = 601098, upload-time = "2025-12-04T15:07:11.898Z" },
     { url = "https://files.pythonhosted.org/packages/dc/a6/e959a127b630a58e23529972dbc868c107f9d583b5a9f878fb858c46bc1a/greenlet-3.3.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6cb3a8ec3db4a3b0eb8a3c25436c2d49e3505821802074969db017b87bc6a948", size = 590206, upload-time = "2025-12-04T14:26:01.254Z" },
     { url = "https://files.pythonhosted.org/packages/48/60/29035719feb91798693023608447283b266b12efc576ed013dd9442364bb/greenlet-3.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2de5a0b09eab81fc6a382791b995b1ccf2b172a9fec934747a7a23d2ff291794", size = 1550668, upload-time = "2025-12-04T15:04:22.439Z" },
     { url = "https://files.pythonhosted.org/packages/0a/5f/783a23754b691bfa86bd72c3033aa107490deac9b2ef190837b860996c9f/greenlet-3.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4449a736606bd30f27f8e1ff4678ee193bc47f6ca810d705981cfffd6ce0d8c5", size = 1615483, upload-time = "2025-12-04T14:27:28.083Z" },
@@ -1044,6 +1047,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/0a/a3871375c7b9727edaeeea994bfff7c63ff7804c9829c19309ba2e058807/greenlet-3.3.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:b01548f6e0b9e9784a2c99c5651e5dc89ffcbe870bc5fb2e5ef864e9cc6b5dcb", size = 276379, upload-time = "2025-12-04T14:23:30.498Z" },
     { url = "https://files.pythonhosted.org/packages/43/ab/7ebfe34dce8b87be0d11dae91acbf76f7b8246bf9d6b319c741f99fa59c6/greenlet-3.3.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:349345b770dc88f81506c6861d22a6ccd422207829d2c854ae2af8025af303e3", size = 597294, upload-time = "2025-12-04T14:50:06.847Z" },
     { url = "https://files.pythonhosted.org/packages/a4/39/f1c8da50024feecd0793dbd5e08f526809b8ab5609224a2da40aad3a7641/greenlet-3.3.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e8e18ed6995e9e2c0b4ed264d2cf89260ab3ac7e13555b8032b25a74c6d18655", size = 607742, upload-time = "2025-12-04T14:57:42.349Z" },
+    { url = "https://files.pythonhosted.org/packages/77/cb/43692bcd5f7a0da6ec0ec6d58ee7cddb606d055ce94a62ac9b1aa481e969/greenlet-3.3.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c024b1e5696626890038e34f76140ed1daf858e37496d33f2af57f06189e70d7", size = 622297, upload-time = "2025-12-04T15:07:13.552Z" },
     { url = "https://files.pythonhosted.org/packages/75/b0/6bde0b1011a60782108c01de5913c588cf51a839174538d266de15e4bf4d/greenlet-3.3.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:047ab3df20ede6a57c35c14bf5200fcf04039d50f908270d3f9a7a82064f543b", size = 609885, upload-time = "2025-12-04T14:26:02.368Z" },
     { url = "https://files.pythonhosted.org/packages/49/0e/49b46ac39f931f59f987b7cd9f34bfec8ef81d2a1e6e00682f55be5de9f4/greenlet-3.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2d9ad37fc657b1102ec880e637cccf20191581f75c64087a549e66c57e1ceb53", size = 1567424, upload-time = "2025-12-04T15:04:23.757Z" },
     { url = "https://files.pythonhosted.org/packages/05/f5/49a9ac2dff7f10091935def9165c90236d8f175afb27cbed38fb1d61ab6b/greenlet-3.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83cd0e36932e0e7f36a64b732a6f60c2fc2df28c351bae79fbaf4f8092fe7614", size = 1636017, upload-time = "2025-12-04T14:27:29.688Z" },


### PR DESCRIPTION
## Summary

While validating `main` on the SWC HPC (the full test suite plus the step01-06 ephys walkthrough), a handful of environment, dependency, and test-infrastructure papercuts turned up. None of them are pipeline-logic bugs, but each one makes a fresh setup harder than it should be. This PR fixes them.

## Changes

**Packaging and environment**
- `aeon.__version__` resolved to `"unknown"` because the version lookup used the package name `aeon` instead of the installed distribution name. Set it to `aeon-mecha` so the real version reports.
- Added `cryptography` to the project dependencies. The aeondj MySQL server uses `caching_sha2_password`, which pymysql cannot authenticate against without `cryptography`. Previously it had to be pip-installed by hand on every fresh setup.

**Generated spike-sorting scripts**
- The SLURM sort script (both the generator template in `step03` and the committed example) used a bare `uv sync`, which prunes the `spike_sorting` extra and leaves the job to crash at `import spikeinterface`. Changed to `uv sync --extra spike_sorting`.
- The generated worker script now installs the DataJoint 2.x excepthook after importing the pipeline, so a crashed sort task logs a full traceback instead of only `[ERROR]: Uncaught exception`.

**Test infrastructure**
- When the integration tests run against an external database (with `TEST_DB_PREFIX` set, as on the HPC), the golden fixtures previously left their schemas behind, so re-runs silently reused stale schemas and failed with confusing "Insert 0 new" errors. The session-end teardown now drops the schemas created under that run's test prefix. The drop is scoped strictly to the configured `TEST_DB_PREFIX` (which must end in `_`), so it only removes schemas this run created, never production or another user's schemas, and it only runs against an external DB, leaving the default throwaway-testcontainer runs and any hand-managed database alone.

**Docs**
- `step00_setup.md` now points at `aeondj` as the primary database server and documents that ephys and sorting work needs the `spike_sorting` extra.
- `SPEC_TESTING.md`: Ceph is now mounted on the gateway too, so removed the stale "Ceph isn't visible from the gateway" notes.
