### PR TITLE
Set preprocessed-recording zarr chunk_duration to 30s

### DIFF
--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -320,7 +320,9 @@ class PreProcessing(dj.Computed):
         params = (SortingParamSet & key).fetch1("params")
         save_format = params.get("save_format", "zarr")
 
-        job_kwargs = {"n_jobs": -1, "chunk_duration": "2s"}
+        # 30s chunk_duration matches the raw standalone-compression default; it sets the
+        # zarr time-axis chunk size of the preprocessed recording.zarr intermediate.
+        job_kwargs = {"n_jobs": -1, "chunk_duration": "30s"}
 
         if save_format == "zarr":
             zarr_path = recording_file.parent / "recording.zarr"


### PR DESCRIPTION
## Summary
- Set the preprocessed-recording zarr write in `PreProcessing.make_compute` to a 30s `chunk_duration` (was 2s).

## Context
This brings the intermediate compressed recording (`recording.zarr`) in line with the raw standalone-compression default of 30s, so the pipeline's compressed intermediates use a consistent chunk size.

This is the only `chunk_duration` that governs a compressed intermediate write. The `chunk_duration` values in `PostProcessing.make_compute` (analyzer extension compute) and `SIExport.make` (report export) are parallel-processing and render settings rather than compression writes, so they're left unchanged.

Validated on the SWC HPC against the golden ephys dataset, with the unit suite and the ephys golden integration suite both passing.
