### PR TITLE
Fork-safe ephys parallelism and auto-delete of the preprocessed recording

### DIFF
--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -7,6 +7,7 @@ sorting, postprocessing, exports, and ingestion of sorted units/waveforms.
 import importlib
 import json
 import os
+import shutil
 import tempfile
 from collections.abc import Iterator
 from datetime import UTC, datetime
@@ -23,6 +24,7 @@ from aeon.dj_pipeline import get_schema_name
 from aeon.dj_pipeline.utils.ephys_utils import resolve_ephys_file
 from aeon.dj_pipeline.utils.paths import get_sorting_root_dir
 from aeon.dj_pipeline.utils.spike_sorting_utils import (
+    fork_safe_job_kwargs,
     resolve_analyzer_dir,
     strip_non_numeric_properties,
 )
@@ -322,7 +324,7 @@ class PreProcessing(dj.Computed):
 
         # 30s chunk_duration matches the raw standalone-compression default; it sets the
         # zarr time-axis chunk size of the preprocessed recording.zarr intermediate.
-        job_kwargs = {"n_jobs": -1, "chunk_duration": "30s"}
+        job_kwargs = fork_safe_job_kwargs("30s")
 
         if save_format == "zarr":
             zarr_path = recording_file.parent / "recording.zarr"
@@ -465,6 +467,12 @@ class SpikeSorting(dj.Computed):
 
         if save_format == "zarr":
             zarr_path = Path(recording_file).parent / "recording.zarr"
+            if not zarr_path.exists():
+                raise FileNotFoundError(
+                    f"Preprocessed recording missing at {zarr_path}. It is deleted after a "
+                    "successful sort; to re-sort, delete this block's PreProcessing entry "
+                    "(cascades to SpikeSorting) and re-populate it."
+                )
             recording_for_sorting = si.load(zarr_path)
         else:
             binary_file_path = Path(recording_file).parent / "recording.dat"
@@ -504,6 +512,18 @@ class SpikeSorting(dj.Computed):
                 if f.is_file()
             ]
         )
+
+        # recording.zarr is a large, regenerable intermediate that only sorting reads, so
+        # reclaim it now. It is shared by all paramsets of this block + electrode group, so
+        # skip the delete while a sibling paramset is preprocessed but not yet sorted.
+        shared_key = {k: v for k, v in key.items() if k != "paramset_id"}
+        if not ((PreProcessing & shared_key) - SpikeSorting):
+            recording_zarr = (
+                get_sorting_root_dir() / (PreProcessing & key).fetch1("sorting_output_dir")
+            ).parent / "recording" / "recording.zarr"
+            if recording_zarr.exists():
+                shutil.rmtree(recording_zarr, ignore_errors=True)
+                logger.info(f"Deleted {recording_zarr} after sorting.")
 
 
 @schema
@@ -576,7 +596,7 @@ class PostProcessing(dj.Computed):
 
         postprocessing_params = params["SI_POSTPROCESSING_PARAMS"]
 
-        job_kwargs = postprocessing_params.get("job_kwargs", {"n_jobs": -1, "chunk_duration": "1s"})
+        job_kwargs = postprocessing_params.get("job_kwargs", fork_safe_job_kwargs("1s"))
 
         save_format = params.get("save_format", "zarr")
         analyzer_format = "zarr" if save_format == "zarr" else "binary_folder"
@@ -676,7 +696,7 @@ class SIExport(dj.Computed):
             )
             return
 
