### PR TITLE
Fix ephys HARP time alignment: use Seconds column, not Value.HarpTime

### DIFF
--- a/aeon/dj_pipeline/ephys.py
+++ b/aeon/dj_pipeline/ephys.py
@@ -385,9 +385,9 @@ class EphysSyncModel(dj.Manual):
 
     definition = """
     -> EphysEpoch
-    sync_start: datetime(6)            # PK — observed harp_time[0] from CSV (master clock)
+    sync_start: datetime(6)            # PK — observed HARP time[0] from CSV (Seconds column) 
     ---
-    sync_end: datetime(6)              # observed harp_time[-1] from CSV
+    sync_end: datetime(6)              # observed HARP time[-1] from CSV (Seconds column) 
     onix_ts_start: int64               # observed clock[0] from CSV
     onix_ts_end: int64                 # observed clock[-1] from CSV
     sync_model: <attach>               # joblib-serialized LinearRegression (onix→harp)

--- a/aeon/schema/ephys.py
+++ b/aeon/schema/ephys.py
@@ -41,7 +41,14 @@ class HarpSyncModel(Stream):
         def read(self, file):
             data = super().read(file).dropna()
             onix_clock = data.clock.values.reshape(-1, 1)
-            harp_time = data.harp_time.values.reshape(-1, 1)
+            
+            # ONIX records the raw seconds value arriving from the HARP master
+            # clock as "Value.HarpTime". In the harp world, this timestamp 
+            # corresponds to the second that is about to end in less than a
+            # millisecond, therefore it is lagging by 1 second.
+            # The index colums (Seconds) is the actual time that corresponds most
+            # closely to the actual harp time when the ONIX clock was recorded
+            harp_time = data.index.values.reshape(-1, 1)
 
             model = LinearRegression().fit(onix_clock, harp_time)
             r2 = model.score(onix_clock, harp_time)


### PR DESCRIPTION
## Summary

The ephys time-synchronization pipeline was fitting the ONIX→HARP regression against the wrong CSV column, introducing a **1-second offset** into every HARP timestamp derived from ephys data.

`HarpSync` CSVs have the format:

```
Seconds,Value.Clock,Value.HubClock,Value.HarpTime
3861601200,24933986476361,24933986476326,3861601199
3861601201,24934235900049,24934235899804,3861601200
```

The `HarpSyncModel` reader was using the `Value.HarpTime` column. That HARP timestamp reports the second that is *about to elapse*, so it lags the true time by one second (note `Value.HarpTime` = `Seconds − 1` in every row). The authoritative time is the `Seconds` column, which the `swc.aeon` CSV reader exposes as the DataFrame index.

## Change

- `aeon/schema/ephys.py` — source `harp_time` from `data.index` (the `Seconds` column) instead of `data.harp_time` (`Value.HarpTime`) when fitting the ONIX→HARP `LinearRegression`. Added a comment explaining the offset.
- `aeon/dj_pipeline/ephys.py` — updated the `EphysSyncModel` column comments to note `sync_start`/`sync_end` come from the `Seconds` column.

The fix lives entirely in the reader, so the corrected value propagates through the fitted `model`, `harp_start`/`harp_end`, and `clock_start`/`clock_end`.

## ⚠️ Requires re-ingestion
This fix requires to re-ingest data, since all tables downstream and including `EphysEpoch` are affected.

🤖 Co-created with [Claude Code](https://claude.com/claude-code)
