### PR TITLE
Spike-sorting curation bug fixes (works-as-designed)

### DIFF
--- a/aeon/dj_pipeline/__init__.py
+++ b/aeon/dj_pipeline/__init__.py
@@ -3,8 +3,6 @@
 import json
 import logging
 import os
-import sys
-import traceback
 from typing import cast
 
 import pymysql.converters
@@ -41,36 +39,6 @@ pymysql.converters.escape_dict = _escape_dict_as_json
 pymysql.converters.encoders[dict] = _escape_dict_as_json
 pymysql.converters.conversions[dict] = _escape_dict_as_json
 
-
-# ---------------------------------------------------------------------------
-# DataJoint traceback patch
-#
-# Importing DataJoint installs a process-wide sys.excepthook that routes every
-# uncaught exception through its logger with exc_info attached. Its formatter
-# (datajoint.logging.LevelAwareFormatter) overrides Formatter.format and
-# returns only record.getMessage(), never calling formatException, so the
-# traceback is attached to the record and then discarded. Every crash in any
-# script importing this package therefore prints only:
-#     [YYYY-MM-DD HH:MM:SS][ERROR]: Uncaught exception
-#
-# This reinstates the excepthook with the traceback rendered into the message
-# itself, which every formatter emits unconditionally. We deliberately do not
-# pass exc_info: DataJoint's excepthook is its only exc_info call site, and
-# formatting the text here keeps the patch independent of the formatter chain
-# and free of double-rendering if DataJoint later fixes LevelAwareFormatter.
-#
-# Remove when: DataJoint renders exc_info (broken as of 2.3.1).
-# ---------------------------------------------------------------------------
-def _excepthook(exc_type, exc_value, exc_traceback):
-    if issubclass(exc_type, KeyboardInterrupt):
-        sys.__excepthook__(exc_type, exc_value, exc_traceback)
-        return
-
-    formatted = "".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
-    dj.logger.error("Uncaught exception\n%s", formatted.rstrip())
-
-
-sys.excepthook = _excepthook
 
 # Register Aeon + xarray codecs BEFORE any schema activation
 from aeon.dj_pipeline.utils.codec import (  # pyright: ignore[reportUnusedImport]

--- a/aeon/dj_pipeline/scripts/launch_si_gui.py
+++ b/aeon/dj_pipeline/scripts/launch_si_gui.py
@@ -41,7 +41,6 @@ _launch_start_time = time.perf_counter()
 import argparse
 import json
 import resource
-import sys
 import traceback
 
 try:
@@ -49,16 +48,6 @@ try:
 except Exception:
     traceback.print_exc()
     raise
-
-# datajoint installs its own sys.excepthook on import, and its log formatter drops
-# the traceback entirely - any uncaught exception (including from GUI button clicks)
-# shows up as a bare "[ERROR]: Uncaught exception" with no detail. The import above already
-# triggered aeon/dj_pipeline/__init__.py's own excepthook patch for this (routes through
-# dj.logger.error(), which prints to stdout with a timestamp/level prefix) - deliberately
-# override that here instead: plain traceback.print_exception writes to stderr (the
-# conventionally-correct stream for uncaught exceptions) with no logger prefix, which reads
-# better for a human watching this GUI crash in real time than a timestamped log line does.
-sys.excepthook = traceback.print_exception
 
 
 def _set_window_title(key: dict) -> None:

--- a/aeon/dj_pipeline/scripts/launch_si_gui.py
+++ b/aeon/dj_pipeline/scripts/launch_si_gui.py
@@ -44,7 +44,7 @@ import resource
 import traceback
 
 try:
-    from aeon.dj_pipeline import spike_sorting_curation
+    from aeon.dj_pipeline import spike_sorting, spike_sorting_curation
 except Exception:
     traceback.print_exc()
     raise
@@ -181,14 +181,15 @@ if __name__ == "__main__":
 
     # Custom label categories for the curation panel. Only applies to blocks with no
     # curation_data.json / zarr curation attrs already saved - see launch_spikeinterface_gui().
-    # "tags" is edited via the multitag plugin view registered below, not the built-in
-    # unit table editor. label_options is sourced from MANUAL_TAG_OPTIONS - the same list
-    # spike_sorting_curation.py reads back off the analyzer into SortedSpikes.UnitTag - so
-    # this, multitag_view.TAG_SHORTCUTS, and the DB-writing side can't drift apart.
+    # "tags" is edited via the multitag plugin view registered below, not the built-in unit
+    # table editor. label_options comes from the CurationTag lookup - the single source of
+    # truth that SortedSpikes.UnitTag foreign-keys into and the read-back reads - so the GUI,
+    # multitag_view.TAG_SHORTCUTS (validated below), and the DB side can't drift apart.
+    tag_options = list(spike_sorting.CurationTag.fetch("tag"))
     label_definitions = {
         "quality": {"label_options": ["good", "noise", "MUA"], "exclusive": True},
         "tags": {
-            "label_options": list(spike_sorting_curation.MANUAL_TAG_OPTIONS),
+            "label_options": tag_options,
             "exclusive": False,
         },
     }
@@ -196,7 +197,16 @@ if __name__ == "__main__":
     # Register the custom multitag view (checkbox + keyboard-shortcut multi-tagging,
     # see multitag_view.py) so it can be referenced in the layout below.
     import spikeinterface_gui.viewlist as _viewlist
-    from multitag_view import MultiTagView
+    from multitag_view import TAG_SHORTCUTS, MultiTagView
+
+    # Guard against the GUI shortcuts drifting from the CurationTag vocabulary: a shortcut for a
+    # tag that isn't valid would be selectable but rejected on write. Checked here (not at
+    # multitag_view import) because it needs the database.
+    if set(TAG_SHORTCUTS.values()) != set(tag_options):
+        raise ValueError(
+            f"multitag_view.TAG_SHORTCUTS {set(TAG_SHORTCUTS.values())} != CurationTag "
+            f"{set(tag_options)} - keep the GUI shortcuts in sync with the CurationTag lookup."
+        )
 
     _viewlist.builtin_views.append(MultiTagView)
 

--- a/aeon/dj_pipeline/scripts/launch_si_gui.py
+++ b/aeon/dj_pipeline/scripts/launch_si_gui.py
@@ -185,7 +185,7 @@ if __name__ == "__main__":
     # table editor. label_options comes from the CurationTag lookup - the single source of
     # truth that SortedSpikes.UnitTag foreign-keys into and the read-back reads - so the GUI,
     # multitag_view.TAG_SHORTCUTS (validated below), and the DB side can't drift apart.
-    tag_options = list(spike_sorting.CurationTag.fetch("tag"))
+    tag_options = list(spike_sorting.CurationTag.to_arrays("tag"))
     label_definitions = {
         "quality": {"label_options": ["good", "noise", "MUA"], "exclusive": True},
         "tags": {

--- a/aeon/dj_pipeline/scripts/multitag_view.py
+++ b/aeon/dj_pipeline/scripts/multitag_view.py
@@ -13,15 +13,13 @@ See: https://spikeinterface-gui.readthedocs.io/en/latest/custom_views.html
 
 from spikeinterface_gui.view_base import ViewBase
 
-from aeon.dj_pipeline.spike_sorting_curation import MANUAL_TAG_OPTIONS
-
 TAGS_CATEGORY = "tags"
 
 # plain-letter shortcuts not already used elsewhere in the GUI (existing: space, c, g, m, n).
-# Keys are this view's own choice; values must match MANUAL_TAG_OPTIONS exactly - that's the
-# list spike_sorting_curation.py actually reads back off the analyzer when writing
-# SortedSpikes.UnitTag, so a mismatch here would mean a tag is selectable in the GUI but
-# silently never reaches the database. The assertion below catches that at import time.
+# Keys are this view's own choice; values must match the CurationTag lookup - that's the list
+# spike_sorting_curation.py reads back off the analyzer when writing SortedSpikes.UnitTag, so a
+# mismatch would mean a tag is selectable in the GUI but silently never reaches the database.
+# launch_si_gui.py validates this against CurationTag at launch (needs the database).
 TAG_SHORTCUTS = {
     "w": "irregular waveform",
     "d": "amplitude drift",
@@ -30,10 +28,6 @@ TAG_SHORTCUTS = {
     "r": "refractory violations",
     "f": "flag",
 }
-assert set(TAG_SHORTCUTS.values()) == set(MANUAL_TAG_OPTIONS), (
-    f"TAG_SHORTCUTS values {set(TAG_SHORTCUTS.values())} != MANUAL_TAG_OPTIONS "
-    f"{set(MANUAL_TAG_OPTIONS)} - keep these in sync with spike_sorting_curation.MANUAL_TAG_OPTIONS."
-)
 
 
 class MultiTagView(ViewBase):

--- a/aeon/dj_pipeline/scripts/unit_matching_qc.py
+++ b/aeon/dj_pipeline/scripts/unit_matching_qc.py
@@ -126,18 +126,12 @@ def get_unit_locations(block_key_: dict) -> pd.DataFrame:
     return pd.DataFrame(locations, index=analyzer.unit_ids, columns=columns)
 
 
-# Now defined in spike_sorting_curation (where the curation-writing logic that reads these
-# properties lives) - kept as a module-level alias here since existing code/notebooks refer to
-# qc.MANUAL_TAG_OPTIONS.
-MANUAL_TAG_OPTIONS = spike_sorting_curation.MANUAL_TAG_OPTIONS
-
-
 def get_unit_manual_labels(block_key_: dict) -> pd.DataFrame:
     """Manual curation quality label + custom tags (index=unit_id) for a block.
 
     Read directly from the curated analyzer's `sorting` properties - these are the labels
     actually assigned by hand in the SpikeInterface GUI (`quality`: good/MUA/noise, plus one
-    boolean property per tag in MANUAL_TAG_OPTIONS). This is NOT the same thing as
+    boolean property per tag in the CurationTag lookup). This is NOT the same thing as
     `SortedSpikes.Unit.unit_quality`, which is Kilosort's own KSLabel and doesn't reflect
     manual curation at all (it reads "good" for units manually labeled MUA/noise too).
     Curation also doesn't remove MUA/noise units - they stay in SortedSpikes.Unit.
@@ -151,7 +145,7 @@ def get_unit_manual_labels(block_key_: dict) -> pd.DataFrame:
 
     data = {"unit": analyzer.unit_ids}
     data["manual_quality"] = sorting.get_property("quality") if "quality" in prop_keys else None
-    for tag in MANUAL_TAG_OPTIONS:
+    for tag in spike_sorting.CurationTag.fetch("tag"):
         data[tag] = sorting.get_property(tag) if tag in prop_keys else None
     return pd.DataFrame(data).set_index("unit")
 
@@ -295,13 +289,14 @@ def _annotate_orphans(
     earlier_block_start,
     is_prev_side: bool,
 ) -> pd.DataFrame:
+    tag_options = list(spike_sorting.CurationTag.fetch("tag"))
     if not orphan_unit_ids:
         return pd.DataFrame(
             columns=[
                 "unit",
                 "unit_quality",
                 "manual_quality",
-                *MANUAL_TAG_OPTIONS,
+                *tag_options,
                 *_QC_METRIC_COLUMNS,
                 "x",
                 "y",
@@ -339,11 +334,11 @@ def _annotate_orphans(
             row["x"] = row["y"] = None
         if unit_id in manual_labels.index:
             row["manual_quality"] = manual_labels.loc[unit_id, "manual_quality"]
-            for tag in MANUAL_TAG_OPTIONS:
+            for tag in tag_options:
                 row[tag] = manual_labels.loc[unit_id, tag]
         else:
             row["manual_quality"] = None
-            row.update(dict.fromkeys(MANUAL_TAG_OPTIONS))
+            row.update(dict.fromkeys(tag_options))
         overlap_times = spike_sorting._restrict_to_overlap(
             this_trains.get(unit_id, np.array([])), overlap_start_s, overlap_end_s
         )

--- a/aeon/dj_pipeline/scripts/unit_matching_qc.py
+++ b/aeon/dj_pipeline/scripts/unit_matching_qc.py
@@ -4,9 +4,9 @@ Covers three things, used interactively from notebooks (e.g.
 notebooks/zofia/spike_sorting/unit_matching.ipynb) rather than run as a CLI:
 
 1. Matched-pair retrieval + waveform template lookup, for visually spot-checking matches.
-2. Backfilling UnitMatching.CandidateMatch for UnitMatching rows computed before that table
+2. Backfilling UnitMatching.BlockComparison for UnitMatching rows computed before that table
    existed (recomputes the same overlap-window comparison spike_sorting.UnitMatching.make()
-   runs, but only inserts the candidate-pairing audit rows - it does not touch GlobalUnit,
+   runs, but only inserts the full agreement-score grid - it does not touch GlobalUnit,
    UnitMatching.Unit, or UnitMatching.Spikes, which are already correct).
 3. Orphan-unit diagnostics: for units that didn't get matched between two blocks, pull
    quality metrics, probe location, whether they even had spikes in the overlap window, and
@@ -157,21 +157,20 @@ def get_unit_manual_labels(block_key_: dict) -> pd.DataFrame:
 
 
 # ---------------------------------------------------------------------------
-# CandidateMatch backfill
+# BlockComparison backfill
 # ---------------------------------------------------------------------------
 
 
-def backfill_candidate_matches(key: dict) -> int:
-    """Populate UnitMatching.CandidateMatch for an already-computed UnitMatching row.
+def backfill_block_comparisons(key: dict) -> int:
+    """Populate UnitMatching.BlockComparison for an already-computed UnitMatching row.
 
     Recomputes the same overlap-window spike-time comparison `UnitMatching.make()` runs
     (using that row's own UnitMatchingParamSet.params, same as make() does), against every
-    previously-matched block that overlaps it, and inserts candidate rows
-    (agreement_score >= min_score) - skipping any already present, so this is safe to call
-    repeatedly for the same key. Does not touch GlobalUnit, UnitMatching.Unit, or
-    UnitMatching.Spikes.
+    previously-matched block that overlaps it, and stores the full agreement-score grid -
+    skipping any comparison already present, so this is safe to call repeatedly for the same
+    key. Does not touch GlobalUnit, UnitMatching.Unit, or UnitMatching.Spikes.
 
-    Returns the number of new rows inserted.
+    Returns the number of new BlockComparison rows inserted.
     """
     insertion_key = {k: key[k] for k in ("experiment_name", "subject", "insertion_number")}
     paramset_key = {"matching_paramset_id": key["matching_paramset_id"]}
@@ -195,13 +194,15 @@ def backfill_candidate_matches(key: dict) -> int:
     if not this_block_units:
         return 0
 
-    existing_keys = {
-        (e["unit"], e["prev_block_start"], e["prev_unit"])
-        for e in (spike_sorting.UnitMatching.CandidateMatch & key).to_dicts()
+    existing_matched_starts = {
+        e["matched_block_start"]
+        for e in (spike_sorting.UnitMatching.BlockComparison & key).to_dicts()
     }
 
     new_rows = []
     for prev_block in overlapping_blocks:
+        if prev_block["block_start"] in existing_matched_starts:
+            continue
         prev_units = spike_sorting._load_block_unit_spike_trains(prev_block)
         if not prev_units:
             continue
@@ -216,29 +217,19 @@ def backfill_candidate_matches(key: dict) -> int:
         )
         if comparison is None:
             continue
-        prev_to_this, _ = comparison.get_matching()
-        for prev_uid in comparison.agreement_scores.index:
-            for this_uid in comparison.agreement_scores.columns:
-                score = float(comparison.agreement_scores.at[prev_uid, this_uid])
-                if score < params["min_score"]:
-                    continue
-                dedup_key = (this_uid, prev_block["block_start"], prev_uid)
-                if dedup_key in existing_keys:
-                    continue
-                new_rows.append(
-                    {
-                        **key,
-                        "unit": this_uid,
-                        "prev_block_start": prev_block["block_start"],
-                        "prev_unit": prev_uid,
-                        "agreement_score": score,
-                        "matched_spike_count": int(comparison.match_event_count.at[prev_uid, this_uid]),
-                        "is_hungarian_match": bool(prev_to_this.get(prev_uid) == this_uid),
-                    }
-                )
+        new_rows.append(
+            {
+                **key,
+                "matched_block_start": prev_block["block_start"],
+                "matched_block_end": prev_block["block_end"],
+                "unit_ids": np.asarray(comparison.agreement_scores.columns),
+                "matched_block_unit_ids": np.asarray(comparison.agreement_scores.index),
+                "agreement_scores": comparison.agreement_scores.to_numpy(),
+            }
+        )
 
     if new_rows:
-        spike_sorting.UnitMatching.CandidateMatch.insert(
+        spike_sorting.UnitMatching.BlockComparison.insert(
             new_rows, ignore_extra_fields=True, allow_direct_insert=True
         )
     return len(new_rows)
@@ -252,32 +243,47 @@ _QC_METRIC_COLUMNS = ("presence_ratio", "isi_violations_ratio", "snr", "firing_r
 
 
 def _best_candidate(unit_id: int, is_prev_side: bool, later_block_key: dict, earlier_block_start) -> dict:
-    """Best-scoring candidate for a unit, from UnitMatching.CandidateMatch.
+    """Best-scoring candidate for a unit, read from UnitMatching.BlockComparison's score grid.
 
-    `later_block_key` is the block whose UnitMatching row did the comparison (always the
-    later of the two blocks, since CandidateMatch rows are keyed by "this block" = the block
-    make() was processing). `is_prev_side=True` means `unit_id` belongs to the earlier
-    block, so it's looked up as `prev_unit`; `False` means it belongs to the later block, so
-    it's looked up as `unit`.
+    `later_block_key` is the block whose UnitMatching row did the comparison (always the later
+    of the two blocks, since the grid is stored under "this block" = the block make() was
+    processing). `is_prev_side=True` means `unit_id` belongs to the earlier (matched-against)
+    block, so it's a row of the grid; `False` means it belongs to the later block, so it's a
+    column. Returns the highest-scoring opposite-side unit and that score (None if no grid or
+    the unit isn't in it).
     """
-    if is_prev_side:
-        rows = (
-            spike_sorting.UnitMatching.CandidateMatch
-            & later_block_key
-            & {"prev_block_start": earlier_block_start, "prev_unit": unit_id}
-        ).to_dicts()
-        other_id_field = "unit"
-    else:
-        rows = (spike_sorting.UnitMatching.CandidateMatch & later_block_key & {"unit": unit_id}).to_dicts()
-        other_id_field = "prev_unit"
+    none_result = {"best_candidate_unit": None, "best_candidate_score": None}
+    grid = (
+        spike_sorting.UnitMatching.BlockComparison
+        & later_block_key
+        & {"matched_block_start": earlier_block_start}
+    )
+    if not grid:
+        return none_result
+    row = grid.fetch1()
+    scores = np.asarray(row["agreement_scores"])              # [matched_block_unit_ids x unit_ids]
+    this_units = np.asarray(row["unit_ids"])                  # columns (later block)
+    matched_units = np.asarray(row["matched_block_unit_ids"])  # rows (earlier block)
+    if scores.size == 0:
+        return none_result
 
-    if not rows:
-        return {"best_candidate_unit": None, "best_candidate_score": None, "best_candidate_matched_spike_count": None}
-    best = max(rows, key=lambda r: r["agreement_score"])
+    if is_prev_side:
+        idx = np.where(matched_units == unit_id)[0]
+        if len(idx) == 0:
+            return none_result
+        score_vec, other_units = scores[idx[0], :], this_units
+    else:
+        idx = np.where(this_units == unit_id)[0]
+        if len(idx) == 0:
+            return none_result
+        score_vec, other_units = scores[:, idx[0]], matched_units
+
+    if len(score_vec) == 0:
+        return none_result
+    best_i = int(np.argmax(score_vec))
     return {
-        "best_candidate_unit": best[other_id_field],
-        "best_candidate_score": best["agreement_score"],
-        "best_candidate_matched_spike_count": best["matched_spike_count"],
+        "best_candidate_unit": int(other_units[best_i]),
+        "best_candidate_score": float(score_vec[best_i]),
     }
 
 
@@ -302,7 +308,6 @@ def _annotate_orphans(
                 "overlap_window_spike_count",
                 "best_candidate_unit",
                 "best_candidate_score",
-                "best_candidate_matched_spike_count",
             ]
         )
 
@@ -382,8 +387,8 @@ def _resolve_shank_blocks(shank_key: dict, matching_paramset_id: int):
 def get_orphan_units(shank_key: dict, matching_paramset_id: int) -> tuple[pd.DataFrame, pd.DataFrame]:
     """A-side and B-side units that didn't get matched across a shank's two blocks.
 
-    Call `backfill_candidate_matches` for the later block's UnitMatching key first if
-    CandidateMatch hasn't been populated for it yet, otherwise best_candidate_* columns will
+    Call `backfill_block_comparisons` for the later block's UnitMatching key first if
+    BlockComparison hasn't been populated for it yet, otherwise best_candidate_* columns will
     be empty.
 
     Returns (a_orphans, b_orphans):

--- a/aeon/dj_pipeline/scripts/unit_matching_qc.py
+++ b/aeon/dj_pipeline/scripts/unit_matching_qc.py
@@ -145,7 +145,7 @@ def get_unit_manual_labels(block_key_: dict) -> pd.DataFrame:
 
     data = {"unit": analyzer.unit_ids}
     data["manual_quality"] = sorting.get_property("quality") if "quality" in prop_keys else None
-    for tag in spike_sorting.CurationTag.fetch("tag"):
+    for tag in spike_sorting.CurationTag.to_arrays("tag"):
         data[tag] = sorting.get_property(tag) if tag in prop_keys else None
     return pd.DataFrame(data).set_index("unit")
 
@@ -289,7 +289,7 @@ def _annotate_orphans(
     earlier_block_start,
     is_prev_side: bool,
 ) -> pd.DataFrame:
-    tag_options = list(spike_sorting.CurationTag.fetch("tag"))
+    tag_options = list(spike_sorting.CurationTag.to_arrays("tag"))
     if not orphan_unit_ids:
         return pd.DataFrame(
             columns=[

--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -1214,19 +1214,16 @@ class GlobalUnit(dj.Manual):
     """
 
 
-# SpikeInterface's own "chance_score" default. Candidate pairings scoring below this are
-# noise-level (essentially no coincident spikes relative to each unit's spike count) and
-# aren't worth persisting in UnitMatching.CandidateMatch.
 # Defaults for UnitMatchingParamSet.params - used for any key missing from a given paramset's
 # params blob, so existing paramsets (saved with params={}) keep behaving exactly as before.
-# Note: "min_score" here is our own name for what gets passed as compare_two_sorters'
-# "chance_score" kwarg - renamed on our side since we also reuse it as the threshold for what
-# gets persisted to CandidateMatch, which isn't quite the same concept SpikeInterface's own
-# "chance_score" name implies.
+# "min_score" is our own name for compare_two_sorters' "chance_score" kwarg (pairings below it
+# are noise-level - essentially no coincident spikes relative to each unit's spike count).
+# BlockComparison stores the whole agreement-score grid regardless, so min_score no longer gates
+# what is persisted; it only feeds the comparison.
 _DEFAULT_MATCHING_PARAMS = {
     "delta_time": 0.4,  # ms; coincidence window for compare_two_sorters
     "match_score": 0.5,  # min agreement_score to accept a 1:1 (Hungarian) match
-    "min_score": 0.1,  # min agreement_score worth persisting to CandidateMatch at all
+    "min_score": 0.1,  # compare_two_sorters chance_score (below = noise-level)
 }
 
 
@@ -1366,21 +1363,18 @@ class UnitMatching(dj.Computed):
         unique index (experiment_name, subject, insertion_number, global_unit, chunk_start)
         """
 
-    class CandidateMatch(dj.Part):
+    class BlockComparison(dj.Part):
         definition = """
-        # Every (this-block unit, prev-block unit) candidate pairing that compare_two_sorters
-        # scored >= the paramset's min_score against an overlapping previous block - not just the
-        # final accepted 1:1 (Hungarian) assignment. Lets QC ask how close an unmatched unit
-        # came (its best candidate's agreement_score), instead of only knowing it didn't clear
-        # match_score.
+        # Full agreement-score grid from compare_two_sorters between this block's units and the
+        # units of one block it was compared against - every pairing, not just those above a
+        # threshold. QC/audit only; does not affect matching or global-unit assignment. One row
+        # per block this block was compared against.
         -> master
-        -> SortedSpikes.Unit
-        prev_block_start: datetime(6)  # block_start of the compared-against previous block
-        prev_unit: int32               # unit id in that previous block
+        -> ephys.EphysBlock.proj(matched_block_start='block_start', matched_block_end='block_end')
         ---
-        agreement_score: float64        # SpikeInterface's Jaccard-style score (0-1)
-        matched_spike_count: int32       # coincident spike count within delta_time
-        is_hungarian_match: bool         # whether this pair was the accepted 1:1 assignment
+        unit_ids: <blob>                # this block's unit ids (column order of agreement_scores)
+        matched_block_unit_ids: <blob>  # compared block's unit ids (row order of agreement_scores)
+        agreement_scores: <blob>        # 2D float64 [matched_block_unit_ids x unit_ids], Jaccard 0-1
         """
 
     @property
@@ -1506,10 +1500,10 @@ class UnitMatching(dj.Computed):
         # Map: this block's unit_id -> matched spike count from the comparison that produced
         # its match (unset for newly-created global units, which had nothing to match against)
         unit_to_match_count = {}
-        # Every candidate pairing scored >= min_score against any overlapping previous block,
-        # not just the accepted match - persisted to CandidateMatch below so unmatched units
-        # can be audited later (how close was their best candidate?).
-        all_candidate_rows = []
+        # Full agreement-score grid for each overlapping previous block, persisted to
+        # BlockComparison below (the complete matrix, no threshold) so QC can see the whole
+        # spectrum of scores - how close every unit came, not just the accepted matches.
+        block_comparison_rows = []
 
         if not previously_matched:
             logger.info("First block for this insertion — all units will be new global units.")
@@ -1544,6 +1538,20 @@ class UnitMatching(dj.Computed):
             # get_matching() returns (sorting1→sorting2, sorting2→sorting1)
             prev_to_this, _ = comparison.get_matching()
 
+            # Save the full score grid for this comparison (QC/audit only - does not affect the
+            # assignment below). agreement_scores is indexed [prev/matched units x this units]
+            # and holds every pair's score regardless of min_score, so this is the whole spectrum.
+            block_comparison_rows.append(
+                {
+                    **key,
+                    "matched_block_start": prev_block["block_start"],
+                    "matched_block_end": prev_block["block_end"],
+                    "unit_ids": np.asarray(comparison.agreement_scores.columns),
+                    "matched_block_unit_ids": np.asarray(comparison.agreement_scores.index),
+                    "agreement_scores": comparison.agreement_scores.to_numpy(),
+                }
+            )
+
             for prev_uid in comparison.agreement_scores.index:
                 for this_uid in comparison.agreement_scores.columns:
                     score = float(comparison.agreement_scores.at[prev_uid, this_uid])
@@ -1551,17 +1559,6 @@ class UnitMatching(dj.Computed):
                         continue
                     matched_spike_count = int(comparison.match_event_count.at[prev_uid, this_uid])
                     is_hungarian_match = bool(prev_to_this.get(prev_uid) == this_uid)
-                    all_candidate_rows.append(
-                        {
-                            **key,
-                            "unit": this_uid,
-                            "prev_block_start": prev_block["block_start"],
-                            "prev_unit": prev_uid,
-                            "agreement_score": score,
-                            "matched_spike_count": matched_spike_count,
-                            "is_hungarian_match": is_hungarian_match,
-                        }
-                    )
                     # First accepted (Hungarian) match wins - a unit is not reconsidered once
                     # assigned, even if a later overlapping block would score higher. Blocks are
                     # only ever compared to at most one already-processed neighbor at a time in
@@ -1679,9 +1676,9 @@ class UnitMatching(dj.Computed):
                     ignore_extra_fields=True,
                 )
 
-        # ---- Insert UnitMatching.CandidateMatch (audit trail beyond the final assignment) ----
-        if all_candidate_rows:
-            self.CandidateMatch.insert(all_candidate_rows, ignore_extra_fields=True)
+        # ---- Insert UnitMatching.BlockComparison (full score grid, QC/audit) ----
+        if block_comparison_rows:
+            self.BlockComparison.insert(block_comparison_rows, ignore_extra_fields=True)
 
         logger.info(
             f"Unit matching complete for block {key['block_start']}:\n"

--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -73,6 +73,24 @@ class UnitQuality(dj.Lookup):
 
 
 @schema
+class CurationTag(dj.Lookup):
+    definition = """
+    # Valid non-exclusive manual-curation tags a curator can apply to a unit in the SI GUI.
+    # SortedSpikes.UnitTag foreign-keys into this; the GUI and QC read the list from here (not
+    # from a hardcoded constant). Extend by inserting rows.
+    tag: varchar(64)
+    """
+    contents = [
+        ("irregular waveform",),
+        ("amplitude drift",),
+        ("bimodal amplitude",),
+        ("intermittent",),
+        ("refractory violations",),
+        ("flag",),
+    ]
+
+
+@schema
 class SortingMethod(dj.Lookup):
     definition = """ # Method for spike sorting
     sorting_method: varchar(16)
@@ -738,10 +756,10 @@ class SortedSpikes(dj.Imported):
     class UnitTag(dj.Part):
         definition = """
         # Manual curation tags (non-exclusive) - one row per tag actually applied to a unit,
-        # read from the curated analyzer's per-tag boolean properties (see
-        # spike_sorting_curation.MANUAL_TAG_OPTIONS). A unit with no tags has no rows here.
+        # read from the curated analyzer's per-tag boolean properties (one per CurationTag).
+        # A unit with no tags has no rows here.
         -> master.Unit
-        tag: varchar(64)
+        -> CurationTag
         """
 
     def make(self, key):

--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -1270,9 +1270,16 @@ def _restrict_to_overlap(spike_times_s: np.ndarray, start_s: float, end_s: float
 
 
 def _load_block_unit_spike_trains(block_key: dict) -> dict[int, np.ndarray]:
-    """Return {unit_id: sorted spike times in epoch seconds} for every unit in a block."""
+    """Return {unit_id: sorted spike times in epoch seconds} for every non-noise unit in a block.
+
+    Units the curator manually labeled "noise" (SortedSpikes.Unit.curation_quality == "noise") are
+    excluded: they are kept in SortedSpikes/SyncedSpikes but should never be matched across blocks or
+    handed a global unit id. The antijoin excludes only the exact "noise" label, so uncurated units
+    (curation_quality NULL) and every other label are still loaded.
+    """
+    non_noise_units = SortedSpikes.Unit - {"curation_quality": "noise"}
     trains: dict[int, list] = {}
-    for unit_entry in (SyncedSpikes.Unit & block_key).to_dicts():
+    for unit_entry in (SyncedSpikes.Unit & block_key & non_noise_units).to_dicts():
         trains.setdefault(unit_entry["unit"], []).append(unit_entry["spike_times"])
     for unit_id, chunks in trains.items():
         concatenated = np.sort(np.concatenate(chunks))

--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -741,12 +741,8 @@ class SortedSpikes(dj.Imported):
         unit: int32
         ---
         -> ephys.ElectrodeConfig.Electrode  # electrode with highest waveform amplitude for this unit
-        -> UnitQuality
-        curation_quality=null: varchar(16)  # manual curation quality label (good/mua/noise), read
-                                             # from the curated analyzer's "quality" property - null
-                                             # until manually curated. NOT the same as unit_quality
-                                             # above, which is Kilosort's own KSLabel and doesn't
-                                             # reflect manual curation at all.
+        -> UnitQuality  # Kilosort's KSLabel for raw sorting; replaced by the curator's manual quality
+                        # label once an official curation is applied (single field, per the spec)
         spike_count: int32       # how many spikes in this recording for this unit
         spike_indices: <blob@dj_store>  # array of spike indices into the concatenated binary data (from preprocessing)
         spike_sites : <blob@dj_store>   # array of electrode associated with each spike
@@ -855,15 +851,23 @@ class SortedSpikes(dj.Imported):
             )
         }
 
-        # Get unit id to quality label mapping
-        cluster_quality_label_map = {
-            int(unit_id): (
-                si_sorting.get_unit_property(unit_id, "KSLabel")
-                if "KSLabel" in si_sorting.get_property_keys()
-                else "n.a."
+        # unit_quality is a single field: the curator's manual label once an official curation has
+        # been applied (curation_id != -1, so we've loaded the curated analyzer), otherwise Kilosort's
+        # own KSLabel. The manual call lives in the curated sorting's "quality" property; the
+        # make_curation_official gate guarantees every curated unit has one, so a curated block's units
+        # all carry the human's call, with KSLabel only as a defensive fallback.
+        prop_keys = set(si_sorting.get_property_keys())
+        use_manual_quality = curation_id != -1 and "quality" in prop_keys
+        unit_quality_map = {}
+        for unit_id in si_sorting.unit_ids:
+            quality = (
+                (si_sorting.get_unit_property(unit_id, "quality") or "").strip().lower()
+                if use_manual_quality
+                else ""
             )
-            for unit_id in si_sorting.unit_ids
-        }
+            if not quality:
+                quality = si_sorting.get_unit_property(unit_id, "KSLabel") if "KSLabel" in prop_keys else "n.a."
+            unit_quality_map[int(unit_id)] = quality
 
         spike_locations = sorting_analyzer.get_extension("spike_locations")
         extremum_channel_inds = si.template_tools.get_template_extremum_channel(
@@ -893,7 +897,7 @@ class SortedSpikes(dj.Imported):
                     **key,
                     **channel2electrode_map[unit_peak_channel[unit_id]],
                     "unit": unit_id,
-                    "unit_quality": cluster_quality_label_map[unit_id],
+                    "unit_quality": unit_quality_map[unit_id],
                     "spike_indices": spike_indices,
                     "spike_count": spike_count_dict[unit_id],
                     "spike_sites": spike_sites,
@@ -901,6 +905,18 @@ class SortedSpikes(dj.Imported):
                 },
                 ignore_extra_fields=True,
             )
+
+        # Manual curation tags (curated blocks only): one UnitTag row per (unit, tag) the curator
+        # applied, read from the curated analyzer's per-tag boolean properties (see CurationTag).
+        if curation_id != -1:
+            tag_rows = [
+                {**key, "unit": int(unit_id), "tag": tag}
+                for unit_id in si_sorting.unit_ids
+                for tag in CurationTag.fetch("tag")
+                if tag in prop_keys and bool(si_sorting.get_unit_property(unit_id, tag))
+            ]
+            if tag_rows:
+                self.UnitTag.insert(tag_rows, ignore_extra_fields=True)
 
 
 @schema
@@ -1272,12 +1288,13 @@ def _restrict_to_overlap(spike_times_s: np.ndarray, start_s: float, end_s: float
 def _load_block_unit_spike_trains(block_key: dict) -> dict[int, np.ndarray]:
     """Return {unit_id: sorted spike times in epoch seconds} for every non-noise unit in a block.
 
-    Units the curator manually labeled "noise" (SortedSpikes.Unit.curation_quality == "noise") are
+    Units the curator manually labeled "noise" (SortedSpikes.Unit.unit_quality == "noise") are
     excluded: they are kept in SortedSpikes/SyncedSpikes but should never be matched across blocks or
-    handed a global unit id. The antijoin excludes only the exact "noise" label, so uncurated units
-    (curation_quality NULL) and every other label are still loaded.
+    handed a global unit id. Matching only runs on curated blocks, so unit_quality there is the
+    curator's own call; the antijoin excludes only that exact "noise" label, leaving every other label
+    (including Kilosort's own on any raw unit) loaded.
     """
-    non_noise_units = SortedSpikes.Unit - {"curation_quality": "noise"}
+    non_noise_units = SortedSpikes.Unit - {"unit_quality": "noise"}
     trains: dict[int, list] = {}
     for unit_entry in (SyncedSpikes.Unit & block_key & non_noise_units).to_dicts():
         trains.setdefault(unit_entry["unit"], []).append(unit_entry["spike_times"])

--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -909,10 +909,11 @@ class SortedSpikes(dj.Imported):
         # Manual curation tags (curated blocks only): one UnitTag row per (unit, tag) the curator
         # applied, read from the curated analyzer's per-tag boolean properties (see CurationTag).
         if curation_id != -1:
+            curation_tags = CurationTag.to_arrays("tag")
             tag_rows = [
                 {**key, "unit": int(unit_id), "tag": tag}
                 for unit_id in si_sorting.unit_ids
-                for tag in CurationTag.fetch("tag")
+                for tag in curation_tags
                 if tag in prop_keys and bool(si_sorting.get_unit_property(unit_id, tag))
             ]
             if tag_rows:

--- a/aeon/dj_pipeline/spike_sorting_curation.py
+++ b/aeon/dj_pipeline/spike_sorting_curation.py
@@ -756,6 +756,11 @@ def save_manual_curation(key: dict, description: str = "") -> int:
     # if this fails (e.g. a schema/connection issue), the live curation_data is still intact
     # and save_manual_curation() can just be retried, rather than leaving an orphaned
     # snapshot file on disk with no way to reconstruct it from the (already-cleared) source.
+    #
+    # Wrap both inserts in one transaction so the master and its File part land together or
+    # not at all. This is a standalone function, not a table make(), so it gets none of the
+    # autopopulate framework's automatic per-make() transaction - without this, a failure
+    # between the two inserts would leave a ManualCuration row with no File row behind.
     curation_datetime = datetime.now(UTC)
     curation_entry = {
         **full_key,
@@ -765,15 +770,15 @@ def save_manual_curation(key: dict, description: str = "") -> int:
         "curation_method": "SpikeInterface",
         "description": description,
     }
-    ManualCuration.insert1(curation_entry)
-
     file_entry = {
         **full_key,
         "curation_id": next_curation_id,
         "file_name": curated_file_name,
         "file": curated_file_path,
     }
-    ManualCuration.File.insert1(file_entry)
+    with ManualCuration.connection.transaction:
+        ManualCuration.insert1(curation_entry)
+        ManualCuration.File.insert1(file_entry)
 
     # Now safe to clear the original, live-editable copy
     if is_zarr:

--- a/aeon/dj_pipeline/spike_sorting_curation.py
+++ b/aeon/dj_pipeline/spike_sorting_curation.py
@@ -16,18 +16,6 @@ from aeon.dj_pipeline.utils.spike_sorting_utils import resolve_analyzer_dir
 schema = dj.Schema(get_schema_name("spike_sorting_curation"))
 logger = dj.logger
 
-# Non-exclusive tag options from the SI GUI's "tags" label category (scripts/launch_si_gui.py)
-# - each becomes its own boolean property on the curated sorting after apply_curation, keyed by
-# the tag string itself. Kept here (not in scripts/unit_matching_qc.py) since this is where the
-# curation-writing logic that reads them lives.
-MANUAL_TAG_OPTIONS = (
-    "irregular waveform",
-    "amplitude drift",
-    "bimodal amplitude",
-    "intermittent",
-    "refractory violations",
-    "flag",
-)
 
 
 @schema
@@ -147,9 +135,10 @@ def insert_sorted_spikes_from_analyzer(
         int(unit_id): (si_sorting.get_unit_property(unit_id, "quality") or "").lower() or None
         for unit_id in si_sorting.unit_ids
     } if "quality" in prop_keys else {}
+    tag_options = spike_sorting.CurationTag.fetch("tag")
     manual_tags_map = {
         int(unit_id): [
-            tag for tag in MANUAL_TAG_OPTIONS
+            tag for tag in tag_options
             if tag in prop_keys and bool(si_sorting.get_unit_property(unit_id, tag))
         ]
         for unit_id in si_sorting.unit_ids

--- a/aeon/dj_pipeline/spike_sorting_curation.py
+++ b/aeon/dj_pipeline/spike_sorting_curation.py
@@ -235,7 +235,11 @@ class ApplyOfficialCuration(dj.Imported):
         official_curation_row = (OfficialCuration & key).fetch1()
 
         # Auto-approved curation: no manual curation file, based on raw sorting
-        has_curation_file = bool(ManualCuration.File & key & {"curation_id": curation_id})
+        has_curation_file = bool(
+            ManualCuration.File
+            & key
+            & {"curation_id": curation_id, "file_name": f"curation_data_id{curation_id}.json"}
+        )
         if not has_curation_file:
             parent_curation_id = (ManualCuration & key & {"curation_id": curation_id}).fetch1(
                 "parent_curation_id"
@@ -516,8 +520,20 @@ def launch_spikeinterface_gui(
                 f"Parent curation with curation_id={parent_curation_id} not found for this sorting task."
             )
 
-        # Get the parent curation file path
-        parent_file = Path((ManualCuration.File & parent_curation_key).fetch1("file").full_path)
+        # Get the parent curation file path. Name the file explicitly: ManualCuration.File is a
+        # list of every file for a curation - the curation JSON here, plus the
+        # "curation_applied_analyzer" pointer ApplyOfficialCuration writes under the same
+        # curation_id - so a fetch1 must say which one it wants, or it raises "2 tuples found"
+        # for any parent that has already been applied.
+        parent_file = Path(
+            (
+                ManualCuration.File
+                & parent_curation_key
+                & {"file_name": f"curation_data_id{parent_curation_id}.json"}
+            )
+            .fetch1("file")
+            .full_path
+        )
 
         if not parent_file.exists():
             raise FileNotFoundError(

--- a/aeon/dj_pipeline/spike_sorting_curation.py
+++ b/aeon/dj_pipeline/spike_sorting_curation.py
@@ -278,21 +278,11 @@ class ApplyOfficialCuration(dj.Imported):
         with open(curation_file_path) as f:
             curation_dict = json.load(f)
 
-        # Units manually labeled "noise" should never survive into official data. Fold them
-        # into the same `removed` list apply_curation() already uses for explicit manual
-        # deletions, so they're excluded from the curated analyzer - and therefore from
-        # SortedSpikes and everything downstream (Waveform, SortingQuality, SyncedSpikes,
-        # UnitMatching, GlobalUnit) - the same way as any manually-deleted unit. This does NOT
-        # touch the saved curation_data.json snapshot (the full manual_labels history, incl.
-        # noise, stays intact there and on the raw analyzer) or MUA-labeled units.
-        noise_unit_ids = {
-            lbl["unit_id"]
-            for lbl in curation_dict.get("manual_labels", [])
-            if "noise" in lbl.get("labels", {}).get("quality", [])
-        }
-        if noise_unit_ids:
-            curation_dict["removed"] = sorted(set(curation_dict.get("removed", [])) | noise_unit_ids)
-            logger.info(f"Excluding {len(noise_unit_ids)} unit(s) manually labeled 'noise': {sorted(noise_unit_ids)}")
+        # Units manually labeled "noise" are kept, not deleted: apply_curation() runs on the
+        # curation exactly as saved, so noise units survive into the curated analyzer carrying
+        # their "quality"="noise" property, which insert_sorted_spikes_from_analyzer() writes into
+        # SortedSpikes.Unit.curation_quality. They are held out of unit matching instead (see
+        # _load_block_unit_spike_trains in spike_sorting.py), not deleted here.
 
         # Load original sorting analyzer
         analyzer_output_dir = _get_analyzer_dir_from_key(key)
@@ -821,6 +811,41 @@ def make_curation_official(key: dict, curation_id: int) -> None:
         else:
             logger.info(f"Official curation with curation_id={curation_id} already exists.")
             return
+
+    # Gate: every unit the curator kept must carry a manual quality label, so noise-exclusion and
+    # downstream analysis see a complete picture. Units the curator removed, merged, or split are
+    # considered handled and don't need a standalone label. Checked here (when promoting to official)
+    # so an incomplete curation is refused before any apply work happens.
+    curation_file = Path(
+        (
+            ManualCuration.File
+            & sorted_spikes_key
+            & {"curation_id": curation_id, "file_name": f"curation_data_id{curation_id}.json"}
+        )
+        .fetch1("file")
+        .full_path
+    )
+    with open(curation_file) as f:
+        curation_dict = json.load(f)
+    labeled = {
+        lbl["unit_id"]
+        for lbl in curation_dict.get("manual_labels", [])
+        if lbl.get("labels", {}).get("quality")
+    }
+    handled = set(curation_dict.get("removed", []))
+    for merge_key in ("merges", "merge_unit_groups"):
+        for group in curation_dict.get(merge_key, []) or []:
+            handled.update(group)
+    for split_key in ("splits", "split_units"):
+        handled.update(curation_dict.get(split_key, {}) or {})
+    raw_unit_ids = {int(u) for u in (spike_sorting.SortedSpikes.Unit & sorted_spikes_key).fetch("unit")}
+    unlabeled = raw_unit_ids - labeled - handled
+    if unlabeled:
+        raise ValueError(
+            f"Curation {curation_id} can't be made official: {len(unlabeled)} unit(s) have no quality "
+            f"label: {sorted(unlabeled)}. Label every unit (good/mua/noise) in the GUI before making "
+            f"the curation official."
+        )
 
     # Create OfficialCuration entry
     # sorted_spikes_key already contains SpikeSorting fields (through inheritance)

--- a/aeon/dj_pipeline/spike_sorting_curation.py
+++ b/aeon/dj_pipeline/spike_sorting_curation.py
@@ -17,7 +17,6 @@ schema = dj.Schema(get_schema_name("spike_sorting_curation"))
 logger = dj.logger
 
 
-
 @schema
 class CurationMethod(dj.Lookup):
     definition = """
@@ -54,140 +53,14 @@ class ManualCuration(dj.Manual):
 
 @schema
 class OfficialCuration(dj.Manual):
-    definition = """  # One final/official curation for a SortedSpikes
-    -> spike_sorting.SortedSpikes
+    definition = """  # One final/official curation for a block
+    # Keyed on PostProcessing (not SortedSpikes, which is 1:1 with it and has the same primary key)
+    # so that applying a curation - which deletes and re-populates SortedSpikes - does not
+    # cascade-delete this record or the ApplyOfficialCuration that depends on it.
+    -> spike_sorting.PostProcessing
     ---
     -> ManualCuration
     """
-
-
-def insert_sorted_spikes_from_analyzer(
-    key: dict, sorting_analyzer, curation_id: int, execution_time: datetime
-) -> None:
-    """Insert SortedSpikes (+ Unit rows) from an already-loaded SortingAnalyzer.
-
-    Mirrors spike_sorting.SortedSpikes.make()'s unit-extraction logic, but takes an
-    already-loaded analyzer directly instead of resolving/loading one from disk. Used by
-    ApplyOfficialCuration.make() to recreate SortedSpikes immediately from the curated
-    analyzer already in memory, instead of deferring to a separate SortedSpikes.populate()
-    call. That deferral doesn't work here: OfficialCuration's primary key is inherited from
-    SortedSpikes (-> spike_sorting.SortedSpikes), so it's cascade-deleted along with the old
-    SortedSpikes row and needs SortedSpikes to exist again before it can be restored - within
-    the same transaction, not a later populate() run.
-    """
-    import spikeinterface as si
-
-    spike_sorting.SortedSpikes.insert1(
-        {
-            **key,
-            "execution_time": execution_time,
-            "execution_duration": (datetime.now(UTC) - execution_time).total_seconds() / 3600,
-            "curation_id": curation_id,
-        },
-        allow_direct_insert=True,
-    )
-
-    si_sorting = sorting_analyzer.sorting
-    if si_sorting.unit_ids.size == 0:
-        logger.info("No units found in sorting analyzer. Skipping Unit ingestion...")
-        return
-
-    electrode_query = (
-        ephys.EphysBlockInfo.Channel.proj(..., "-channel_name")
-        * ephys.ElectrodeConfig.Electrode
-        * spike_sorting.ElectrodeGroup.Electrode
-        * ephys.ProbeType.Electrode.proj("electrode_name")
-        & key
-    )
-
-    unit_channel_indices: dict[int, np.ndarray] = si.ChannelSparsity.from_best_channels(
-        sorting_analyzer,
-        1,
-    ).unit_id_to_channel_indices
-    unit_peak_channel: dict[int, int] = {u: chn[0] for u, chn in unit_channel_indices.items()}
-
-    spike_count_dict: dict[int, int] = si_sorting.count_num_spikes_per_unit()
-
-    electrode_map: dict[int, dict] = {elec["electrode"]: elec for elec in electrode_query.to_dicts()}
-    channel2electrode_map = {
-        chn_idx: electrode_map[int(elec_id)]
-        for chn_idx, elec_id in zip(
-            sorting_analyzer.get_probe().device_channel_indices,
-            sorting_analyzer.get_probe().contact_ids,
-            strict=False,
-        )
-    }
-
-    cluster_quality_label_map = {
-        int(unit_id): (
-            si_sorting.get_unit_property(unit_id, "KSLabel")
-            if "KSLabel" in si_sorting.get_property_keys()
-            else "n.a."
-        )
-        for unit_id in si_sorting.unit_ids
-    }
-
-    # Manual curation quality (good/mua/noise) and tags, if this analyzer has been through
-    # manual curation - both are properties on the sorting object (see apply_curation_labels
-    # in spikeinterface), not columns anywhere; absent entirely for a raw/uncurated analyzer.
-    prop_keys = set(si_sorting.get_property_keys())
-    manual_quality_map = {
-        int(unit_id): (si_sorting.get_unit_property(unit_id, "quality") or "").lower() or None
-        for unit_id in si_sorting.unit_ids
-    } if "quality" in prop_keys else {}
-    tag_options = spike_sorting.CurationTag.fetch("tag")
-    manual_tags_map = {
-        int(unit_id): [
-            tag for tag in tag_options
-            if tag in prop_keys and bool(si_sorting.get_unit_property(unit_id, tag))
-        ]
-        for unit_id in si_sorting.unit_ids
-    }
-
-    spike_locations = sorting_analyzer.get_extension("spike_locations")
-    extremum_channel_inds = si.template_tools.get_template_extremum_channel(sorting_analyzer, outputs="index")
-    spikes_df = pd.DataFrame(
-        sorting_analyzer.sorting.to_spike_vector(extremum_channel_inds=extremum_channel_inds)
-    )
-    for unit_idx, raw_unit_id in enumerate(si_sorting.unit_ids):
-        unit_id = int(raw_unit_id)
-        unit_spikes_df = spikes_df[spikes_df.unit_index == unit_idx]
-        spike_sites = np.array(
-            [channel2electrode_map[chn_idx]["electrode"] for chn_idx in unit_spikes_df.channel_index]
-        )
-        unit_spikes_loc = spike_locations.get_data()[unit_spikes_df.index]
-        _, spike_depths = zip(*unit_spikes_loc, strict=True)  # x-coordinates, y-coordinates
-        spike_indices = si_sorting.get_unit_spike_train(unit_id)
-
-        if not (len(spike_indices) == len(spike_sites) == len(spike_depths)):
-            raise ValueError(
-                f"Unit {unit_id}: mismatched spike data lengths "
-                f"(indices={len(spike_indices)}, sites={len(spike_sites)}, depths={len(spike_depths)})"
-            )
-
-        spike_sorting.SortedSpikes.Unit.insert1(
-            {
-                **key,
-                **channel2electrode_map[unit_peak_channel[unit_id]],
-                "unit": unit_id,
-                "unit_quality": cluster_quality_label_map[unit_id],
-                "curation_quality": manual_quality_map.get(unit_id),
-                "spike_indices": spike_indices,
-                "spike_count": spike_count_dict[unit_id],
-                "spike_sites": spike_sites,
-                "spike_depths": spike_depths,
-            },
-            ignore_extra_fields=True,
-            allow_direct_insert=True,
-        )
-
-    tag_rows = [
-        {**key, "unit": unit_id, "tag": tag}
-        for unit_id, tags in manual_tags_map.items()
-        for tag in tags
-    ]
-    if tag_rows:
-        spike_sorting.SortedSpikes.UnitTag.insert(tag_rows, ignore_extra_fields=True, allow_direct_insert=True)
 
 
 @schema
@@ -216,12 +89,8 @@ class ApplyOfficialCuration(dj.Imported):
         execution_time = datetime.now(UTC)
 
         # Get curation_id from OfficialCuration entry (it's in attributes, not primary key)
-        # The key only contains SortedSpikes primary key fields, not attributes
+        # The key only contains the block's primary key fields, not attributes
         curation_id = (OfficialCuration & key).fetch1("curation_id")
-        # OfficialCuration's primary key is inherited from SortedSpikes (-> spike_sorting.SortedSpikes),
-        # so it's a dependent that gets cascade-deleted along with SortedSpikes below - save its full
-        # row now so it can be restored once SortedSpikes exists again.
-        official_curation_row = (OfficialCuration & key).fetch1()
 
         # Auto-approved curation: no manual curation file, based on raw sorting
         has_curation_file = bool(
@@ -280,9 +149,9 @@ class ApplyOfficialCuration(dj.Imported):
 
         # Units manually labeled "noise" are kept, not deleted: apply_curation() runs on the
         # curation exactly as saved, so noise units survive into the curated analyzer carrying
-        # their "quality"="noise" property, which insert_sorted_spikes_from_analyzer() writes into
-        # SortedSpikes.Unit.curation_quality. They are held out of unit matching instead (see
-        # _load_block_unit_spike_trains in spike_sorting.py), not deleted here.
+        # their "quality"="noise" property, which SortedSpikes.make() writes into
+        # SortedSpikes.Unit.unit_quality on repopulation. They are held out of unit matching instead
+        # (see _load_block_unit_spike_trains in spike_sorting.py), not deleted here.
 
         # Load original sorting analyzer
         analyzer_output_dir = _get_analyzer_dir_from_key(key)
@@ -374,21 +243,15 @@ class ApplyOfficialCuration(dj.Imported):
         if current_curation_id == -1:
             logger.info("Deleting old SortedSpikes (curation_id=-1) and downstream tables...")
             (spike_sorting.SortedSpikes & key).delete(prompt=False)
-            logger.info(
-                "Deleted SortedSpikes (downstream tables auto-deleted by DataJoint, including "
-                "OfficialCuration - its primary key is inherited from SortedSpikes)"
-            )
+            # Cascade reaches only SortedSpikes' downstream (Waveform, SortingQuality, SyncedSpikes,
+            # UnitMatching). OfficialCuration and this ApplyOfficialCuration are keyed on
+            # PostProcessing, not SortedSpikes, so they survive - which is what lets us record the
+            # apply below and then rebuild SortedSpikes separately via SortedSpikes.populate().
+            logger.info("Deleted SortedSpikes and its downstream tables (curation records preserved).")
 
-        # Recreate SortedSpikes (+ Unit rows) directly from the curated analyzer already in memory,
-        # then restore OfficialCuration now that SortedSpikes exists again - both were swept away
-        # by the delete above. Doing this here (rather than a separate later SortedSpikes.populate()
-        # call) keeps it all in the same transaction as the ApplyOfficialCuration insert below, which
-        # needs OfficialCuration to exist as its FK parent.
-        sorted_spikes_execution_time = datetime.now(UTC)
-        insert_sorted_spikes_from_analyzer(key, curated_analyzer, curation_id, sorted_spikes_execution_time)
-        OfficialCuration.insert1(official_curation_row)
-
-        # Insert ApplyOfficialCuration entry
+        # Insert ApplyOfficialCuration entry. SortedSpikes is intentionally left deleted here; the
+        # curated analyzer is on disk and SortedSpikes.make() rebuilds from it (reading the manual
+        # quality labels into unit_quality) on the next SortedSpikes.populate().
         self.insert1(
             {
                 **key,
@@ -407,8 +270,8 @@ class ApplyOfficialCuration(dj.Imported):
         )
 
         logger.info(
-            "SortedSpikes has been repopulated from the curated analyzer. Run .populate() on "
-            "downstream tables (SyncedSpikes, etc.) to continue the pipeline."
+            "Run SortedSpikes.populate() to rebuild it from the curated analyzer, then .populate() "
+            "the downstream tables (SyncedSpikes, etc.) to continue the pipeline."
         )
 
 

--- a/docs/ephys_runbooks/step04_post_sorting_and_curation.py
+++ b/docs/ephys_runbooks/step04_post_sorting_and_curation.py
@@ -223,9 +223,11 @@ If you want to review units interactively instead of auto-approving:
        from aeon.dj_pipeline import spike_sorting_curation as curation
        curation.ApplyOfficialCuration.populate(display_progress=True)
 
-   NOTE: Applying manual curation DELETES existing SortedSpikes and all
-   downstream entries (Waveform, SortingQuality, SyncedSpikes), then
-   re-populates them with curated data. You must re-run:
+   NOTE: Applying manual curation DELETES the existing SortedSpikes and all
+   downstream entries (Waveform, SortingQuality, SyncedSpikes). It does NOT
+   rebuild them itself - you must re-run the populates below, which reload
+   from the curated analyzer (SortedSpikes.make reads the manual quality
+   labels + tags off it into unit_quality/UnitTag):
 
        spike_sorting.SortedSpikes.populate(display_progress=True)
        spike_sorting.Waveform.populate(display_progress=True)

--- a/docs/specs/2026-08-27-curation-design-options.md
+++ b/docs/specs/2026-08-27-curation-design-options.md
@@ -1,0 +1,127 @@
+# Spike-Sorting Curation: Two Design Decisions for the Team
+
+**Prepared:** 2026-08-26 (for the 2026-08-27 meeting)
+**Context:** Elissa's planned PR **into Zofia's `zs/spike_sorting` branch** (PR #604), landing before
+#604 merges to `main`. Both issues below were found while reviewing #604 with Zofia.
+**Why bring it to the team:** both decisions are core/shared design (Thinh) and touch Zofia's
+in-progress curation work, so they're worth deciding together rather than patching unilaterally.
+
+> **How to read this**
+> - **[Verified]** — checked against the current branch code, GitHub `main`, and the original spec.
+> - **[Proposal]** — Claude's analysis of options and trade-offs, for discussion. Not decisions.
+> - **[Decided — Elissa]** — calls Elissa has already made.
+
+---
+
+## Background — two problems in the curation pipeline
+
+### Problem A — the manual quality label is never stored [Verified]
+
+- `SortedSpikes.Unit.unit_quality` is meant to carry each unit's quality label.
+- In every code path that builds those rows — `SortedSpikes.make()`, and on the branch also
+  `insert_sorted_spikes_from_analyzer()` — `unit_quality` is read from Kilosort's `KSLabel`
+  property, never from the curator's manual `quality` property. So it always reflects Kilosort's
+  automatic call, never the human's curation, even after a curation has been applied.
+- The original spec (`docs/specs/SPEC_SPIKE_SORTING_CURATION.md`, unchanged since 2026-04-20)
+  describes a **single** quality field that holds Kilosort's label before curation and is
+  **replaced** by the curator's label once a curation is applied. There is no second field in it.
+- This is a **pre-existing bug in `main`**, not something Zofia introduced.
+- Mechanism (verified): SpikeInterface stores the curator's call in a separate `quality` property
+  and leaves `KSLabel` untouched, so any code reading `KSLabel` never picks up the curation. Per
+  Elissa, the original code read `KSLabel` on the assumption that applying a curation overwrites it
+  in place — the separate `quality` property wasn't understood at the time.
+- On the branch, Zofia added a **second** column, `curation_quality`, to hold the manual label
+  separately, plus a `UnitTag` part table for non-exclusive tags. The spec was never updated to
+  describe either.
+
+### Problem B — applying a curation deletes its own parent (circular cascade) [Verified]
+
+- Dependency chain: `PostProcessing → SortedSpikes → OfficialCuration → ApplyOfficialCuration`
+  (each table borrows its primary key from the one above).
+- `ApplyOfficialCuration.make()` deletes the `SortedSpikes` row in order to swap raw units for
+  curated ones. That delete cascades **down the chain**: it removes the `OfficialCuration` child,
+  which in turn removes the `ApplyOfficialCuration` grandchild.
+- The next line then tries to insert the `ApplyOfficialCuration` record — but the `OfficialCuration`
+  parent it must attach to was just cascade-deleted. Foreign-key violation. The step cannot complete.
+- This is **fatal and pre-existing in `main`**. It was never caught because the apply step was a
+  draft that was never actually run until Zofia tested it.
+- The spec's "Circular Dependency Handling" section addresses only the Python **import** cycle
+  (the lazy import), not this table cascade.
+- **Zofia's workaround:** inside `make()`, stash the `OfficialCuration` row in memory before the
+  delete, rebuild `SortedSpikes` from the in-memory analyzer, then re-insert `OfficialCuration` and
+  `ApplyOfficialCuration` in the same transaction. It works, but a computed table is reaching
+  upstream to delete and rebuild its own ancestor.
+
+---
+
+## Decision 1 — how to represent quality labels [Proposal]
+
+Fixing Problem A forces a choice: when `unit_quality` reflects the manual curation, do we keep
+Kilosort's label too?
+
+### Option 1A — single field (the original spec)
+One `unit_quality` field: holds the curator's manual label once curated, with Kilosort's label
+standing in until then.
+- **Pros:** matches the spec; one source of truth; simplest; removes Zofia's extra column, moving
+  the branch back toward `main`.
+- **Cons:** Kilosort's label is gone once a unit is curated (no side-by-side comparison); a bare
+  label doesn't say whether it's a human or a machine call unless we mark it.
+- **Sub-choice:** mark Kilosort-sourced values with a `ks_` prefix (`ks_good` / `ks_mua` /
+  `ks_noise`) so provenance stays visible, or leave them bare.
+
+### Option 1B — two fields (the branch's current state)
+`unit_quality` = Kilosort's label always; `curation_quality` = the manual label (null until curated).
+- **Pros:** both labels visible at once; no ambiguity; nothing lost.
+- **Cons:** diverges from the spec; two fields to keep straight everywhere downstream; "fixes" the
+  bug by adding a field rather than correcting the one that was wrong.
+
+> Related, **[Decided — Elissa]**: noise-labelled units are **kept and labelled**, not deleted, and
+> are **excluded from unit matching**. That holds under either option above; only which field the
+> matching filter reads would change.
+
+---
+
+## Decision 2 — in-place modification vs. duplication [Proposal]
+
+Fixing Problem B forces a choice about how curated results are stored. Note (Elissa's framing): every
+option short of 2B still feels like a patch, because the underlying issue is that one mutable table
+holds both the raw and the curated result and swaps between them in place.
+
+### Option 2A — keep in-place modification, patch the cascade
+One `SortedSpikes` table, swapped between raw and curated; fix only the circularity.
+- **Variant i — reparent:** move `OfficialCuration`'s parent from `SortedSpikes` up to
+  `PostProcessing` (same primary key, since they're 1:1). Deleting `SortedSpikes` no longer destroys
+  the curation records, and Zofia's in-memory recreate can be removed.
+- **Variant ii — keep Zofia's in-memory recreate** as the workaround.
+- **Pros:** minimal; downstream tables untouched; unblocks Zofia now.
+- **Cons:** treats the symptom, not the cause — a computed table still deletes and rebuilds an
+  upstream table in place. The reparent also loosens the enforced link between "which curation is
+  official" and "what's actually in `SortedSpikes` right now" (left to the `curation_id` convention).
+  Still a schema change on the live DB.
+
+### Option 2B — duplication (DataJoint Elements pattern)
+Raw `SortedSpikes` becomes immutable. The curated result lives in its own downstream table computed
+from `OfficialCuration`; downstream reads the curated table, falling back to raw when there's no
+curation. Nothing is ever deleted and rebuilt.
+- **Pros:** removes both the circularity and the in-place mutation entirely; matches the established
+  DataJoint Elements curation pattern (`Clustering → Curation → CuratedClustering`); clean lineage.
+- **Cons:** larger restructure; repoints downstream tables (`SyncedSpikes`, `UnitMatching`, …); a
+  second units table with some duplicated extraction logic; migration on the live DB.
+
+---
+
+## Suggested framing for the discussion [Proposal]
+
+- Both problems are pre-existing in `main`, so fixing them here also improves what eventually lands
+  in `main`.
+- The two decisions interact: the cleaner Decision-2 design (2B) is also the natural moment to settle
+  Decision 1, since the curated units table would be built fresh either way.
+- **Sensitivity:** Zofia is already running the branch on real curated data. A restructure (2B) or
+  the schema changes (1A / 2A) may require her to re-apply or re-curate existing blocks — worth
+  checking what she's willing to redo before choosing.
+
+## Open questions for the team
+1. **Decision 1:** single field (1A — with or without the `ks_` prefix) or two fields (1B)?
+2. **Decision 2:** patch in place now (2A-i, reparent) or restructure to duplication (2B)?
+3. If 2B: do it now, or patch with 2A to unblock and schedule 2B as the planned "full redesign"?
+4. How much of her existing curated data is Zofia willing to re-apply / re-curate afterward?

--- a/docs/specs/2026-08-27-curation-design-options.md
+++ b/docs/specs/2026-08-27-curation-design-options.md
@@ -1,127 +1,180 @@
-# Spike-Sorting Curation: Two Design Decisions for the Team
+# Spike-Sorting Curation — Meeting Reference (2026-08-27)
 
-**Prepared:** 2026-08-26 (for the 2026-08-27 meeting)
-**Context:** Elissa's planned PR **into Zofia's `zs/spike_sorting` branch** (PR #604), landing before
-#604 merges to `main`. Both issues below were found while reviewing #604 with Zofia.
-**Why bring it to the team:** both decisions are core/shared design (Thinh) and touch Zofia's
-in-progress curation work, so they're worth deciding together rather than patching unilaterally.
+**Purpose:** Talking-points reference for the 2026-08-27 meeting on the spike-sorting curation
+pipeline — Zofia's PR **#604** (`zs/spike_sorting`) and the follow-up PR **#608**
+(`es/curation-fixes` → `zs/spike_sorting`). Covers what already landed, the two design decisions
+that need the team, and the smaller related questions worth raising.
 
 > **How to read this**
 > - **[Verified]** — checked against the current branch code, GitHub `main`, and the original spec.
-> - **[Proposal]** — Claude's analysis of options and trade-offs, for discussion. Not decisions.
-> - **[Decided — Elissa]** — calls Elissa has already made.
+> - **[Proposal]** — Claude's analysis / options for discussion. Not decisions.
+> - **[Decided — Elissa]** — a call Elissa has already made (to confirm with the team).
+>
+> Items under "Other talking points" are candidates to raise, not settled outcomes.
 
 ---
 
-## Background — two problems in the curation pipeline
+## Quick agenda
 
-### Problem A — the manual quality label is never stored [Verified]
-
-- `SortedSpikes.Unit.unit_quality` is meant to carry each unit's quality label.
-- In every code path that builds those rows — `SortedSpikes.make()`, and on the branch also
-  `insert_sorted_spikes_from_analyzer()` — `unit_quality` is read from Kilosort's `KSLabel`
-  property, never from the curator's manual `quality` property. So it always reflects Kilosort's
-  automatic call, never the human's curation, even after a curation has been applied.
-- The original spec (`docs/specs/SPEC_SPIKE_SORTING_CURATION.md`, unchanged since 2026-04-20)
-  describes a **single** quality field that holds Kilosort's label before curation and is
-  **replaced** by the curator's label once a curation is applied. There is no second field in it.
-- This is a **pre-existing bug in `main`**, not something Zofia introduced.
-- Mechanism (verified): SpikeInterface stores the curator's call in a separate `quality` property
-  and leaves `KSLabel` untouched, so any code reading `KSLabel` never picks up the curation. Per
-  Elissa, the original code read `KSLabel` on the assumption that applying a curation overwrites it
-  in place — the separate `quality` property wasn't understood at the time.
-- On the branch, Zofia added a **second** column, `curation_quality`, to hold the manual label
-  separately, plus a `UnitTag` part table for non-exclusive tags. The spec was never updated to
-  describe either.
-
-### Problem B — applying a curation deletes its own parent (circular cascade) [Verified]
-
-- Dependency chain: `PostProcessing → SortedSpikes → OfficialCuration → ApplyOfficialCuration`
-  (each table borrows its primary key from the one above).
-- `ApplyOfficialCuration.make()` deletes the `SortedSpikes` row in order to swap raw units for
-  curated ones. That delete cascades **down the chain**: it removes the `OfficialCuration` child,
-  which in turn removes the `ApplyOfficialCuration` grandchild.
-- The next line then tries to insert the `ApplyOfficialCuration` record — but the `OfficialCuration`
-  parent it must attach to was just cascade-deleted. Foreign-key violation. The step cannot complete.
-- This is **fatal and pre-existing in `main`**. It was never caught because the apply step was a
-  draft that was never actually run until Zofia tested it.
-- The spec's "Circular Dependency Handling" section addresses only the Python **import** cycle
-  (the lazy import), not this table cascade.
-- **Zofia's workaround:** inside `make()`, stash the `OfficialCuration` row in memory before the
-  delete, rebuild `SortedSpikes` from the in-memory analyzer, then re-insert `OfficialCuration` and
-  `ApplyOfficialCuration` in the same transaction. It works, but a computed table is reaching
-  upstream to delete and rebuild its own ancestor.
+1. Status — what already landed in PR #608 (partial set)
+2. **Decision 1** — how to represent quality labels
+3. **Decision 2** — in-place modification vs. duplication (the cascade)
+4. Noise units — keep + label + exclude from matching (confirm)
+5. The `unit_quality` bug — fallback + `ks_` prefix + keep-both
+6. Data duplication (Chris's concern) — what's actually duplicated
+7. Backfilling already-curated blocks after the label fix
+8. The applied-analyzer in `ManualCuration.File` + restore cleanup
+9. Label-completeness gate — add one?
+10. Testing gap — no unit-matching coverage
+11. Schema migration + sensitivity to re-curation
+12. Ownership / who decides what
+13. DataJoint version bump riding along
 
 ---
 
-## Decision 1 — how to represent quality labels [Proposal]
+## 1. Status — what already landed in PR #608 (partial set) [Verified]
 
-Fixing Problem A forces a choice: when `unit_quality` reflects the manual curation, do we keep
-Kilosort's label too?
+PR #608 collects the safe, agreed fixes so they don't block on the bigger design questions. All go
+into `zs/spike_sorting` before it reaches `main`:
 
-### Option 1A — single field (the original spec)
-One `unit_quality` field: holds the curator's manual label once curated, with Kilosort's label
-standing in until then.
-- **Pros:** matches the spec; one source of truth; simplest; removes Zofia's extra column, moving
-  the branch back toward `main`.
-- **Cons:** Kilosort's label is gone once a unit is curated (no side-by-side comparison); a bare
-  label doesn't say whether it's a human or a machine call unless we mark it.
-- **Sub-choice:** mark Kilosort-sourced values with a `ks_` prefix (`ks_good` / `ks_mua` /
-  `ks_noise`) so provenance stays visible, or leave them bare.
+- Removed the obsolete uncaught-exception workarounds (DataJoint 2.3.2 fixes it upstream; the branch
+  already pins `datajoint>=2.3.2`).
+- Fixed "2 tuples found" — name the file in the remaining `ManualCuration.File` reads.
+- Made `save_manual_curation`'s two inserts atomic (it's a helper, not a table `make()`).
+- Replaced `UnitMatching.CandidateMatch` with `UnitMatching.BlockComparison` — the full
+  agreement-score grid per compared block, no threshold.
+- Parameterized the curation tags into a `CurationTag` lookup table.
 
-### Option 1B — two fields (the branch's current state)
-`unit_quality` = Kilosort's label always; `curation_quality` = the manual label (null until curated).
-- **Pros:** both labels visible at once; no ambiguity; nothing lost.
-- **Cons:** diverges from the spec; two fields to keep straight everywhere downstream; "fixes" the
-  bug by adding a field rather than correcting the one that was wrong.
-
-> Related, **[Decided — Elissa]**: noise-labelled units are **kept and labelled**, not deleted, and
-> are **excluded from unit matching**. That holds under either option above; only which field the
-> matching filter reads would change.
+Deferred to this meeting: the quality-label change (Decision 1) and the cascade restructure
+(Decision 2).
 
 ---
 
-## Decision 2 — in-place modification vs. duplication [Proposal]
+## 2. Decision 1 — how to represent quality labels
 
-Fixing Problem B forces a choice about how curated results are stored. Note (Elissa's framing): every
-option short of 2B still feels like a patch, because the underlying issue is that one mutable table
-holds both the raw and the curated result and swaps between them in place.
+### The bug it fixes [Verified]
+`SortedSpikes.Unit.unit_quality` is read from Kilosort's `KSLabel` in every code path that builds
+the rows, never from the curator's manual `quality` property — so it always reflects Kilosort, never
+the human's curation, even after a curation is applied. Pre-existing in `main`. The original spec
+(`SPEC_SPIKE_SORTING_CURATION.md`, unchanged since 2026-04-20) intended a **single** quality field:
+Kilosort's label before curation, replaced by the curator's label after. On the branch, Zofia added a
+**second** column, `curation_quality`, to hold the manual label separately (plus a `UnitTag` part
+table for tags); the spec was never updated to describe either.
 
-### Option 2A — keep in-place modification, patch the cascade
-One `SortedSpikes` table, swapped between raw and curated; fix only the circularity.
+### Option 1A — single field (the original spec) [Proposal]
+One `unit_quality`: the curator's manual label once curated, Kilosort's standing in until then.
+- **Pros:** matches the spec; one source of truth; simplest; drops Zofia's extra column (toward `main`).
+- **Cons:** Kilosort's label is lost once curated (no side-by-side); a bare label is ambiguous about
+  human vs. machine unless marked.
+- **Sub-choice:** mark Kilosort-sourced values `ks_good`/`ks_mua`/`ks_noise`, or leave bare.
+
+### Option 1B — two fields (the branch's current state) [Proposal]
+`unit_quality` = Kilosort always; `curation_quality` = manual (null until curated).
+- **Pros:** both labels visible; no ambiguity; nothing lost.
+- **Cons:** diverges from the spec; two fields downstream; "fixes" the bug by adding a field rather
+  than correcting the wrong one.
+
+---
+
+## 3. Decision 2 — in-place modification vs. duplication (the cascade)
+
+### The bug it fixes [Verified]
+Dependency chain: `PostProcessing → SortedSpikes → OfficialCuration → ApplyOfficialCuration` (each
+inherits its primary key from the one above). `ApplyOfficialCuration.make()` deletes the
+`SortedSpikes` row to swap raw units for curated ones — but that delete cascades down and removes the
+`OfficialCuration` child and the `ApplyOfficialCuration` grandchild, so the next line, which inserts
+the `ApplyOfficialCuration` record, has no parent to attach to. Foreign-key violation; the step can't
+complete. **Fatal and pre-existing in `main`** — never caught because the apply step was a draft never
+run until Zofia tested it. (The spec's "Circular Dependency Handling" section only covers the Python
+import cycle, not this table cascade.) Zofia's workaround stashes the `OfficialCuration` row before the
+delete, rebuilds `SortedSpikes` from the in-memory analyzer, and re-inserts both in one transaction —
+it works, but a computed table is reaching up to delete and rebuild its own ancestor.
+
+### Option 2A — patch in place [Proposal]
+Keep one `SortedSpikes` table swapped between raw and curated; fix only the circularity.
 - **Variant i — reparent:** move `OfficialCuration`'s parent from `SortedSpikes` up to
   `PostProcessing` (same primary key, since they're 1:1). Deleting `SortedSpikes` no longer destroys
   the curation records, and Zofia's in-memory recreate can be removed.
 - **Variant ii — keep Zofia's in-memory recreate** as the workaround.
-- **Pros:** minimal; downstream tables untouched; unblocks Zofia now.
-- **Cons:** treats the symptom, not the cause — a computed table still deletes and rebuilds an
-  upstream table in place. The reparent also loosens the enforced link between "which curation is
-  official" and "what's actually in `SortedSpikes` right now" (left to the `curation_id` convention).
-  Still a schema change on the live DB.
+- **Pros:** minimal; downstream untouched; unblocks now.
+- **Cons:** treats the symptom, not the cause — a computed table still deletes/rebuilds an upstream
+  table in place; the reparent also loosens the enforced link between "which curation is official" and
+  "what's in `SortedSpikes` now" (left to the `curation_id` convention); still a schema change.
 
-### Option 2B — duplication (DataJoint Elements pattern)
-Raw `SortedSpikes` becomes immutable. The curated result lives in its own downstream table computed
+### Option 2B — duplication (DataJoint Elements pattern) [Proposal]
+Raw `SortedSpikes` becomes immutable; the curated result lives in its own downstream table computed
 from `OfficialCuration`; downstream reads the curated table, falling back to raw when there's no
 curation. Nothing is ever deleted and rebuilt.
-- **Pros:** removes both the circularity and the in-place mutation entirely; matches the established
-  DataJoint Elements curation pattern (`Clustering → Curation → CuratedClustering`); clean lineage.
+- **Pros:** removes both the circularity and the in-place mutation; matches the established DataJoint
+  Elements curation pattern (`Clustering → Curation → CuratedClustering`); clean lineage.
 - **Cons:** larger restructure; repoints downstream tables (`SyncedSpikes`, `UnitMatching`, …); a
-  second units table with some duplicated extraction logic; migration on the live DB.
+  second units table with some duplicated extraction logic; migration.
+
+> Note (Elissa's framing): every option short of 2B still feels like a patch, because the root issue
+> is one mutable table holding both the raw and curated result and swapping in place.
 
 ---
 
-## Suggested framing for the discussion [Proposal]
+## Other talking points
 
-- Both problems are pre-existing in `main`, so fixing them here also improves what eventually lands
-  in `main`.
-- The two decisions interact: the cleaner Decision-2 design (2B) is also the natural moment to settle
-  Decision 1, since the curated units table would be built fresh either way.
-- **Sensitivity:** Zofia is already running the branch on real curated data. A restructure (2B) or
-  the schema changes (1A / 2A) may require her to re-apply or re-curate existing blocks — worth
-  checking what she's willing to redo before choosing.
+### 4. Noise units — keep, label, exclude from matching [Decided — Elissa; confirm with team]
+Zofia's branch currently **deletes** noise-labelled units at apply time. The decision is to **keep
+them, label them "noise," and exclude them from unit matching** instead of deleting. Confirm Zofia and
+Thinh agree. Interacts with Decision 1 (which field the matching filter reads). [Verified] `main` does
+neither — it never deletes noise and never excludes it from matching; both behaviours are new on the
+branch.
 
-## Open questions for the team
-1. **Decision 1:** single field (1A — with or without the `ks_` prefix) or two fields (1B)?
-2. **Decision 2:** patch in place now (2A-i, reparent) or restructure to duplication (2B)?
-3. If 2B: do it now, or patch with 2A to unblock and schedule 2B as the planned "full redesign"?
-4. How much of her existing curated data is Zofia willing to re-apply / re-curate afterward?
+### 5. The `unit_quality` fix — fallback, prefix, keep-both [Proposal]
+If Decision 1 goes single-field, open sub-questions: the per-unit fallback for a unit left unlabelled
+in a curated block (use Kilosort's label as a stand-in?); whether to mark Kilosort-sourced values with
+a `ks_` prefix so provenance is visible; and the standing argument for keeping both the Kilosort and
+manual labels (which is really Decision 1 itself).
+
+### 6. Data duplication — what's actually duplicated [Verified] (Chris's concern)
+Worth pinning down which of these Chris meant:
+- The curated analyzer is a **full second copy on disk** per applied curation; restore deletes neither
+  the folder nor its `File` row.
+- Spike payloads are stored **twice** — `SyncedSpikes.Unit.spike_times`, then again in
+  `UnitMatching.Spikes.spike_times` keyed by `global_unit`.
+- Apply/restore cycles **leak old external blobs** (DataJoint's row delete doesn't remove
+  external-store files).
+- `ManualCuration.File` mixes two different kinds of thing (the curation JSON and the apply-step's
+  analyzer pointer) — the root of the "2 tuples" bug. Connects to Decision 2.
+
+### 7. Backfilling already-curated blocks [Proposal]
+The `unit_quality` fix is forward-looking: blocks Zofia has already curated keep the buggy Kilosort
+label until re-applied. Manual labels are safe on disk in the curated analyzers, so nothing is lost,
+but correcting existing blocks means re-applying each curation (disruptive) or a one-off migration
+script. Decide whether and how to backfill.
+
+### 8. Applied-analyzer in `ManualCuration.File` + restore cleanup [Verified; Decided — Elissa on cleanup]
+The apply step stores the curated-analyzer path in `ManualCuration.File` — an apply-step output living
+in a manual-curation file table, which is what makes the "2 tuples" collision possible. Whether it
+should move to its own table is part of Decision 2. Separately, [Decided — Elissa] leave
+`restore_raw_sorting` as-is: with the file-name fix, the leftover applied-analyzer rows are harmless
+and are useful provenance; the only cost is on-disk folders accumulating.
+
+### 9. Label-completeness gate [Verified: none exists; Proposal]
+There is **no** gate requiring an official curation to have every unit labelled. Decide whether to add
+one, or rely on the Kilosort per-unit fallback for units the curator didn't touch.
+
+### 10. Testing gap [Verified]
+There is **no automated coverage** for unit matching — the golden dataset is a single block, and
+matching needs several overlapping curated blocks. Zofia is asked (in PR #608) to test the matching
+changes on real data. [Proposal] consider building multi-block test fixtures so this path isn't
+verified only by hand.
+
+### 11. Schema migration + sensitivity [Verified / Elissa]
+PR #608 already recreates tables on the live DB (adds `CurationTag` and `BlockComparison`, makes
+`UnitTag.tag` a foreign key, removes `CandidateMatch`). Decision 2 (restructure) would be a bigger
+migration. [Elissa] Zofia is running on real curated data and won't want to re-curate, so major
+changes should be weighed against how much of her existing work they'd force her to redo.
+
+### 12. Ownership / who decides [Proposal]
+- Cascade + core table structure (Decision 2) — **Thinh** (shared/core design).
+- Curation workflow, tags, QC — **Zofia** (her PR).
+- The removed `__init__.py` exception-handler workaround was **Adrian's** (via `ar/core`), not Zofia's.
+
+### 13. DataJoint version bump [Verified]
+The branch bumps DataJoint from `main`'s `>=2.2.2` to `>=2.3.2` (needed for the upstream traceback
+fix). Flag that this rides along with the branch into `main`.

--- a/docs/specs/2026-08-27-curation-design-options.md
+++ b/docs/specs/2026-08-27-curation-design-options.md
@@ -2,15 +2,11 @@
 
 **Purpose:** Talking-points reference for the 2026-08-27 meeting on the spike-sorting curation
 pipeline — Zofia's PR **#604** (`zs/spike_sorting`) and the follow-up PR **#608**
-(`es/curation-fixes` → `zs/spike_sorting`). Covers what already landed, the two design decisions
-that need the team, and the smaller related questions worth raising.
+(`es/curation-fixes` → `zs/spike_sorting`).
 
-> **How to read this**
-> - **[Verified]** — checked against the current branch code, GitHub `main`, and the original spec.
-> - **[Proposal]** — Claude's analysis / options for discussion. Not decisions.
-> - **[Decided — Elissa]** — a call Elissa has already made (to confirm with the team).
->
-> Items under "Other talking points" are candidates to raise, not settled outcomes.
+> **Labels:** **[Verified]** — checked against the code, GitHub `main`, and the spec.
+> **[Proposal]** — options for discussion, not decisions. **[Decided — Elissa]** — already decided,
+> to confirm with the team.
 
 ---
 
@@ -27,171 +23,102 @@ that need the team, and the smaller related questions worth raising.
    a separate curated table (clean — bigger).
 4. **Noise units** — Keep + label "noise" + exclude from matching (not delete). **Confirm** with
    Zofia/Thinh.
-5. **`unit_quality` fix details** — If single field: use Kilosort as the per-unit fallback for
-   unlabelled units? Mark machine labels with a `ks_` prefix? (Both are sub-choices of Decision 1.)
-6. **Duplication (Chris)** — Real duplication points: a full curated-analyzer copy per curation;
-   spikes stored twice (SyncedSpikes + UnitMatching.Spikes); leaked blobs on restore; the File table
-   mixing the curation JSON with the apply output. **Ask Chris** which he meant.
-7. **Backfill** — The label fix is forward-only; blocks Zofia already curated keep the wrong label
-   until re-applied. **Decide:** re-apply, migration script, or leave.
-8. **Applied-analyzer in `ManualCuration.File`** — Root of the "2 tuples" bug; move it to its own
-   table (part of Decision 2)? Restore-cleanup already decided: leave as-is.
-9. **Label-completeness gate** — None exists today. **Decide:** add one, or rely on the fallback.
-10. **Testing** — Zero automated matching coverage (golden dataset is one block). Zofia tests by hand;
-    **build multi-block fixtures?**
-11. **Migration + sensitivity** — #608 already recreates tables; a restructure is bigger. **How much
-    re-curation of Zofia's existing data is acceptable?**
-12. **Ownership** — Cascade/core = Thinh; curation/tags/QC = Zofia; the exception-handler we removed
-    was Adrian's, not Zofia's.
-13. **DJ bump** — Branch bumps DataJoint `2.2.2 → 2.3.2`; it rides along into main.
+5. **`unit_quality` sub-choices** (if single field) — Use Kilosort as the per-unit fallback for
+   unlabelled units? Mark machine labels with a `ks_` prefix?
+6. **Label-completeness gate** — None exists today. **Decide:** add one, or rely on the fallback.
+7. **Applying the changes = just repopulating** — No re-sorting and no re-curation: every sorting
+   analyzer and curation file is saved, so it's only re-populating the tables, not real work for
+   Zofia. **Be clear about that**, and settle with Zofia how she wants to handle re-applying.
 
-*(Full detail on each item is below if you need to drill in.)*
+*(Full detail on each is below if you need to drill in.)*
 
 ---
 
 ## 1. Status — what already landed in PR #608 (partial set) [Verified]
 
-PR #608 collects the safe, agreed fixes so they don't block on the bigger design questions. All go
-into `zs/spike_sorting` before it reaches `main`:
+The safe, agreed fixes, so they don't block on the big design questions. All into `zs/spike_sorting`
+before it reaches `main`:
 
-- Removed the obsolete uncaught-exception workarounds (DataJoint 2.3.2 fixes it upstream; the branch
-  already pins `datajoint>=2.3.2`).
+- Removed the obsolete uncaught-exception workarounds (DataJoint 2.3.2 fixes it upstream).
 - Fixed "2 tuples found" — name the file in the remaining `ManualCuration.File` reads.
-- Made `save_manual_curation`'s two inserts atomic (it's a helper, not a table `make()`).
-- Replaced `UnitMatching.CandidateMatch` with `UnitMatching.BlockComparison` — the full
-  agreement-score grid per compared block, no threshold.
+- Made `save_manual_curation`'s two inserts atomic.
+- Replaced `UnitMatching.CandidateMatch` with `UnitMatching.BlockComparison` (the full
+  agreement-score grid per compared block, no threshold).
 - Parameterized the curation tags into a `CurationTag` lookup table.
-
-Deferred to this meeting: the quality-label change (Decision 1) and the cascade restructure
-(Decision 2).
 
 ---
 
 ## 2. Decision 1 — how to represent quality labels
 
-### The bug it fixes [Verified]
-`SortedSpikes.Unit.unit_quality` is read from Kilosort's `KSLabel` in every code path that builds
-the rows, never from the curator's manual `quality` property — so it always reflects Kilosort, never
+**The bug [Verified].** `SortedSpikes.Unit.unit_quality` is read from Kilosort's `KSLabel` in every
+build path, never from the curator's manual `quality` property — so it always reflects Kilosort, never
 the human's curation, even after a curation is applied. Pre-existing in `main`. The original spec
-(`SPEC_SPIKE_SORTING_CURATION.md`, unchanged since 2026-04-20) intended a **single** quality field:
-Kilosort's label before curation, replaced by the curator's label after. On the branch, Zofia added a
-**second** column, `curation_quality`, to hold the manual label separately (plus a `UnitTag` part
-table for tags); the spec was never updated to describe either.
+intended a **single** quality field: Kilosort's label before curation, replaced by the curator's after.
+Zofia's branch instead added a **second** column, `curation_quality`, for the manual label.
 
-### Option 1A — single field (the original spec) [Proposal]
-One `unit_quality`: the curator's manual label once curated, Kilosort's standing in until then.
-- **Pros:** matches the spec; one source of truth; simplest; drops Zofia's extra column (toward `main`).
-- **Cons:** Kilosort's label is lost once curated (no side-by-side); a bare label is ambiguous about
-  human vs. machine unless marked.
-- **Sub-choice:** mark Kilosort-sourced values `ks_good`/`ks_mua`/`ks_noise`, or leave bare.
+**Option 1A — single field (the spec).** One `unit_quality`: the manual label once curated, Kilosort
+standing in until then.
+- Pros: matches the spec; one source of truth; simplest.
+- Cons: Kilosort's label is lost once curated; a bare label is ambiguous (human vs. machine) unless
+  marked with a `ks_` prefix.
 
-### Option 1B — two fields (the branch's current state) [Proposal]
-`unit_quality` = Kilosort always; `curation_quality` = manual (null until curated).
-- **Pros:** both labels visible; no ambiguity; nothing lost.
-- **Cons:** diverges from the spec; two fields downstream; "fixes" the bug by adding a field rather
-  than correcting the wrong one.
+**Option 1B — two fields (current branch).** `unit_quality` = Kilosort always; `curation_quality` =
+manual (null until curated).
+- Pros: both labels visible; nothing lost.
+- Cons: diverges from the spec; two fields downstream; fixes the bug by adding a field, not correcting
+  the wrong one.
 
 ---
 
 ## 3. Decision 2 — in-place modification vs. duplication (the cascade)
 
-### The bug it fixes [Verified]
-Dependency chain: `PostProcessing → SortedSpikes → OfficialCuration → ApplyOfficialCuration` (each
-inherits its primary key from the one above). `ApplyOfficialCuration.make()` deletes the
-`SortedSpikes` row to swap raw units for curated ones — but that delete cascades down and removes the
-`OfficialCuration` child and the `ApplyOfficialCuration` grandchild, so the next line, which inserts
-the `ApplyOfficialCuration` record, has no parent to attach to. Foreign-key violation; the step can't
-complete. **Fatal and pre-existing in `main`** — never caught because the apply step was a draft never
-run until Zofia tested it. (The spec's "Circular Dependency Handling" section only covers the Python
-import cycle, not this table cascade.) Zofia's workaround stashes the `OfficialCuration` row before the
-delete, rebuilds `SortedSpikes` from the in-memory analyzer, and re-inserts both in one transaction —
-it works, but a computed table is reaching up to delete and rebuild its own ancestor.
+**The bug [Verified].** Chain: `PostProcessing → SortedSpikes → OfficialCuration →
+ApplyOfficialCuration` (each inherits the one above's primary key). `ApplyOfficialCuration.make()`
+deletes `SortedSpikes` to swap raw units for curated ones — but that cascades down and deletes its own
+`OfficialCuration`/`ApplyOfficialCuration`, so the insert that follows has no parent. Fatal, and
+pre-existing in `main`; never caught because the apply step was a draft never run until Zofia tested it.
+Her workaround stashes the row and rebuilds in one transaction — it works, but a computed table is
+deleting and rebuilding its own ancestor.
 
-### Option 2A — patch in place [Proposal]
-Keep one `SortedSpikes` table swapped between raw and curated; fix only the circularity.
-- **Variant i — reparent:** move `OfficialCuration`'s parent from `SortedSpikes` up to
-  `PostProcessing` (same primary key, since they're 1:1). Deleting `SortedSpikes` no longer destroys
-  the curation records, and Zofia's in-memory recreate can be removed.
-- **Variant ii — keep Zofia's in-memory recreate** as the workaround.
-- **Pros:** minimal; downstream untouched; unblocks now.
-- **Cons:** treats the symptom, not the cause — a computed table still deletes/rebuilds an upstream
-  table in place; the reparent also loosens the enforced link between "which curation is official" and
-  "what's in `SortedSpikes` now" (left to the `curation_id` convention); still a schema change.
+**Option 2A — patch in place.** Keep one `SortedSpikes` swapped between raw/curated; fix only the
+circularity, e.g. reparent `OfficialCuration` onto `PostProcessing` (same key, since 1:1) so the delete
+no longer destroys the curation records.
+- Pros: minimal; downstream untouched; unblocks now.
+- Cons: treats the symptom — a computed table still deletes/rebuilds an upstream table in place.
 
-### Option 2B — duplication (DataJoint Elements pattern) [Proposal]
-Raw `SortedSpikes` becomes immutable; the curated result lives in its own downstream table computed
-from `OfficialCuration`; downstream reads the curated table, falling back to raw when there's no
-curation. Nothing is ever deleted and rebuilt.
-- **Pros:** removes both the circularity and the in-place mutation; matches the established DataJoint
-  Elements curation pattern (`Clustering → Curation → CuratedClustering`); clean lineage.
-- **Cons:** larger restructure; repoints downstream tables (`SyncedSpikes`, `UnitMatching`, …); a
-  second units table with some duplicated extraction logic; migration.
+**Option 2B — duplication (DataJoint Elements pattern).** Raw `SortedSpikes` becomes immutable; the
+curated result is its own downstream table; downstream reads curated, falling back to raw. Nothing is
+deleted and rebuilt.
+- Pros: removes the circularity and the in-place mutation; matches the Elements pattern
+  (`Clustering → Curation → CuratedClustering`).
+- Cons: larger restructure; repoints downstream tables; bigger migration.
 
-> Note (Elissa's framing): every option short of 2B still feels like a patch, because the root issue
-> is one mutable table holding both the raw and curated result and swapping in place.
+> Elissa's framing: everything short of 2B still feels like a patch, because the root issue is one
+> mutable table holding both raw and curated and swapping in place.
 
 ---
 
-## Other talking points
+## 4. Noise units — keep, label, exclude from matching [Decided — Elissa; confirm with team]
 
-### 4. Noise units — keep, label, exclude from matching [Decided — Elissa; confirm with team]
-Zofia's branch currently **deletes** noise-labelled units at apply time. The decision is to **keep
-them, label them "noise," and exclude them from unit matching** instead of deleting. Confirm Zofia and
-Thinh agree. Interacts with Decision 1 (which field the matching filter reads). [Verified] `main` does
-neither — it never deletes noise and never excludes it from matching; both behaviours are new on the
-branch.
+Zofia's branch **deletes** noise-labelled units at apply time. The decision: **keep them, label them
+"noise," and exclude them from unit matching** instead. Confirm Zofia/Thinh. [Verified] `main` does
+neither — both behaviours are new on the branch. Interacts with Decision 1 (which field the matching
+filter reads).
 
-### 5. The `unit_quality` fix — fallback, prefix, keep-both [Proposal]
-If Decision 1 goes single-field, open sub-questions: the per-unit fallback for a unit left unlabelled
-in a curated block (use Kilosort's label as a stand-in?); whether to mark Kilosort-sourced values with
-a `ks_` prefix so provenance is visible; and the standing argument for keeping both the Kilosort and
-manual labels (which is really Decision 1 itself).
+## 5. `unit_quality` sub-choices [Proposal]
 
-### 6. Data duplication — what's actually duplicated [Verified] (Chris's concern)
-Worth pinning down which of these Chris meant:
-- The curated analyzer is a **full second copy on disk** per applied curation; restore deletes neither
-  the folder nor its `File` row.
-- Spike payloads are stored **twice** — `SyncedSpikes.Unit.spike_times`, then again in
-  `UnitMatching.Spikes.spike_times` keyed by `global_unit`.
-- Apply/restore cycles **leak old external blobs** (DataJoint's row delete doesn't remove
-  external-store files).
-- `ManualCuration.File` mixes two different kinds of thing (the curation JSON and the apply-step's
-  analyzer pointer) — the root of the "2 tuples" bug. Connects to Decision 2.
+If Decision 1 goes single-field: use Kilosort's label as the per-unit fallback for a unit left
+unlabelled in a curated block? And mark Kilosort-sourced values with a `ks_` prefix so provenance stays
+visible? Both are sub-choices of Decision 1.
 
-### 7. Backfilling already-curated blocks [Proposal]
-The `unit_quality` fix is forward-looking: blocks Zofia has already curated keep the buggy Kilosort
-label until re-applied. Manual labels are safe on disk in the curated analyzers, so nothing is lost,
-but correcting existing blocks means re-applying each curation (disruptive) or a one-off migration
-script. Decide whether and how to backfill.
+## 6. Label-completeness gate [Verified: none exists; Proposal]
 
-### 8. Applied-analyzer in `ManualCuration.File` + restore cleanup [Verified; Decided — Elissa on cleanup]
-The apply step stores the curated-analyzer path in `ManualCuration.File` — an apply-step output living
-in a manual-curation file table, which is what makes the "2 tuples" collision possible. Whether it
-should move to its own table is part of Decision 2. Separately, [Decided — Elissa] leave
-`restore_raw_sorting` as-is: with the file-name fix, the leftover applied-analyzer rows are harmless
-and are useful provenance; the only cost is on-disk folders accumulating.
-
-### 9. Label-completeness gate [Verified: none exists; Proposal]
 There is **no** gate requiring an official curation to have every unit labelled. Decide whether to add
-one, or rely on the Kilosort per-unit fallback for units the curator didn't touch.
+one, or rely on the Kilosort fallback for units the curator didn't touch.
 
-### 10. Testing gap [Verified]
-There is **no automated coverage** for unit matching — the golden dataset is a single block, and
-matching needs several overlapping curated blocks. Zofia is asked (in PR #608) to test the matching
-changes on real data. [Proposal] consider building multi-block test fixtures so this path isn't
-verified only by hand.
+## 7. Applying the changes = repopulation only [Elissa]
 
-### 11. Schema migration + sensitivity [Verified / Elissa]
-PR #608 already recreates tables on the live DB (adds `CurationTag` and `BlockComparison`, makes
-`UnitTag.tag` a foreign key, removes `CandidateMatch`). Decision 2 (restructure) would be a bigger
-migration. [Elissa] Zofia is running on real curated data and won't want to re-curate, so major
-changes should be weighed against how much of her existing work they'd force her to redo.
-
-### 12. Ownership / who decides [Proposal]
-- Cascade + core table structure (Decision 2) — **Thinh** (shared/core design).
-- Curation workflow, tags, QC — **Zofia** (her PR).
-- The removed `__init__.py` exception-handler workaround was **Adrian's** (via `ar/core`), not Zofia's.
-
-### 13. DataJoint version bump [Verified]
-The branch bumps DataJoint from `main`'s `>=2.2.2` to `>=2.3.2` (needed for the upstream traceback
-fix). Flag that this rides along with the branch into `main`.
+These changes recreate/repopulate the affected tables, but this is **not** re-sorting or re-curation:
+every sorting analyzer and curation file is saved on disk, so re-applying is only re-populating the
+tables — no real work for Zofia. Be explicit about that, and settle with Zofia how she'd like to handle
+the re-apply.

--- a/docs/specs/2026-08-27-curation-design-options.md
+++ b/docs/specs/2026-08-27-curation-design-options.md
@@ -14,21 +14,38 @@ that need the team, and the smaller related questions worth raising.
 
 ---
 
-## Quick agenda
+## TL;DR — glance during the meeting
 
-1. Status — what already landed in PR #608 (partial set)
-2. **Decision 1** — how to represent quality labels
-3. **Decision 2** — in-place modification vs. duplication (the cascade)
-4. Noise units — keep + label + exclude from matching (confirm)
-5. The `unit_quality` bug — fallback + `ks_` prefix + keep-both
-6. Data duplication (Chris's concern) — what's actually duplicated
-7. Backfilling already-curated blocks after the label fix
-8. The applied-analyzer in `ManualCuration.File` + restore cleanup
-9. Label-completeness gate — add one?
-10. Testing gap — no unit-matching coverage
-11. Schema migration + sensitivity to re-curation
-12. Ownership / who decides what
-13. DataJoint version bump riding along
+1. **Status** — 5 safe fixes shipped in PR #608 into `zs/spike_sorting`; the 2 big decisions below
+   were deferred to today.
+2. **Decision 1 — quality labels** — Bug: `unit_quality` is read from Kilosort's KSLabel and never
+   reflects the manual curation. **Decide:** one field (Kilosort, replaced by the manual call) or two
+   fields (keep both). The spec says one.
+3. **Decision 2 — the cascade (fatal)** — Applying a curation deletes `SortedSpikes`, which
+   cascade-deletes its own `OfficialCuration`/`ApplyOfficialCuration`, so the apply can't finish.
+   Pre-existing in main, never actually worked. **Decide:** patch (reparent — quick) or restructure to
+   a separate curated table (clean — bigger).
+4. **Noise units** — Keep + label "noise" + exclude from matching (not delete). **Confirm** with
+   Zofia/Thinh.
+5. **`unit_quality` fix details** — If single field: use Kilosort as the per-unit fallback for
+   unlabelled units? Mark machine labels with a `ks_` prefix? (Both are sub-choices of Decision 1.)
+6. **Duplication (Chris)** — Real duplication points: a full curated-analyzer copy per curation;
+   spikes stored twice (SyncedSpikes + UnitMatching.Spikes); leaked blobs on restore; the File table
+   mixing the curation JSON with the apply output. **Ask Chris** which he meant.
+7. **Backfill** — The label fix is forward-only; blocks Zofia already curated keep the wrong label
+   until re-applied. **Decide:** re-apply, migration script, or leave.
+8. **Applied-analyzer in `ManualCuration.File`** — Root of the "2 tuples" bug; move it to its own
+   table (part of Decision 2)? Restore-cleanup already decided: leave as-is.
+9. **Label-completeness gate** — None exists today. **Decide:** add one, or rely on the fallback.
+10. **Testing** — Zero automated matching coverage (golden dataset is one block). Zofia tests by hand;
+    **build multi-block fixtures?**
+11. **Migration + sensitivity** — #608 already recreates tables; a restructure is bigger. **How much
+    re-curation of Zofia's existing data is acceptable?**
+12. **Ownership** — Cascade/core = Thinh; curation/tags/QC = Zofia; the exception-handler we removed
+    was Adrian's, not Zofia's.
+13. **DJ bump** — Branch bumps DataJoint `2.2.2 → 2.3.2`; it rides along into main.
+
+*(Full detail on each item is below if you need to drill in.)*
 
 ---
 


### PR DESCRIPTION
Bug fixes from our review of #604, so the curation pipeline works as originally intended before #604 goes to `main`. The two design questions this started with — how to represent quality labels, and how to fix the curation cascade — were settled at the 2026-08-27 meeting (single quality field; patch the cascade with a reparent) and are implemented here. The larger rework waits on Chris's long-session sorter; this PR just makes the current design correct.

Design write-up for reference: `docs/specs/2026-08-27-curation-design-options.md`.

## Bug fixes

**Uncaught-exception workarounds removed.** DataJoint 2.3.2 renders tracebacks itself and this branch already pins `datajoint>=2.3.2`, so the two hand-rolled `sys.excepthook` patches (in `dj_pipeline/__init__.py` and `scripts/launch_si_gui.py`) are redundant and gone.

**"2 tuples found" fixed.** `ManualCuration.File` holds more than one file per curation (the curation JSON plus the `curation_applied_analyzer` pointer), so the remaining `fetch1`s keyed on `curation_id` alone are now restricted by `file_name`.

**`save_manual_curation` made atomic.** It's a standalone helper, not a table `make()`, so its `ManualCuration` + `ManualCuration.File` inserts are now wrapped in one transaction.

**Curation cascade fixed (reparent).** Applying a curation deletes `SortedSpikes`, which previously cascade-deleted its own `OfficialCuration`/`ApplyOfficialCuration` — a fatal circular dependency that meant apply never actually worked. `OfficialCuration` is reparented onto `PostProcessing` (same primary key, since it's 1:1 with `SortedSpikes`), so the delete no longer destroys the curation records. The in-memory rebuild workaround (`insert_sorted_spikes_from_analyzer`) is removed; `ApplyOfficialCuration.make` now applies, saves the curated analyzer, deletes `SortedSpikes`, and records itself, and `SortedSpikes.populate()` rebuilds from the curated analyzer.

**Quality label fixed (single field).** `unit_quality` was read from Kilosort's KSLabel in every build path, so it never reflected the manual curation. Back to the spec's single-field design: `SortedSpikes.make` now writes the curator's manual label (and the tags) into `unit_quality`/`UnitTag` when rebuilding from a curated analyzer, with KSLabel only for raw sorting. The separate `curation_quality` column is removed.

**Noise units kept and labeled, not deleted.** They persist in `SortedSpikes` with `unit_quality="noise"` and are held out of unit matching instead of being dropped from the pipeline.

**Full labeling gate.** `make_curation_official` refuses to promote a curation unless every kept unit carries a quality label (removed/merged/split units are exempt).

**Full unit-match score grid.** `UnitMatching.CandidateMatch` (only pairings above a threshold) is replaced by `UnitMatching.BlockComparison`: one row per compared block holding the complete agreement-score grid, so the whole spectrum of scores is kept. Matching and global-unit assignment are unchanged. The QC helpers are rewritten to read the grid.

**Curation tags parameterized.** The hardcoded `MANUAL_TAG_OPTIONS` tuple becomes a `CurationTag` lookup table; `SortedSpikes.UnitTag` foreign-keys into it and every consumer reads the vocabulary from it.

## Schema changes
On an existing database the affected tables are recreated: `OfficialCuration` is reparented; `SortedSpikes.Unit` drops `curation_quality`; `CurationTag` and `UnitMatching.BlockComparison` are added; `UnitMatching.CandidateMatch` is removed; `SortedSpikes.UnitTag.tag` becomes a foreign key. On-disk sorting analyzers and curation files are untouched.

## Please test
There's no automated coverage for the curation/matching path (the golden dataset is a single block). @zofiasus — could you exercise the apply → repopulate → match flow on your real multi-block data? Because your sorting analyzers and curation files are all saved on disk, this is only re-populating tables, **not** re-curating — see the testing note in the discussion. And if any notebook referenced `qc.MANUAL_TAG_OPTIONS`, it should now read the `CurationTag` lookup.