-        job_kwargs = {"n_jobs": -1, "chunk_duration": "1s"}
+        job_kwargs = fork_safe_job_kwargs("1s")
         si.exporters.export_report(
             sorting_analyzer=sorting_analyzer,
             output_folder=analyzer_output_dir / "spikeinterface_report",

--- a/aeon/dj_pipeline/utils/spike_sorting_utils.py
+++ b/aeon/dj_pipeline/utils/spike_sorting_utils.py
@@ -5,9 +5,30 @@ than in spike_sorting.py) to keep them importable and unit-testable without
 activating the spike_sorting schema.
 """
 
+import os
 from pathlib import Path
 
 import numpy as np
+
+
+def fork_safe_job_kwargs(chunk_duration: str, max_jobs: int = 8) -> dict:
+    """SpikeInterface job_kwargs that avoid the SLURM fork/oversubscription hang.
+
+    Uses a thread pool (no fork) and a worker count taken from the cgroup CPU
+    allocation (``os.sched_getaffinity``), capped at ``max_jobs`` -- rather than
+    ``n_jobs=-1``, which SpikeInterface resolves against ``os.cpu_count()`` (every
+    core on the node, not the allocation) and then thrashes or fork-deadlocks.
+    """
+    try:
+        n_jobs = len(os.sched_getaffinity(0))
+    except AttributeError:  # not Linux
+        n_jobs = os.cpu_count() or 1
+    return {
+        "n_jobs": max(1, min(max_jobs, n_jobs)),
+        "pool_engine": "thread",
+        "max_threads_per_worker": 1,
+        "chunk_duration": chunk_duration,
+    }
 
 
 def resolve_analyzer_dir(output_dir: Path) -> Path:

--- a/docs/ephys_runbooks/step03_spike_sorting.py
+++ b/docs/ephys_runbooks/step03_spike_sorting.py
@@ -24,6 +24,11 @@ After sorting completes, continue to Step 4 for post-processing and
 curation. See docs/ephys_runbooks/run_aeon_spike_sorting.{py,sh} for
 example output (golden dataset values).
 
+NOTE: a successful SpikeSorting run deletes the preprocessed recording
+(recording.zarr) to reclaim space -- only the sorting step reads it and it is
+regenerable. To re-sort a block afterward, delete its PreProcessing entry (which
+cascades to SpikeSorting and the downstream steps) and re-run PreProcessing.
+
 Run from the repo root on an HPC compute node (Ceph must be visible):
 
     uv run python docs/ephys_runbooks/step03_spike_sorting.py

--- a/tests/dj_pipeline/conftest.py
+++ b/tests/dj_pipeline/conftest.py
@@ -766,7 +766,12 @@ def ephys_sorting_setup(ephys_test_blocks, ephys_full_pipeline, ephys_golden_dat
                         "spike_locations": {},
                         "quality_metrics": {},
                     },
-                    "job_kwargs": {"n_jobs": 1, "chunk_duration": "1s"},
+                    "job_kwargs": {
+                        "n_jobs": 4,
+                        "pool_engine": "thread",
+                        "max_threads_per_worker": 1,
+                        "chunk_duration": "1s",
+                    },
                 },
             },
         },

--- a/tests/dj_pipeline/utils/test_spike_sorting_utils_unit.py
+++ b/tests/dj_pipeline/utils/test_spike_sorting_utils_unit.py
@@ -76,3 +76,43 @@ class TestStripNonNumericProperties:
         strip_non_numeric_properties(rec)
 
         assert "myuint" in set(rec.get_property_keys())
+
+
+class TestForkSafeJobKwargs:
+    """fork_safe_job_kwargs caps the worker count to the cgroup allocation, no fork."""
+
+    def test_respects_cpu_affinity(self, monkeypatch):
+        import os
+
+        from aeon.dj_pipeline.utils.spike_sorting_utils import fork_safe_job_kwargs
+
+        monkeypatch.setattr(os, "sched_getaffinity", lambda pid: {0, 1, 2, 3}, raising=False)
+        assert fork_safe_job_kwargs("30s")["n_jobs"] == 4
+
+    def test_caps_at_max_jobs(self, monkeypatch):
+        import os
+
+        from aeon.dj_pipeline.utils.spike_sorting_utils import fork_safe_job_kwargs
+
+        monkeypatch.setattr(os, "sched_getaffinity", lambda pid: set(range(64)), raising=False)
+        assert fork_safe_job_kwargs("30s", max_jobs=8)["n_jobs"] == 8
+
+    def test_fallback_to_cpu_count_without_affinity(self, monkeypatch):
+        import os
+
+        from aeon.dj_pipeline.utils.spike_sorting_utils import fork_safe_job_kwargs
+
+        monkeypatch.delattr(os, "sched_getaffinity", raising=False)
+        monkeypatch.setattr(os, "cpu_count", lambda: 6)
+        assert fork_safe_job_kwargs("30s")["n_jobs"] == 6
+
+    def test_thread_pool_and_chunk_passthrough(self, monkeypatch):
+        import os
+
+        from aeon.dj_pipeline.utils.spike_sorting_utils import fork_safe_job_kwargs
+
+        monkeypatch.setattr(os, "sched_getaffinity", lambda pid: {0, 1}, raising=False)
+        kw = fork_safe_job_kwargs("2s")
+        assert kw["pool_engine"] == "thread"
+        assert kw["max_threads_per_worker"] == 1
+        assert kw["chunk_duration"] == "2s"


### PR DESCRIPTION
## Summary
- Replace `n_jobs=-1` in the spike-sorting parallel steps with a cgroup-aware, capped worker count on a thread-based pool (`fork_safe_job_kwargs()`, which sets `pool_engine="thread"`), in `PreProcessing`, `PostProcessing`, and `SIExport`.
- Delete the preprocessed `recording.zarr` after a successful `SpikeSorting`, guarded so it only deletes when no sibling paramset for the same block and electrode group still needs it.
- Raise an actionable error if `SpikeSorting` runs when the preprocessed recording is missing (deleted after a prior sort), pointing at the re-populate recovery path.

## Context

### Why the parallelism change

Two independent problems, both triggered by `n_jobs=-1`, made the preprocessing step intermittently hang on the HPC:

1. **Oversubscription.** `n_jobs=-1` resolves against `os.cpu_count()`, which on SLURM returns every physical core on the node (64+), not the handful of CPUs the job was actually allocated (the cgroup limit). So a 4-CPU job would try to run 64 workers, thrashing the node. `fork_safe_job_kwargs()` instead reads the schedulable-CPU count (`os.sched_getaffinity`, i.e. the real cgroup allocation) and caps it, so we never spawn more workers than we have CPUs.

2. **Fork deadlock.** By default SpikeInterface parallelizes by *forking* the process — the child is a raw copy of the parent's memory. If the parent was mid-way through a NumPy/BLAS call at fork time, the child inherits a locked internal state it can never unlock, and the worker hangs forever. This is a known hazard of mixing `fork` with multithreaded native libraries, and it's intermittent because it depends on the exact moment the fork happens. Setting `pool_engine="thread"` makes SpikeInterface use threads instead of forking, which removes the failure mode entirely.

The same change applies to all three steps that used `n_jobs=-1`.

### Why delete the preprocessed recording

`recording.zarr` is a large, regenerable intermediate (~60% of the per-block footprint) that only the sorting step reads, so deleting it after a successful sort reclaims that space. Because it's shared by every paramset for a block and electrode group, deletion is skipped while any sibling paramset is preprocessed but not yet sorted; a not-yet-preprocessed sibling regenerates it through its own PreProcessing. To re-sort after deletion, delete the block's PreProcessing entry and re-populate.

## Validation

Validated on the SWC HPC against the golden ephys dataset on aeondj: the unit suite (143) and the ephys golden integration suite (33) both pass, including the PreProcessing step that previously hung.
