### PR TITLE
Fix DataJoint 2.x antijoin crash in SpikeSorting recording cleanup

### DIFF
--- a/aeon/dj_pipeline/spike_sorting.py
+++ b/aeon/dj_pipeline/spike_sorting.py
@@ -522,8 +522,11 @@ class SpikeSorting(dj.Computed):
         # recording.zarr is a large, regenerable intermediate that only sorting reads, so
         # reclaim it now. It is shared by all paramsets of this block + electrode group, so
         # skip the delete while a sibling paramset is preprocessed but not yet sorted.
+        # Both sides are projected to their primary keys: PreProcessing and SpikeSorting
+        # share the secondary attributes `execution_time` / `execution_duration`, and
+        # DataJoint 2.x rejects a join on attributes that carry no common lineage.
         shared_key = {k: v for k, v in key.items() if k != "paramset_id"}
-        if not ((PreProcessing & shared_key) - SpikeSorting):
+        if not ((PreProcessing & shared_key).proj() - SpikeSorting.proj()):
             recording_dir = (
                 get_sorting_root_dir() / (PreProcessing & key).fetch1("sorting_output_dir")
             ).parent / "recording"


### PR DESCRIPTION
# Fix DataJoint 2.x antijoin crash in SpikeSorting recording cleanup

## What
`SpikeSorting.make_insert` deletes the shared `recording.zarr` after a successful
sort, guarded by an antijoin that skips the delete while a sibling paramset is
still preprocessed-but-not-sorted:

```python
if not ((PreProcessing & shared_key) - SpikeSorting):
```

`PreProcessing` and `SpikeSorting` both carry `execution_time` and
`execution_duration` as secondary attributes. DataJoint 2.x rejects an antijoin
(`-`) on same-named attributes that have no common lineage, so this raised.

## Why it matters
The antijoin runs inside `make_insert`, i.e. inside the `make` transaction,
immediately after the row insert. When it raised, the whole transaction rolled
back and discarded the just-completed (and expensive) sort. Recovering required
manually backfilling the `SpikeSorting` rows to avoid re-running sorting.

## Fix
Project both operands to their primary keys before the difference, so it compares
on primary key only:

```python
if not ((PreProcessing & shared_key).proj() - SpikeSorting.proj()):
```

Behaviour is unchanged: the check still asks whether any sibling paramset is
preprocessed but not yet sorted.

---
Fix authored by Adrian Roggenbach (@AdrianRoggenbach), who found it while running the 30-hour sorting blocks; landing it in main on his behalf.
