### PR TITLE
Read compressed raw ephys files (prefer .zarr, fall back to .bin)

### DIFF
--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -20,6 +20,7 @@ import pandas as pd
 from swc.aeon.io import api as io_api
 
 from aeon.dj_pipeline import get_schema_name
+from aeon.dj_pipeline.utils.ephys_utils import resolve_ephys_file
 from aeon.dj_pipeline.utils.paths import get_sorting_root_dir
 from aeon.dj_pipeline.utils.spike_sorting_utils import (
     resolve_analyzer_dir,
@@ -261,18 +262,28 @@ class PreProcessing(dj.Computed):
 
         execution_time = datetime.now(UTC)
 
-        # Concatenate recordings
+        # Concatenate recordings. Each chunk file is resolved on disk: prefer the
+        # compressed .zarr twin under the processed store, else the raw .bin.
         si_recs = []
         for f, d in zip(ephys_files, dir_types, strict=False):
             ephys_dir = acquisition.Experiment.get_data_directory(key, directory_type=d)
-            si_rec = se.read_binary(
-                ephys_dir / f,
-                sampling_frequency=fs_hz,
-                dtype=np.uint16,
-                num_channels=num_channels,
-                gain_to_uV=gain_to_uV,
-                offset_to_uV=offset_to_uV,
-            )
+            resolved = resolve_ephys_file(ephys_dir / f)
+            if resolved.suffix == ".zarr":
+                # The compression library writes zarr from a plain read_binary
+                # (no gains), so re-attach the gain/offset metadata the .bin
+                # branch sets, to keep the two branches equivalent.
+                si_rec = si.load(resolved)
+                si_rec.set_channel_gains(gain_to_uV)
+                si_rec.set_channel_offsets(offset_to_uV)
+            else:
+                si_rec = se.read_binary(
+                    resolved,
+                    sampling_frequency=fs_hz,
+                    dtype=np.uint16,
+                    num_channels=num_channels,
+                    gain_to_uV=gain_to_uV,
+                    offset_to_uV=offset_to_uV,
+                )
             si_recs.append(si_rec)
         si_recording = si.concatenate_recordings(si_recs)
 

--- a/aeon/dj_pipeline/utils/ephys_utils.py
+++ b/aeon/dj_pipeline/utils/ephys_utils.py
@@ -21,6 +21,59 @@ DEVICE_PROBE_TYPE_MAP = {
 }
 
 
+def resolve_ephys_file(raw_bin_path: Path) -> Path:
+    """Resolve a raw amplifier ``.bin`` path to the file that exists on disk.
+
+    Compressed raw ephys (from the companion ``aeon_raw_compression`` library) is
+    written as a ``.zarr`` archive under a *processed* data root that mirrors the
+    raw sub-path: a file at ``.../data/raw/<sub>/<name>.bin`` has its compressed
+    twin at ``.../data/processed/<sub>/<name>.zarr``. This resolver prefers that
+    ``.zarr`` twin and falls back to the raw ``.bin`` (compression is optional and
+    per-user; either or both may be present).
+
+    The raw->processed mapping is a fixed convention, not configurable: replace
+    the single ``"raw"`` path component with ``"processed"`` and swap the suffix
+    to ``.zarr``. This mirrors ``aeon_raw_compression``'s path mapping
+    (``pipeline._processed_zarr_path``) WITHOUT importing that library, since not
+    all users install it -- keep the two in sync by hand if either changes.
+
+    Args:
+        raw_bin_path: Absolute path to the raw ``.bin`` amplifier file as
+            reconstructed by the pipeline (``data_directory / file_path``).
+
+    Returns:
+        The ``.zarr`` twin if it exists, else the raw ``.bin`` if it exists.
+
+    Raises:
+        ValueError: If the path has more than one ``"raw"`` component (the
+            processed-store root would be ambiguous).
+        FileNotFoundError: If neither the ``.zarr`` twin nor the ``.bin`` exists.
+    """
+    raw_bin_path = Path(raw_bin_path)
+    parts = raw_bin_path.parts
+
+    raw_indices = [i for i, part in enumerate(parts) if part == "raw"]
+    if len(raw_indices) > 1:
+        raise ValueError(
+            f"Cannot resolve compressed twin for {raw_bin_path}: path has "
+            f"{len(raw_indices)} 'raw' components; the processed-store root is "
+            f"ambiguous."
+        )
+
+    zarr_candidate = None
+    if len(raw_indices) == 1:
+        i = raw_indices[0]
+        zarr_candidate = Path(*parts[:i], "processed", *parts[i + 1 :]).with_suffix(".zarr")
+
+    if zarr_candidate is not None and zarr_candidate.exists():
+        return zarr_candidate
+    if raw_bin_path.exists():
+        return raw_bin_path
+
+    checked = str(raw_bin_path) if zarr_candidate is None else f"{zarr_candidate} or {raw_bin_path}"
+    raise FileNotFoundError(f"No ephys file found (checked {checked}).")
+
+
 def get_probe_id(metadata: dict | None, device_name: str, probe_label: str) -> str | None:
     """Extract probe identifier from metadata.
 

--- a/aeon/dj_pipeline/utils/ephys_utils.py
+++ b/aeon/dj_pipeline/utils/ephys_utils.py
@@ -52,17 +52,15 @@ def resolve_ephys_file(raw_bin_path: Path) -> Path:
     raw_bin_path = Path(raw_bin_path)
     parts = raw_bin_path.parts
 
-    raw_indices = [i for i, part in enumerate(parts) if part == "raw"]
-    if len(raw_indices) > 1:
+    if parts.count("raw") > 1:
         raise ValueError(
             f"Cannot resolve compressed twin for {raw_bin_path}: path has "
-            f"{len(raw_indices)} 'raw' components; the processed-store root is "
-            f"ambiguous."
+            "multiple 'raw' components; the processed-store root is ambiguous."
         )
 
     zarr_candidate = None
-    if len(raw_indices) == 1:
-        i = raw_indices[0]
+    if "raw" in parts:
+        i = parts.index("raw")
         zarr_candidate = Path(*parts[:i], "processed", *parts[i + 1 :]).with_suffix(".zarr")
 
     if zarr_candidate is not None and zarr_candidate.exists():

--- a/docs/running_golden_tests_on_hpc.md
+++ b/docs/running_golden_tests_on_hpc.md
@@ -36,13 +36,9 @@ Both flags matter. `--extra spike_sorting` pulls in spikeinterface/probeinterfac
 (without it the ephys tests skip and some unit tests hard-fail). `--group
 test-golden` pulls in `swc-aeon-rigs-foragingabc`, needed by the golden fixtures.
 
-If you connect to **aeondj** (MySQL), also install the auth dependency it needs:
-
-```
-uv pip install cryptography
-```
-
-(Not needed for `aeon-db`.)
+`cryptography` (needed for aeondj's `caching_sha2_password` auth) is a core
+dependency as of PR #591, so the `uv sync` above already installs it. No separate
+install step is needed for either server.
 
 ## 3. Point at your database
 

--- a/docs/specs/SPEC_READ_COMPRESSED.md
+++ b/docs/specs/SPEC_READ_COMPRESSED.md
@@ -208,11 +208,13 @@ integration test covers it on real data.
 
 ## PR checklist
 
-- [ ] Add `resolve_ephys_file` to `aeon/dj_pipeline/utils/ephys_utils.py`
-- [ ] Wire it into `PreProcessing.make_compute` (resolve + suffix branch +
+- [x] Add `resolve_ephys_file` to `aeon/dj_pipeline/utils/ephys_utils.py`
+- [x] Wire it into `PreProcessing.make_compute` (resolve + suffix branch +
       gain/offset re-apply on the `.zarr` branch)
-- [ ] Unit tests in `tests/dj_pipeline/utils/test_ephys_utils_unit.py`
-- [ ] Golden integration test in `tests/dj_pipeline/test_ephys_ingestion.py`
-- [ ] Add this spec (`docs/specs/SPEC_READ_COMPRESSED.md`)
-- [ ] Run unit suite locally; run golden suite on HPC
+- [x] Unit tests in `tests/dj_pipeline/utils/test_ephys_utils_unit.py`
+- [x] Golden integration test in `tests/dj_pipeline/test_ephys_ingestion.py`
+      (`TestCompressedReadEquivalence`)
+- [x] Add this spec (`docs/specs/SPEC_READ_COMPRESSED.md`)
+- [x] Run unit suite locally (113 passed)
+- [ ] Run golden suite on HPC (`TestCompressedReadEquivalence` + regression)
 - [ ] Open PR into main (after explicit go-ahead)

--- a/docs/specs/SPEC_READ_COMPRESSED.md
+++ b/docs/specs/SPEC_READ_COMPRESSED.md
@@ -1,0 +1,218 @@
+# Reading compressed raw ephys files
+
+Spec for making the aeon_mecha spike-sorting load path read **compressed**
+raw ephys data. The companion `aeon_raw_compression` library losslessly
+compresses raw `*_AmplifierData_*.bin` Neuropixels binaries to `.zarr` under a
+processed data root. This spec covers the read side: when the pipeline goes to
+read an amplifier chunk, it resolves the file on disk at load time — **preferring
+`.zarr`, falling back to `.bin`** — without ever changing what is stored in the
+database.
+
+**Status:** Design approved 2026-07-08. Companion to `aeon_raw_compression`
+(separate repo). Read-side design decision locked with Thinh 2026-06-26
+(option A: store paths as read, resolve at load time, never rewrite stored paths).
+
+**Branch:** `es/read-compressed` (off main, after PRs #589 / #591).
+
+---
+
+## Background
+
+The `aeon_raw_compression` library compresses each raw amplifier binary at
+`…/data/raw/<ARENA>/<experiment>/<epoch>/<device>/<file>.bin` to a zarr archive
+at the mirrored sub-path under a **processed** root,
+`…/data/processed/<ARENA>/<experiment>/<epoch>/<device>/<file>.zarr`. The raw
+and processed roots are siblings; the sub-path below them is identical; only the
+extension changes (`.bin` → `.zarr`). The compression is a verified byte-exact
+round-trip, so the decompressed traces are bit-identical to the original binary.
+
+Compression is optional and per-user: some users will never compress. Both the
+raw store (uncompressed `.bin`) and the processed store (compressed `.zarr`) can
+coexist, and for any given chunk file only one of the two may be present.
+
+aeon_mecha reads amplifier binaries in exactly one place: `PreProcessing`
+(`aeon/dj_pipeline/spike_sorting.py`). `PreProcessing.make_fetch` queries the
+`EphysChunk.File` rows for the block's `*_AmplifierData_*.bin` files and returns
+their stored (`.bin`) file paths together with each file's `directory_type`.
+`PreProcessing.make_compute` then, per file, resolves the data directory for that
+`directory_type` via `acquisition.Experiment.get_data_directory(key,
+directory_type=d)` (ephys uses the split `raw` / `raw-ephys` directory types),
+joins it with the stored file path (`ephys_dir / f`) to get the absolute path,
+and reads it with `spikeinterface.extractors.read_binary`, concatenating the
+per-chunk recordings.
+
+Today that read is `.bin`-only. This spec makes it resolve `.zarr` first.
+
+## Design
+
+### Principle: resolve at load time, never rewrite stored paths (option A)
+
+The database keeps storing the raw `.bin` path exactly as ingested. Nothing in
+the DB changes. At read time, a pure resolver maps the stored raw path to the
+file that actually exists on disk (the `.zarr` twin if present, else the raw
+`.bin`). This keeps the two stores decoupled: compressing (or later deleting)
+raw files never requires touching aeon_mecha's database, and a user who never
+compresses sees no behavior change.
+
+### The resolver (pure utility)
+
+A single pure function is added to `aeon/dj_pipeline/utils/ephys_utils.py`:
+
+```python
+def resolve_ephys_file(raw_bin_path: Path) -> Path:
+    """Resolve a raw amplifier .bin path to the file that exists on disk.
+
+    Prefers the compressed .zarr twin under the processed store, falling back
+    to the raw .bin. Raises FileNotFoundError (naming both candidates) if
+    neither exists.
+    """
+```
+
+**Path convention (baked in, not configurable).** The raw→processed mapping is
+a fixed convention, so it lives inline in the function rather than as env vars,
+DataJoint config, or module constants:
+
+1. Split the path into components (`Path.parts`).
+2. Count components exactly equal to `"raw"`:
+   - **exactly one** → replace it with `"processed"` and swap the suffix to
+     `.zarr`; that is the zarr candidate.
+   - **zero** → the path is not under a `raw` store, so there is no zarr twin;
+     skip straight to the `.bin` fallback.
+   - **more than one** → raise `ValueError`. The mapping would be ambiguous (we
+     cannot know which `raw` is the store root), and silently guessing could
+     read the wrong store. A hard error is safer.
+3. If the zarr candidate exists on disk → return it.
+4. Else if the raw `.bin` exists → return it.
+5. Else raise `FileNotFoundError` naming both candidates.
+
+This matches `aeon_raw_compression`'s mapping
+(`(PROCESSED_ROOT / bin.relative_to(RAW_ROOT)).with_suffix(".zarr")`, defaults
+`/ceph/aeon/aeon/data/raw` ↔ `/ceph/aeon/aeon/data/processed`) **without importing
+that library** — aeon_mecha must work for users who never install it. The swap
+assumes the raw and processed roots are siblings differing only in that one
+component (the default Ceph layout); the library technically allows a non-sibling
+processed root, which this resolver intentionally does not support (the read side
+was locked to a hardcoded convention, no env/DB config). A comment in the
+function cross-references the library, and a unit test pins the mapping.
+
+Exact-component equality (not substring replace) means `raw-ephys` — the
+DataJoint `directory_type` *label*, which never appears as a physical path
+component — is correctly ignored, as is any `Raw`/`RAW` casing.
+
+### Wiring into the load path
+
+In `PreProcessing.make_compute`, the per-file read loop resolves each file and
+branches on the resolved suffix:
+
+```python
+resolved = resolve_ephys_file(ephys_dir / f)
+if resolved.suffix == ".zarr":
+    si_rec = si.load(resolved)
+    si_rec.set_channel_gains(gain_to_uV)
+    si_rec.set_channel_offsets(offset_to_uV)
+else:
+    si_rec = se.read_binary(
+        resolved,
+        sampling_frequency=fs_hz,
+        dtype=np.uint16,
+        num_channels=num_channels,
+        gain_to_uV=gain_to_uV,
+        offset_to_uV=offset_to_uV,
+    )
+si_recs.append(si_rec)
+```
+
+**Why the `.zarr` branch re-applies gains and offsets.** `read_binary`'s
+`gain_to_uV`/`offset_to_uV` arguments do not transform the stored samples; they
+only *attach* gain/offset metadata to the recording object (verified in
+SpikeInterface `binaryrecordingextractor.py`: the constructor calls
+`set_channel_gains`/`set_channel_offsets` when those args are not `None`). The
+compression library compresses from a plain `read_binary` **without** gain/offset
+args, so the `.zarr` on disk carries no gain/offset metadata. `si.load(zarr)`
+faithfully returns that gain-less recording, so we re-attach the same gain/offset
+that the `.bin` branch passes. Because the round-trip is byte-exact and the
+attached metadata is then identical, the `.zarr` branch produces a recording
+equivalent to the current `.bin` branch through `unsigned_to_signed`,
+preprocessing, and sorting.
+
+Files are resolved independently, so a probe whose chunk files are a mix of
+compressed and uncompressed still concatenates correctly (all branches yield
+recordings with matching channel count, dtype, and sampling frequency).
+
+This is the **only** read site that changes. Other raw reads — `Clock_*.bin`,
+IMU (`Bno055`), tracking, and behavior streams — are not touched by
+`aeon_raw_compression` (it compresses only `*_AmplifierData_*.bin`), so they are
+left exactly as-is.
+
+### What is NOT included
+
+- **No database changes.** No schema change, no new table or column, no
+  migration, no writes to any table, and no rewriting of stored file paths.
+  `EphysChunk.File.file_path` keeps storing the `.bin`-relative path forever.
+  The resolver runs purely at read time; nothing it computes is persisted.
+- **No changes to `aeon_raw_compression`.** This is the read side only.
+- **No changes to non-amplifier read paths.**
+- **No historical migration.** Existing data with no `.zarr` twin reads exactly
+  as before via the `.bin` fallback.
+
+### Backward compatibility
+
+- Users who never compress: every `resolve_ephys_file` call finds no `.zarr`
+  and returns the `.bin` — identical behavior to today.
+- Existing DBs and existing sorting outputs are unaffected.
+- The change is read-time only and fully reversible (no persisted state).
+
+---
+
+## Testing
+
+The project uses three pytest markers (`pyproject.toml`): `unit` (no database,
+synthetic data), `integration` (needs a DB — locally via testcontainers, or on
+the SWC HPC against an external DB via `TEST_DB_PREFIX` because there is no
+Docker there), and `specialized` (defined but currently unused). The ephys
+golden suite (`tests/dj_pipeline/test_ephys_ingestion.py`) is marked
+`integration` and is run on the HPC because it reads real amplifier data off
+Ceph. `PreProcessing.populate()` — the wiring site — is exercised only by that
+golden suite.
+
+### Unit tests (`unit`, no DB, `tmp_path`)
+
+Extend `tests/dj_pipeline/utils/test_ephys_utils_unit.py`. These give the bulk of
+the resolver confidence cheaply and run in CI:
+
+- **Mapping** — a raw `.bin` path under a `raw` component maps to the mirrored
+  `.zarr` under `processed` (pins the convention format; drift guard).
+- **Preference / errors:**
+  - both `.zarr` and `.bin` present → returns `.zarr`
+  - only `.bin` present → returns `.bin`
+  - only `.zarr` present → returns `.zarr`
+  - neither present → `FileNotFoundError` (message names both candidates)
+  - more than one `"raw"` component → `ValueError`
+  - zero `"raw"` components, `.bin` present → returns `.bin` (fall-through)
+
+### Integration test (`integration`, golden, HPC)
+
+The existing golden tests already exercise the `.bin` fallback (no `.zarr`
+present today) — free regression coverage. Add one golden test that stages a
+`.zarr` twin for a golden amplifier file under the processed root, runs
+`PreProcessing`, and asserts it (a) reads the `.zarr` and (b) produces a
+recording equivalent to the `.bin` path. This test also covers the gain/offset
+re-application end-to-end on real data. It runs on the HPC with the rest of the
+golden suite and skips locally (gated by `require_ephys_golden_data`).
+
+The gain/offset equivalence is not duplicated as a standalone local test: it is
+effectively verifying SpikeInterface's own load/save round-trip, and the golden
+integration test covers it on real data.
+
+---
+
+## PR checklist
+
+- [ ] Add `resolve_ephys_file` to `aeon/dj_pipeline/utils/ephys_utils.py`
+- [ ] Wire it into `PreProcessing.make_compute` (resolve + suffix branch +
+      gain/offset re-apply on the `.zarr` branch)
+- [ ] Unit tests in `tests/dj_pipeline/utils/test_ephys_utils_unit.py`
+- [ ] Golden integration test in `tests/dj_pipeline/test_ephys_ingestion.py`
+- [ ] Add this spec (`docs/specs/SPEC_READ_COMPRESSED.md`)
+- [ ] Run unit suite locally; run golden suite on HPC
+- [ ] Open PR into main (after explicit go-ahead)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aeon_mecha"
-version = "0.4.5"
+version = "0.4.6"
 requires-python = ">=3.11,<3.13"
 description = '''
     Code for managing acquired data from Project Aeon experiments. Includes general file IO,

--- a/tests/dj_pipeline/test_ephys_ingestion.py
+++ b/tests/dj_pipeline/test_ephys_ingestion.py
@@ -176,6 +176,81 @@ class TestPreProcessing:
         assert np.any(traces != 0), "recording.zarr decompressed to all-zero traces"
 
 
+class TestCompressedReadEquivalence:
+    """Reading a compressed .zarr twin + re-applying gains/offsets must equal
+    reading the raw .bin, on real golden data.
+
+    This is the correctness crux of the read-compressed wiring in
+    ``PreProcessing.make_compute`` (the ``.zarr`` branch): the companion
+    ``aeon_raw_compression`` library compresses from a plain ``read_binary``
+    (no gains), so the zarr carries no gain/offset metadata and the pipeline
+    re-attaches it after ``si.load``. Here we verify, on a real golden amplifier
+    file, that the round-trip preserves the raw traces byte-for-byte and that the
+    re-applied gains/offsets match the ``.bin`` branch. The resolver's path logic
+    itself is covered by the unit tests in
+    ``tests/dj_pipeline/utils/test_ephys_utils_unit.py::TestResolveEphysFile``.
+    """
+
+    def test_zarr_roundtrip_matches_binary(
+        self, ephys_sorting_setup, require_ephys_golden_data, ctx, tmp_path
+    ):
+        import numpy as np
+        import spikeinterface as si
+        import spikeinterface.extractors as se
+
+        from aeon.dj_pipeline import acquisition
+
+        exp_key = {"experiment_name": ctx.cfg["experiment_name"]}
+        ctx.ephys.EphysChunk.ingest_chunks(ctx.cfg["experiment_name"])
+
+        amp_files = (
+            ctx.ephys.EphysChunk.File & exp_key & "file_name LIKE '%AmplifierData%.bin'"
+        ).to_dicts()
+        assert amp_files, "no golden AmplifierData .bin registered"
+
+        f0 = amp_files[0]
+        ephys_dir = acquisition.Experiment.get_data_directory(
+            exp_key, directory_type=f0["directory_type"]
+        )
+        bin_path = ephys_dir / f0["file_path"]
+        assert bin_path.exists(), f"golden .bin missing: {bin_path}"
+
+        # Must match PreProcessing.make_compute.
+        fs_hz = 30e3
+        gain_to_uV = 3.05176
+        offset_to_uV = -2048 * gain_to_uV
+        num_channels = ctx.cfg["n_recording_channels"]
+        n_frames = 30_000  # 1 s; keep the zarr write fast (reads are lazy/memmapped)
+
+        # .bin branch: read with gains (as make_compute does), take a slice.
+        rec_bin = se.read_binary(
+            bin_path,
+            sampling_frequency=fs_hz,
+            dtype=np.uint16,
+            num_channels=num_channels,
+            gain_to_uV=gain_to_uV,
+            offset_to_uV=offset_to_uV,
+        ).frame_slice(0, n_frames)
+
+        # .zarr branch: mimic the library (read WITHOUT gains, save to zarr), then
+        # load + re-apply gains/offsets exactly as make_compute's zarr branch does.
+        zarr_path = tmp_path / "amp_slice.zarr"
+        se.read_binary(
+            bin_path,
+            sampling_frequency=fs_hz,
+            dtype=np.uint16,
+            num_channels=num_channels,
+        ).frame_slice(0, n_frames).save(format="zarr", folder=zarr_path)
+        rec_zarr = si.load(zarr_path)
+        rec_zarr.set_channel_gains(gain_to_uV)
+        rec_zarr.set_channel_offsets(offset_to_uV)
+
+        # Raw traces byte-identical, and re-applied metadata matches the .bin read.
+        assert np.array_equal(rec_bin.get_traces(), rec_zarr.get_traces())
+        assert np.array_equal(rec_bin.get_channel_gains(), rec_zarr.get_channel_gains())
+        assert np.array_equal(rec_bin.get_channel_offsets(), rec_zarr.get_channel_offsets())
+
+
 class TestPostProcessing:
     """Verify PostProcessing.populate() output.
 

--- a/tests/dj_pipeline/test_ephys_ingestion.py
+++ b/tests/dj_pipeline/test_ephys_ingestion.py
@@ -177,22 +177,22 @@ class TestPreProcessing:
 
 
 class TestCompressedReadEquivalence:
-    """Reading a compressed .zarr twin + re-applying gains/offsets must equal
-    reading the raw .bin, on real golden data.
+    """A compressed .zarr twin, read back and given the pipeline's gains/offsets,
+    must reproduce the raw .bin read on real golden data.
 
-    This is the correctness crux of the read-compressed wiring in
-    ``PreProcessing.make_compute`` (the ``.zarr`` branch): the companion
-    ``aeon_raw_compression`` library compresses from a plain ``read_binary``
-    (no gains), so the zarr carries no gain/offset metadata and the pipeline
-    re-attaches it after ``si.load``. Here we verify, on a real golden amplifier
-    file, that the round-trip preserves the raw traces byte-for-byte and that the
-    re-applied gains/offsets match the ``.bin`` branch. The resolver's path logic
-    itself is covered by the unit tests in
+    This does NOT execute ``PreProcessing.make_compute``; it isolates the
+    SpikeInterface round-trip that the read-compressed wiring relies on. The
+    companion ``aeon_raw_compression`` library compresses from a plain
+    ``read_binary`` (no gains), so the zarr on disk carries no gain/offset
+    metadata and ``make_compute`` re-attaches it after ``si.load``. Here we
+    confirm, on a real golden amplifier file, that the round-trip preserves the
+    raw traces byte-for-byte and that the re-applied gains/offsets match the
+    ``.bin`` read. The resolver's own path logic is covered by the unit tests in
     ``tests/dj_pipeline/utils/test_ephys_utils_unit.py::TestResolveEphysFile``.
     """
 
     def test_zarr_roundtrip_matches_binary(
-        self, ephys_sorting_setup, require_ephys_golden_data, ctx, tmp_path
+        self, ephys_chunks_ingested, require_ephys_golden_data, ctx, tmp_path
     ):
         import numpy as np
         import spikeinterface as si
@@ -201,8 +201,6 @@ class TestCompressedReadEquivalence:
         from aeon.dj_pipeline import acquisition
 
         exp_key = {"experiment_name": ctx.cfg["experiment_name"]}
-        ctx.ephys.EphysChunk.ingest_chunks(ctx.cfg["experiment_name"])
-
         amp_files = (
             ctx.ephys.EphysChunk.File & exp_key & "file_name LIKE '%AmplifierData%.bin'"
         ).to_dicts()
@@ -220,9 +218,10 @@ class TestCompressedReadEquivalence:
         gain_to_uV = 3.05176
         offset_to_uV = -2048 * gain_to_uV
         num_channels = ctx.cfg["n_recording_channels"]
-        n_frames = 30_000  # 1 s; keep the zarr write fast (reads are lazy/memmapped)
 
-        # .bin branch: read with gains (as make_compute does), take a slice.
+        # .bin branch: read with gains (as make_compute does), take a short slice.
+        # 1 s keeps the zarr write fast (reads are lazy/memmapped); min() guards a
+        # chunk shorter than that.
         rec_bin = se.read_binary(
             bin_path,
             sampling_frequency=fs_hz,
@@ -230,7 +229,9 @@ class TestCompressedReadEquivalence:
             num_channels=num_channels,
             gain_to_uV=gain_to_uV,
             offset_to_uV=offset_to_uV,
-        ).frame_slice(0, n_frames)
+        )
+        n_frames = min(30_000, rec_bin.get_num_samples())
+        rec_bin = rec_bin.frame_slice(0, n_frames)
 
         # .zarr branch: mimic the library (read WITHOUT gains, save to zarr), then
         # load + re-apply gains/offsets exactly as make_compute's zarr branch does.
@@ -240,7 +241,7 @@ class TestCompressedReadEquivalence:
             sampling_frequency=fs_hz,
             dtype=np.uint16,
             num_channels=num_channels,
-        ).frame_slice(0, n_frames).save(format="zarr", folder=zarr_path)
+        ).frame_slice(0, n_frames).save(format="zarr", folder=zarr_path, n_jobs=1)
         rec_zarr = si.load(zarr_path)
         rec_zarr.set_channel_gains(gain_to_uV)
         rec_zarr.set_channel_offsets(offset_to_uV)

--- a/tests/dj_pipeline/utils/test_ephys_utils_unit.py
+++ b/tests/dj_pipeline/utils/test_ephys_utils_unit.py
@@ -632,3 +632,74 @@ class TestLoadDeviceChannelMap:
         )
         with pytest.raises(ValueError, match="No active contacts"):
             load_device_channel_map(all_inactive)
+
+
+class TestResolveEphysFile:
+    """Pure path resolver: prefer the .zarr twin under the processed store,
+    else the raw .bin, else error. No DB. See SPEC_READ_COMPRESSED.md."""
+
+    def _make_raw_bin(self, tmp_path):
+        # tmp_path has no "raw" component, so the one we add is unambiguous.
+        bin_path = tmp_path / "raw" / "AEONX1" / "exp" / "dev" / "Probe_AmplifierData_0.bin"
+        bin_path.parent.mkdir(parents=True, exist_ok=True)
+        return bin_path
+
+    def _expected_zarr(self, tmp_path):
+        return tmp_path / "processed" / "AEONX1" / "exp" / "dev" / "Probe_AmplifierData_0.zarr"
+
+    def test_prefers_zarr_when_both_present(self, tmp_path):
+        from aeon.dj_pipeline.utils.ephys_utils import resolve_ephys_file
+
+        bin_path = self._make_raw_bin(tmp_path)
+        bin_path.write_bytes(b"\x00\x00")
+        zarr_path = self._expected_zarr(tmp_path)
+        zarr_path.mkdir(parents=True)  # zarr is a directory on disk
+
+        # Pins the raw->processed mapping AND the zarr preference.
+        assert resolve_ephys_file(bin_path) == zarr_path
+
+    def test_falls_back_to_bin_when_only_bin(self, tmp_path):
+        from aeon.dj_pipeline.utils.ephys_utils import resolve_ephys_file
+
+        bin_path = self._make_raw_bin(tmp_path)
+        bin_path.write_bytes(b"\x00\x00")
+
+        assert resolve_ephys_file(bin_path) == bin_path
+
+    def test_returns_zarr_when_only_zarr(self, tmp_path):
+        from aeon.dj_pipeline.utils.ephys_utils import resolve_ephys_file
+
+        bin_path = self._make_raw_bin(tmp_path)  # parent dir exists, but no .bin file
+        zarr_path = self._expected_zarr(tmp_path)
+        zarr_path.mkdir(parents=True)
+
+        assert resolve_ephys_file(bin_path) == zarr_path
+
+    def test_raises_when_neither_exists(self, tmp_path):
+        from aeon.dj_pipeline.utils.ephys_utils import resolve_ephys_file
+
+        bin_path = self._make_raw_bin(tmp_path)  # nothing created
+
+        with pytest.raises(FileNotFoundError) as excinfo:
+            resolve_ephys_file(bin_path)
+        msg = str(excinfo.value)
+        assert "processed" in msg and ".zarr" in msg and ".bin" in msg
+
+    def test_raises_on_multiple_raw_components(self, tmp_path):
+        from aeon.dj_pipeline.utils.ephys_utils import resolve_ephys_file
+
+        bin_path = tmp_path / "raw" / "sub" / "raw" / "f.bin"
+        bin_path.parent.mkdir(parents=True)
+        bin_path.write_bytes(b"\x00")
+
+        with pytest.raises(ValueError, match="raw"):
+            resolve_ephys_file(bin_path)
+
+    def test_no_raw_component_falls_back_to_bin(self, tmp_path):
+        from aeon.dj_pipeline.utils.ephys_utils import resolve_ephys_file
+
+        bin_path = tmp_path / "data" / "f.bin"  # no "raw" component
+        bin_path.parent.mkdir(parents=True)
+        bin_path.write_bytes(b"\x00")
+
+        assert resolve_ephys_file(bin_path) == bin_path

--- a/tests/dj_pipeline/utils/test_ephys_utils_unit.py
+++ b/tests/dj_pipeline/utils/test_ephys_utils_unit.py
@@ -635,55 +635,51 @@ class TestLoadDeviceChannelMap:
 
 
 class TestResolveEphysFile:
-    """Pure path resolver: prefer the .zarr twin under the processed store,
-    else the raw .bin, else error. No DB. See SPEC_READ_COMPRESSED.md."""
+    """Pure path resolver: prefer the .zarr twin under the processed store, else the raw .bin, else error.
 
-    def _make_raw_bin(self, tmp_path):
+    No DB. See SPEC_READ_COMPRESSED.md.
+    """
+
+    @pytest.fixture
+    def raw_bin_path(self, tmp_path):
+        """Return a raw .bin path under tmp_path with a 'raw' component."""
         # tmp_path has no "raw" component, so the one we add is unambiguous.
         bin_path = tmp_path / "raw" / "AEONX1" / "exp" / "dev" / "Probe_AmplifierData_0.bin"
         bin_path.parent.mkdir(parents=True, exist_ok=True)
         return bin_path
 
-    def _expected_zarr(self, tmp_path):
+    @pytest.fixture
+    def zarr_path(self, tmp_path):
+        """Return a processed .zarr path under tmp_path."""
         return tmp_path / "processed" / "AEONX1" / "exp" / "dev" / "Probe_AmplifierData_0.zarr"
 
-    def test_prefers_zarr_when_both_present(self, tmp_path):
+    def test_prefers_zarr_when_both_present(self, raw_bin_path, zarr_path):
         from aeon.dj_pipeline.utils.ephys_utils import resolve_ephys_file
 
-        bin_path = self._make_raw_bin(tmp_path)
-        bin_path.write_bytes(b"\x00\x00")
-        zarr_path = self._expected_zarr(tmp_path)
+        raw_bin_path.write_bytes(b"\x00\x00")
         zarr_path.mkdir(parents=True)  # zarr is a directory on disk
-
         # Pins the raw->processed mapping AND the zarr preference.
-        assert resolve_ephys_file(bin_path) == zarr_path
+        assert resolve_ephys_file(raw_bin_path) == zarr_path
 
-    def test_falls_back_to_bin_when_only_bin(self, tmp_path):
+    def test_falls_back_to_bin_when_only_bin(self, raw_bin_path):
         from aeon.dj_pipeline.utils.ephys_utils import resolve_ephys_file
 
-        bin_path = self._make_raw_bin(tmp_path)
-        bin_path.write_bytes(b"\x00\x00")
+        raw_bin_path.write_bytes(b"\x00\x00")
+        assert resolve_ephys_file(raw_bin_path) == raw_bin_path
 
-        assert resolve_ephys_file(bin_path) == bin_path
-
-    def test_returns_zarr_when_only_zarr(self, tmp_path):
+    def test_returns_zarr_when_only_zarr(self, raw_bin_path, zarr_path):
         from aeon.dj_pipeline.utils.ephys_utils import resolve_ephys_file
 
-        bin_path = self._make_raw_bin(tmp_path)  # parent dir exists, but no .bin file
-        zarr_path = self._expected_zarr(tmp_path)
+        # raw_bin_path's parent dir exists, but no .bin file
         zarr_path.mkdir(parents=True)
+        assert resolve_ephys_file(raw_bin_path) == zarr_path
 
-        assert resolve_ephys_file(bin_path) == zarr_path
-
-    def test_raises_when_neither_exists(self, tmp_path):
+    def test_raises_when_neither_exists(self, raw_bin_path):
         from aeon.dj_pipeline.utils.ephys_utils import resolve_ephys_file
 
-        bin_path = self._make_raw_bin(tmp_path)  # nothing created
-
-        with pytest.raises(FileNotFoundError) as excinfo:
-            resolve_ephys_file(bin_path)
-        msg = str(excinfo.value)
-        assert "processed" in msg and ".zarr" in msg and ".bin" in msg
+        # nothing created beyond raw_bin_path's parent dir
+        with pytest.raises(FileNotFoundError, match=r"processed.*\.zarr.*\.bin"):
+            resolve_ephys_file(raw_bin_path)
 
     def test_raises_on_multiple_raw_components(self, tmp_path):
         from aeon.dj_pipeline.utils.ephys_utils import resolve_ephys_file
@@ -691,8 +687,7 @@ class TestResolveEphysFile:
         bin_path = tmp_path / "raw" / "sub" / "raw" / "f.bin"
         bin_path.parent.mkdir(parents=True)
         bin_path.write_bytes(b"\x00")
-
-        with pytest.raises(ValueError, match="raw"):
+        with pytest.raises(ValueError, match="multiple 'raw' components"):
             resolve_ephys_file(bin_path)
 
     def test_no_raw_component_falls_back_to_bin(self, tmp_path):
@@ -701,7 +696,6 @@ class TestResolveEphysFile:
         bin_path = tmp_path / "data" / "f.bin"  # no "raw" component
         bin_path.parent.mkdir(parents=True)
         bin_path.write_bytes(b"\x00")
-
         assert resolve_ephys_file(bin_path) == bin_path
 
     def test_raw_ephys_component_not_treated_as_raw(self, tmp_path):
@@ -713,5 +707,4 @@ class TestResolveEphysFile:
         bin_path = tmp_path / "raw-ephys" / "AEONX1" / "f.bin"
         bin_path.parent.mkdir(parents=True)
         bin_path.write_bytes(b"\x00")
-
         assert resolve_ephys_file(bin_path) == bin_path

--- a/tests/dj_pipeline/utils/test_ephys_utils_unit.py
+++ b/tests/dj_pipeline/utils/test_ephys_utils_unit.py
@@ -703,3 +703,15 @@ class TestResolveEphysFile:
         bin_path.write_bytes(b"\x00")
 
         assert resolve_ephys_file(bin_path) == bin_path
+
+    def test_raw_ephys_component_not_treated_as_raw(self, tmp_path):
+        # "raw-ephys" is a DataJoint directory_type label, never a physical path
+        # component. Exact-component matching must not treat it as the "raw" store
+        # root, so no .zarr twin is inferred and we fall back to the .bin.
+        from aeon.dj_pipeline.utils.ephys_utils import resolve_ephys_file
+
+        bin_path = tmp_path / "raw-ephys" / "AEONX1" / "f.bin"
+        bin_path.parent.mkdir(parents=True)
+        bin_path.write_bytes(b"\x00")
+
+        assert resolve_ephys_file(bin_path) == bin_path

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "aeon-mecha"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "." }
 dependencies = [
     { name = "bottleneck" },


### PR DESCRIPTION
## Summary
- Add `resolve_ephys_file` in `utils/ephys_utils.py`. Given a raw amplifier `.bin` path, it returns the file to actually read on disk, preferring the compressed `.zarr` twin under the processed store, falling back to the raw `.bin`, and raising if neither exists.
- Wire it into `PreProcessing.make_compute` so chunk reads resolve on disk at load time. On the `.zarr` branch it re-applies channel gains and offsets after `si.load`, since the compression library writes zarr from a plain `read_binary` that carries no gains.
- Unit tests for the resolver, covering prefer-zarr, fall-back-to-bin, both/only-one/neither present, and the ambiguous multi-`raw` path case.
- Golden integration test confirming a `.zarr` twin read matches the `.bin` read byte-for-byte on real data.

## Context
Companion to the standalone `aeon_raw_compression` library, which losslessly compresses raw `*_AmplifierData_*.bin` files to `.zarr` under a processed data root that mirrors the raw sub-path. This PR is the read side, where aeon_mecha finds and reads those compressed files.

The design, locked with Thinh, is to store paths as read and never rewrite them. The resolver maps a stored raw path to the file on disk at load time by a fixed convention, swapping the `raw` path component for `processed` and `.bin` for `.zarr`. Compression is optional and per-user, so binary reading stays first-class and there is no dependency on `aeon_raw_compression`.

No database changes. No schema change, no migration, no stored-path rewrites. Old data with no `.zarr` twin reads exactly as before.

Verified with the unit suite locally (113 passed) and the ephys golden suite on the SWC HPC (32 passed), including the new equivalence test. The spec is at `docs/specs/SPEC_READ_COMPRESSED.md`.

## Note
Also includes a small unrelated docs fix removing a stale `uv pip install cryptography` step from `docs/running_golden_tests_on_hpc.md`, since `cryptography` became a core dependency in #591.
