### PR TITLE
Write preprocessed recording intermediate to non-backed-up scratch

### DIFF
--- a/aeon/dj_pipeline/__init__.py
+++ b/aeon/dj_pipeline/__init__.py
@@ -48,7 +48,7 @@ from aeon.dj_pipeline.utils.codec import (  # pyright: ignore[reportUnusedImport
 logger = dj.logger
 
 _default_database_prefix = "aeon_"
-_default_repository_config = {"ceph_aeon": "/ceph/aeon"}
+_default_repository_config = {"ceph_aeon": "/ceph/aeon", "ceph_aeon_scratch": "/ceph/scratch"}
 
 os.environ["DJ_SUPPORT_FILEPATH_MANAGEMENT"] = "TRUE"
 

--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -22,7 +22,7 @@ from swc.aeon.io import api as io_api
 
 from aeon.dj_pipeline import get_schema_name
 from aeon.dj_pipeline.utils.ephys_utils import resolve_ephys_file
-from aeon.dj_pipeline.utils.paths import get_sorting_root_dir
+from aeon.dj_pipeline.utils.paths import get_sorting_root_dir, scratch_recording_dir
 from aeon.dj_pipeline.utils.spike_sorting_utils import (
     fork_safe_job_kwargs,
     resolve_analyzer_dir,
@@ -326,8 +326,13 @@ class PreProcessing(dj.Computed):
         # zarr time-axis chunk size of the preprocessed recording.zarr intermediate.
         job_kwargs = fork_safe_job_kwargs("30s")
 
+        # The large, regenerable intermediate lives on scratch (non-backed-up), mirroring
+        # the ceph sub-path; si_recording.pkl above stays on ceph with the DB-tracked outputs.
+        intermediate_dir = scratch_recording_dir(recording_file.parent)
+        intermediate_dir.mkdir(parents=True, exist_ok=True)
+
         if save_format == "zarr":
-            zarr_path = recording_file.parent / "recording.zarr"
+            zarr_path = intermediate_dir / "recording.zarr"
             if zarr_path.exists():
                 logger.info(f"{zarr_path} already exists. Skipping zarr write.")
             else:
@@ -339,7 +344,7 @@ class PreProcessing(dj.Computed):
                     **sorters.basesorter.get_job_kwargs(job_kwargs, True),
                 )
         else:
-            binary_file_path = recording_file.parent / "recording.dat"
+            binary_file_path = intermediate_dir / "recording.dat"
             if binary_file_path.exists():
                 load_and_verify_binary_file(
                     binary_file_path=binary_file_path, se_recording_obj=si_recording
@@ -465,8 +470,9 @@ class SpikeSorting(dj.Computed):
         # https://github.com/SpikeInterface/spikeinterface/blob/705c932/src/spikeinterface/sorters/external/kilosortbase.py#L124
         sorting_params["skip_kilosort_preprocessing"] = False
 
+        intermediate_dir = scratch_recording_dir(Path(recording_file).parent)
         if save_format == "zarr":
-            zarr_path = Path(recording_file).parent / "recording.zarr"
+            zarr_path = intermediate_dir / "recording.zarr"
             if not zarr_path.exists():
                 raise FileNotFoundError(
                     f"Preprocessed recording missing at {zarr_path}. It is deleted after a "
@@ -475,7 +481,7 @@ class SpikeSorting(dj.Computed):
                 )
             recording_for_sorting = si.load(zarr_path)
         else:
-            binary_file_path = Path(recording_file).parent / "recording.dat"
+            binary_file_path = intermediate_dir / "recording.dat"
             recording_for_sorting = load_and_verify_binary_file(
                 binary_file_path=binary_file_path, se_recording_obj=si_recording
             )
@@ -518,9 +524,10 @@ class SpikeSorting(dj.Computed):
         # skip the delete while a sibling paramset is preprocessed but not yet sorted.
         shared_key = {k: v for k, v in key.items() if k != "paramset_id"}
         if not ((PreProcessing & shared_key) - SpikeSorting):
-            recording_zarr = (
+            recording_dir = (
                 get_sorting_root_dir() / (PreProcessing & key).fetch1("sorting_output_dir")
-            ).parent / "recording" / "recording.zarr"
+            ).parent / "recording"
+            recording_zarr = scratch_recording_dir(recording_dir) / "recording.zarr"
             if recording_zarr.exists():
                 shutil.rmtree(recording_zarr, ignore_errors=True)
                 logger.info(f"Deleted {recording_zarr} after sorting.")

--- a/aeon/dj_pipeline/utils/paths.py
+++ b/aeon/dj_pipeline/utils/paths.py
@@ -83,13 +83,14 @@ def scratch_recording_dir(recording_dir: str | pathlib.Path) -> pathlib.Path:
     ``repository_config``, default ``/ceph/scratch``) mirrors the ceph sub-path 1:1, so
     the two line up and the DB-tracked outputs stay on ``ceph_aeon``.
 
-    Falls back to ``recording_dir`` unchanged when the scratch root is unset, absent
-    (e.g. local/CI machines without ``/ceph/scratch``), or ``recording_dir`` is not under
-    the ceph root — so the default on-ceph layout still works everywhere else.
+    Falls back to ``recording_dir`` unchanged when the scratch root is unset, not an
+    existing directory (e.g. local/CI machines without ``/ceph/scratch``), or
+    ``recording_dir`` is not under the ceph root, so the default on-ceph layout still
+    works everywhere else.
     """
     recording_dir = pathlib.Path(recording_dir)
     scratch_root = _pipeline.repository_config.get("ceph_aeon_scratch")
-    if not scratch_root or not pathlib.Path(scratch_root).exists():
+    if not scratch_root or not pathlib.Path(scratch_root).is_dir():
         return recording_dir
     ceph_root = pathlib.Path(_pipeline.repository_config["ceph_aeon"])
     try:

--- a/aeon/dj_pipeline/utils/paths.py
+++ b/aeon/dj_pipeline/utils/paths.py
@@ -72,3 +72,28 @@ def get_sorting_root_dir(repository_name="ceph_aeon") -> pathlib.Path:
     if not sorting_dir.exists():
         raise FileNotFoundError(f"Processed directory does not exist: {sorting_dir}")
     return sorting_dir / "ephys-processed"
+
+
+def scratch_recording_dir(recording_dir: str | pathlib.Path) -> pathlib.Path:
+    """Scratch location for the large, regenerable recording intermediate.
+
+    The preprocessed ``recording.zarr`` / ``recording.dat`` is only read by the sorting
+    step and is not DB-tracked, so it belongs on the non-backed-up scratch filesystem
+    rather than the backed-up ceph store. The scratch root (``ceph_aeon_scratch`` in
+    ``repository_config``, default ``/ceph/scratch``) mirrors the ceph sub-path 1:1, so
+    the two line up and the DB-tracked outputs stay on ``ceph_aeon``.
+
+    Falls back to ``recording_dir`` unchanged when the scratch root is unset, absent
+    (e.g. local/CI machines without ``/ceph/scratch``), or ``recording_dir`` is not under
+    the ceph root — so the default on-ceph layout still works everywhere else.
+    """
+    recording_dir = pathlib.Path(recording_dir)
+    scratch_root = _pipeline.repository_config.get("ceph_aeon_scratch")
+    if not scratch_root or not pathlib.Path(scratch_root).exists():
+        return recording_dir
+    ceph_root = pathlib.Path(_pipeline.repository_config["ceph_aeon"])
+    try:
+        rel = recording_dir.relative_to(ceph_root)
+    except ValueError:
+        return recording_dir
+    return pathlib.Path(scratch_root) / rel

--- a/tests/dj_pipeline/conftest.py
+++ b/tests/dj_pipeline/conftest.py
@@ -137,6 +137,15 @@ def _check_golden_data(dataset_config: dict) -> Path:
     if not Path(pipeline.repository_config["ceph_aeon"]).exists():
         pytest.skip(f"Golden data root not found: {pipeline.repository_config['ceph_aeon']}")
 
+    # Route the large recording intermediate to a scratch mirror so the scratch
+    # relocation is actually exercised (not silently left in-place). Sibling of the
+    # golden root, so it's isolated and works wherever the golden data lives. Skip if
+    # the caller pinned repository_config via DJ_REPOSITORY_CONFIG (their values win).
+    if "DJ_REPOSITORY_CONFIG" not in os.environ:
+        scratch_root = Path(pipeline.repository_config["ceph_aeon"]).parent / "scratch"
+        scratch_root.mkdir(parents=True, exist_ok=True)
+        pipeline.repository_config["ceph_aeon_scratch"] = str(scratch_root)
+
     from aeon.dj_pipeline.utils.paths import get_repository_path
 
     repo_path = get_repository_path("ceph_aeon")

--- a/tests/dj_pipeline/test_ephys_ingestion.py
+++ b/tests/dj_pipeline/test_ephys_ingestion.py
@@ -149,8 +149,11 @@ class TestPreProcessing:
         key = (ctx.spike_sorting.SortingTask & {"experiment_name": ctx.cfg["experiment_name"]}).to_dicts()[
             0
         ]
+        from aeon.dj_pipeline.utils.paths import scratch_recording_dir
+
         output_dir = ctx.spike_sorting.PreProcessing.infer_output_dir(key)
-        recording_zarr = output_dir.parent / "recording" / "recording.zarr"
+        # recording.zarr lives on the scratch mirror when configured, else in-place on ceph.
+        recording_zarr = scratch_recording_dir(output_dir.parent / "recording") / "recording.zarr"
         assert recording_zarr.exists(), f"Expected zarr recording at {recording_zarr}"
         assert any(recording_zarr.iterdir()), "recording.zarr directory is empty"
 


### PR DESCRIPTION
## Summary
Route the large, regenerable preprocessed recording intermediate (`recording.zarr` / `recording.dat`) to a non-backed-up scratch filesystem instead of the backed-up ceph store. Stacks on top of #602.

## Context
The preprocessed recording is only read by the sorting step and is not DB-tracked (`PreProcessing.File` already excludes `recording.zarr` and `recording.dat`), so it does not belong on the backed-up store. A new `scratch_recording_dir()` in `utils/paths.py` mirrors the ceph sub-path under `ceph_aeon_scratch` (default `/ceph/scratch`), so the scratch layout lines up 1:1 with the ceph layout. It falls back to the on-ceph location unchanged when the scratch root is unset, absent, or the recording dir is not under the ceph root, so local and CI machines without `/ceph/scratch` are unaffected.

The redirect is applied at the three sites that reference the intermediate: the write in `PreProcessing`, and the read and post-sort delete in `SpikeSorting`. `si_recording.pkl` and every DB-tracked output stay on ceph, and the recording provenance points at the raw file (not the intermediate), so relocating it changes nothing downstream.

The golden test now exercises the redirect: `conftest` points `ceph_aeon_scratch` at a sibling `scratch/` dir of the golden root, and `test_recording_zarr_exists` resolves the expected path through `scratch_recording_dir()`.

## Note for review
The default `repository_config` now includes `ceph_aeon_scratch: /ceph/scratch`, so with the default config the intermediate is written to `/ceph/scratch` for everyone, not just when explicitly configured. This is the intended SWC behavior and it degrades safely (falls back to the on-ceph location when `/ceph/scratch` is absent), but it is a behavior change worth a second look.

Validated on the SWC HPC against the golden ephys dataset on aeondj: unit 132 passed, ephys golden integration 32 passed / 0 failed, including `test_recording_zarr_exists` resolving to the scratch mirror.
