### PR TITLE
Fix #598: clean up sync_model .joblib temp files left behind by attach fetches

### DIFF
--- a/aeon/dj_pipeline/ephys.py
+++ b/aeon/dj_pipeline/ephys.py
@@ -1,6 +1,7 @@
 """DataJoint schema for the ephys pipeline."""
 
 import re
+import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -406,8 +407,6 @@ class EphysSyncModel(dj.Manual):
         Args:
             experiment_name: Name of the experiment to process
         """
-        import tempfile
-
         import joblib
 
         from aeon.schema.ephys import social_ephys
@@ -614,33 +613,37 @@ class EphysChunk(dj.Manual):
             onix_ts = np.memmap(clock_file, mode="r", dtype=np.uint64)
             first_ts, last_ts = int(onix_ts[0]), int(onix_ts[-1])
 
-            # Query EphysSyncModel rows that cover the first OR last ONIX timestamp
-            matched = (
-                EphysSyncModel
-                & {"experiment_name": experiment_name, "epoch_start": epoch_start}
-                & (
-                    f"({first_ts} BETWEEN onix_ts_start AND onix_ts_end) "
-                    f"OR ({last_ts} BETWEEN onix_ts_start AND onix_ts_end)"
-                )
-            ).to_dicts(order_by="sync_start")
+            # Fetch + resolve inside a temp download dir so the <attach> sync_model
+            # files DataJoint extracts on fetch are cleaned up (issue #598). Any
+            # model load (inside resolve_harp) must happen before the block exits.
+            with tempfile.TemporaryDirectory() as tmpdir, dj.config.override(download_path=tmpdir):
+                # Query EphysSyncModel rows that cover the first OR last ONIX timestamp
+                matched = (
+                    EphysSyncModel
+                    & {"experiment_name": experiment_name, "epoch_start": epoch_start}
+                    & (
+                        f"({first_ts} BETWEEN onix_ts_start AND onix_ts_end) "
+                        f"OR ({last_ts} BETWEEN onix_ts_start AND onix_ts_end)"
+                    )
+                ).to_dicts(order_by="sync_start")
 
-            if not matched:
-                logger.warning(
-                    f"No EphysSyncModel row covers ONIX range [{first_ts}, {last_ts}] "
-                    f"for {ephys_file.name}. Run EphysSyncModel.ingest() first. Skipping."
-                )
-                continue
+                if not matched:
+                    logger.warning(
+                        f"No EphysSyncModel row covers ONIX range [{first_ts}, {last_ts}] "
+                        f"for {ephys_file.name}. Run EphysSyncModel.ingest() first. Skipping."
+                    )
+                    continue
 
-            # Resolve HARP chunk_start / chunk_end via DB-backed sync model.
-            # Use a per-file model cache so both calls share one joblib.load when
-            # matched[0] and matched[-1] are the same SyncModel row.
-            model_cache: dict = {}
-            try:
-                chunk_start = resolve_harp(matched[0], first_ts, _model_cache=model_cache)
-                chunk_end = resolve_harp(matched[-1], last_ts, _model_cache=model_cache)
-            except Exception as e:
-                logger.error(f"Failed to resolve HARP times for {ephys_file}: {e}")
-                continue
+                # Resolve HARP chunk_start / chunk_end via DB-backed sync model.
+                # Use a per-file model cache so both calls share one joblib.load when
+                # matched[0] and matched[-1] are the same SyncModel row.
+                model_cache: dict = {}
+                try:
+                    chunk_start = resolve_harp(matched[0], first_ts, _model_cache=model_cache)
+                    chunk_end = resolve_harp(matched[-1], last_ts, _model_cache=model_cache)
+                except Exception as e:
+                    logger.error(f"Failed to resolve HARP times for {ephys_file}: {e}")
+                    continue
 
             # ElectrodeConfig already resolved on the Insertion row — read it
             # directly from insertion_key (built above from EphysEpochConfig.Insertion).
@@ -871,8 +874,10 @@ class OnixImuChunk(dj.Imported):
         from swc.aeon.io import api as io_api
 
         df = (cls & key).fetch1("stream_df")
-        sync_attach = (EphysSyncModel & key).fetch1("sync_model")
-        model = joblib.load(sync_attach)
+        # Load the <attach> sync_model inside a temp download dir so the extracted
+        # .joblib file is cleaned up on exit (issue #598).
+        with tempfile.TemporaryDirectory() as tmpdir, dj.config.override(download_path=tmpdir):
+            model = joblib.load((EphysSyncModel & key).fetch1("sync_model"))
         harp_seconds = model.predict(df.index.values.reshape(-1, 1)).flatten()
         df.index = io_api.to_datetime(harp_seconds)
         return df
@@ -894,9 +899,9 @@ class OnixImuChunk(dj.Imported):
         )
         from aeon.dj_pipeline.utils.stats import column_stats, timestamp_stats
 
-        onix_ts_start_raw, onix_ts_end_raw, sync_model_attach = (
+        onix_ts_start_raw, onix_ts_end_raw = (
             EphysSyncModel & key
-        ).fetch1("onix_ts_start", "onix_ts_end", "sync_model")
+        ).fetch1("onix_ts_start", "onix_ts_end")
         onix_ts_start = int(onix_ts_start_raw)
         onix_ts_end = int(onix_ts_end_raw)
         epoch_dir = (EphysEpoch & key).fetch1("epoch_dir")
@@ -957,8 +962,10 @@ class OnixImuChunk(dj.Imported):
             return
 
         # HARP timestamps for the summary stats only — stream_df stays
-        # ONIX-indexed (synced_df() applies the regression on fetch).
-        model = joblib.load(sync_model_attach)
+        # ONIX-indexed (synced_df() applies the regression on fetch). Load the
+        # <attach> sync_model in a temp download dir so it is cleaned up (#598).
+        with tempfile.TemporaryDirectory() as tmpdir, dj.config.override(download_path=tmpdir):
+            model = joblib.load((EphysSyncModel & key).fetch1("sync_model"))
         onix_clock = df.index.values
         harp_seconds = model.predict(onix_clock.reshape(-1, 1)).flatten()
         harp_index = pd.to_datetime([harp_to_naive(s) for s in harp_seconds])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aeon_mecha"
-version = "0.4.6"
+version = "0.4.7"
 requires-python = ">=3.11,<3.13"
 description = '''
     Code for managing acquired data from Project Aeon experiments. Includes general file IO,

--- a/tests/dj_pipeline/test_onix_imu_pipeline_integration.py
+++ b/tests/dj_pipeline/test_onix_imu_pipeline_integration.py
@@ -341,3 +341,61 @@ def test_synced_df_raises_on_ambiguous_key(dj_config_integration, tmp_path):
     # Ambiguous key — matches 2 rows
     with pytest.raises(dj.errors.DataJointError):
         ephys.OnixImuChunk.synced_df({"experiment_name": experiment_name})
+
+
+# ============================================================================
+# Issue #598: <attach> sync_model fetches must not leak .joblib files
+# ============================================================================
+
+
+def test_sync_model_fetches_leave_no_joblib(dj_config_integration, tmp_path):
+    """No sync_model .joblib is left in download_path after real fetches (#598).
+
+    Exercises every production sync_model fetch site end-to-end against the DB:
+    ``EphysChunk.ingest_chunks``, ``OnixImuChunk.make`` (via populate), and
+    ``OnixImuChunk.synced_df``. Each must extract its ``<attach>`` into a temp
+    download dir that is cleaned up, so nothing lands in the caller's directory.
+    """
+    import datajoint as dj
+
+    from aeon.dj_pipeline import acquisition, ephys
+    from aeon.dj_pipeline import subject as subj_mod
+
+    experiment_name = "test_sync_model_no_leak"
+    epoch_dir_name = "2024-06-11T10-24-07"
+    device_name = "NeuropixelsV2Beta"
+    probe_label = "ProbeA"
+    subject = "test-mouse-noleak"
+
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    make_synthetic_ephys_epoch(raw_dir, epoch_dir_name, device_name, n_chunks=2)
+    make_synthetic_amplifier_data(raw_dir, epoch_dir_name, device_name, probe_label, n_chunks=2)
+    make_synthetic_bno055_data(raw_dir, epoch_dir_name, device_name, n_chunks=2)
+    epoch_start = register_synthetic_experiment(tmp_path, raw_dir, experiment_name, epoch_dir_name)
+
+    subj_mod.Subject.insert1(
+        {"subject": subject, "sex": "U", "subject_birth_date": "2024-01-01"},
+        skip_duplicates=True,
+    )
+    acquisition.Experiment.Subject.insert1(
+        {"experiment_name": experiment_name, "subject": subject},
+        skip_duplicates=True,
+    )
+    register_synthetic_probe_insertion(experiment_name, subject, epoch_start, probe_label, device_name)
+
+    ephys.EphysSyncModel.ingest(experiment_name)
+
+    # run_dir stands in for the directory a user runs from. Each fetch site
+    # redirects its <attach> extraction to a temp download dir that is deleted
+    # on exit, so no sync_model .joblib should ever be extracted here.
+    run_dir = tmp_path / "run_dir"
+    run_dir.mkdir()
+    with dj.config.override(download_path=str(run_dir)):
+        ephys.EphysChunk.ingest_chunks(experiment_name)  # fetch site: ingest_chunks
+        ephys.OnixImuChunk.populate({"experiment_name": experiment_name})  # fetch site: OnixImuChunk.make
+        imu_keys = (ephys.OnixImuChunk & {"experiment_name": experiment_name}).keys()
+        ephys.OnixImuChunk.synced_df(imu_keys[0])  # fetch site: synced_df
+
+    leaked = list(run_dir.rglob("*.joblib"))
+    assert leaked == [], f"sync_model fetches leaked joblib files into {run_dir}: {leaked}"

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "aeon-mecha"
-version = "0.4.6"
+version = "0.4.7"
 source = { editable = "." }
 dependencies = [
     { name = "bottleneck" },


### PR DESCRIPTION
Fixes #598.

After running `EphysChunk.ingest_chunks`, `.joblib` files (`NeuropixelsV2_HarpSync_*.joblib`) were piling up in whatever directory the script was run from and never getting cleaned up.

The cause is that `EphysSyncModel.sync_model` is an `<attach>` column. DataJoint materializes `<attach>` values to a file under `dj.config["download_path"]` (the current working directory by default) on every fetch, and it deliberately never deletes them. So every fetch of a sync_model row drops a `.joblib` into the working directory. `ingest_chunks`, `OnixImuChunk.make`, and `OnixImuChunk.synced_df` all fetch sync_model and were leaking these files. `SyncedSpikes.make` in spike_sorting already avoided this by wrapping its fetch in a temp download dir.

This adds a small `attach_download_tempdir()` context manager in `ephys_utils` that points `download_path` at a `TemporaryDirectory` for the duration of the fetch-and-load, so the extracted files land in a temp dir that gets removed on exit. Every sync_model fetch site now uses it, and `SyncedSpikes.make` is refactored to the shared helper instead of its own inline copy.

This is a targeted fix that keeps the `<attach>` column as-is. The deeper options (storing the regression as a blob, json, or a custom codec, or just storing the slope and intercept) all eliminate the files at the root, but they need a one-time backfill of already-shipped data, so I'm holding those for a separate discussion with Thinh.

I also added unit coverage for the helper and an integration test that drives `ingest_chunks`, `OnixImuChunk.make`, and `synced_df` against a real attach round-trip and asserts nothing is left behind. A negative-control run with the helper disabled fails those tests and reproduces the exact `HarpSync_*.joblib` leak, so they guard the real behavior. Verified on the HPC against aeondj.
